### PR TITLE
MEW-01-003 - Parse JSON pasted into signed message verifier

### DIFF
--- a/common/containers/Tabs/SignAndVerifyMessage/components/VerifyMessage/index.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/components/VerifyMessage/index.tsx
@@ -50,6 +50,7 @@ export class VerifyMessage extends Component<Props, State> {
               placeholder={signaturePlaceholder}
               value={signature}
               onChange={this.handleSignatureChange}
+              onPaste={this.handleSignaturePaste}
             />
           </div>
 
@@ -102,6 +103,19 @@ export class VerifyMessage extends Component<Props, State> {
   private handleSignatureChange = (e: React.FormEvent<HTMLTextAreaElement>) => {
     const signature = e.currentTarget.value;
     this.setState({ signature });
+  };
+
+  private handleSignaturePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const text = e.clipboardData.getData('Text');
+    if (text) {
+      try {
+        const signature = JSON.stringify(JSON.parse(text), null, 2);
+        this.setState({ signature });
+        e.preventDefault();
+      } catch (err) {
+        // Do nothing, it wasn't json they pasted
+      }
+    }
   };
 }
 


### PR DESCRIPTION
Closes #945. Run any pasted text into the validator textarea through a JSON.parse / JSON.stringify cycle. This will make sure the user sees the actual JSON that ends up in the validator.

Note that the validator always showed the correct validated message in the green textbox below. This just makes it so that the JSON visually lines up with that as well.