### PR TITLE
Add missing key attribute

### DIFF
--- a/common/components/WalletDecrypt/components/InsecureWalletWarning.tsx
+++ b/common/components/WalletDecrypt/components/InsecureWalletWarning.tsx
@@ -114,7 +114,7 @@ export class InsecureWalletWarning extends React.Component<Props, State> {
 
   private makeCheckbox = (checkbox: Checkbox) => {
     return (
-      <label className="AcknowledgeCheckbox">
+      <label className="AcknowledgeCheckbox" key={checkbox.name}>
         <input
           type="checkbox"
           name={checkbox.name}


### PR DESCRIPTION
Closes #1059

### Description

Adds the missing `key` attribute to the insecure wallet checkboxes.