### PR TITLE
Improve CI Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - docker pull dternyak/eth-priv-to-addr:latest
+# uncomment once integration tests are included in CI
+#  - docker pull dternyak/eth-priv-to-addr:latest
   - sudo apt-get install libusb-1.0
   
 install:
@@ -26,13 +27,7 @@ jobs:
     - stage: test
       script: npm run test
     - stage: test
-      script: npm run tslint
-    - stage: test
-      script: npm run tscheck
-    - stage: test
-      script: npm run freezer
-    - stage: test
-      script: npm run freezer:validate
+      script: npm run tslint && npm run tscheck && npm run freezer && npm run freezer:validate
 
 notifications:
   email:


### PR DESCRIPTION
From testing, this brings down CI completion time from ~5 minutes to ~2.

- remove docker dependency (due to integration tests no longer being run in CI)
- streamline jobs