### PR TITLE
Contributor Guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see the [Contributor Guidelines on the wiki](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+If you're having an issue with unlocking your wallet, a transaction, a swap,
+or an ENS auction, please email support@mycrypto.com. Github issues are for
+development only, and support questions that aren't bugs or feature requests
+will not be answered.
+
+---
+
+If you've experienced a bug, please provide the following information:
+
+### Description of the Issue
+
+(Your description goes here)
+
+### Steps to Reproduce
+
+(Explain how you got this issue)
+
+### Description of Your Machine
+
+(Your browser, browser version, operating system, device)
+
+### Console Logs / Screenshots
+
+(Console logs or screenshots go here, if applicable)
+
+---
+
+If you're suggesting a feature, make sure someone hasn't already posted it. If
+no one has, please provide the following information:
+
+### Description of the Feature
+
+(Your description goes here)
+
+### Example(s) of Feature
+
+(If another product or app is doing this, please link it)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+If you're contributing translations, please follow the contributor guidelines
+at https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines#providing-translations
+
+---
+
+If you're contributing code, please link to the issue it resolves and follow the
+contributor guidelines at https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines#contributing-code and fill out the following template:
+
+Closes #(issue number goes here)
+
+### Description
+
+(Description goes here)
+
+### Changes
+
+* High level
+* Changes that
+* You Made
+
+### Steps to Test
+
+1. Steps
+2. To
+3. Test
+
+### Screenshots
+
+(Only if applicable)


### PR DESCRIPTION
Closes #1028. The main contributor guidelines [live on the wiki](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines) so they can be updated without needing to PR. I definitely expect edits and suggestions to this, so don't be shy.

One thing that was lacking was test-writing documentation. I think we should probably go into that more somewhere.