### PR TITLE
Change debugging option for vscode users

### DIFF
--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -281,8 +281,8 @@ module.exports = function(opts = {}) {
   // ====================
   let devtool = false;
   if (!options.isProduction) {
-    if (process.env.SLOW_BUILD_SPEED) {
-      devtool = 'source-map';
+    if (process.env.VSCODE_DEBUG) {
+      devtool = 'cheap-module-source-map';
     } else {
       devtool = 'cheap-module-eval-source-map';
     }


### PR DESCRIPTION
This changes the dev tool to `'cheap-module-source-map'` which makes debug builds much faster for people wanting to use the chrome debug plugin on vscode. It loses column breakpoints but should be worth the tradeoff in build speed performance.