### PR TITLE
Allow modals to specify max width

### DIFF
--- a/common/components/Header/components/CustomNodeModal.tsx
+++ b/common/components/Header/components/CustomNodeModal.tsx
@@ -95,6 +95,7 @@ class CustomNodeModal extends React.Component<Props, State> {
         isOpen={true}
         buttons={buttons}
         handleClose={handleClose}
+        maxWidth={580}
       >
         <div>
           {isHttps && <div className="alert alert-warning small">{translate('NODE_Warning')}</div>}

--- a/common/components/ui/Modal.scss
+++ b/common/components/ui/Modal.scss
@@ -111,7 +111,7 @@ $m-anim-speed: 400ms;
 
   // Mobile styles
   @media(max-width: $screen-sm) {
-    width: calc(100% - 40px);
+    width: calc(100% - 40px) !important;
   }
 }
 

--- a/common/components/ui/Modal.tsx
+++ b/common/components/ui/Modal.tsx
@@ -15,7 +15,12 @@ interface Props {
   disableButtons?: boolean;
   children: any;
   buttons?: IButton[];
+  maxWidth?: number;
   handleClose?(): void;
+}
+interface ModalStyle {
+  width?: string;
+  maxWidth?: string;
 }
 
 const Fade = ({ children, ...props }) => (
@@ -46,16 +51,22 @@ export default class Modal extends PureComponent<Props, {}> {
   }
 
   public render() {
-    const { isOpen, title, children, buttons, handleClose } = this.props;
+    const { isOpen, title, children, buttons, handleClose, maxWidth } = this.props;
     const hasButtons = buttons && buttons.length;
+    const modalStyle: ModalStyle = {};
+
+    if (maxWidth) {
+      modalStyle.width = '100%';
+      modalStyle.maxWidth = `${maxWidth}px`;
+    }
 
     return (
       <TransitionGroup>
         {isOpen && (
           <Fade>
             <div>
-              <div className={`Modalshade`} />
-              <div className={`Modal`}>
+              <div className="Modalshade" />
+              <div className="Modal" style={modalStyle}>
                 {title && (
                   <div className="Modal-header flex-wrapper">
                     <h2 className="Modal-header-title">{title}</h2>


### PR DESCRIPTION
Built on top of #1141.

### Description

Allows specifying a `maxWidth` parameter to modals, that forces the modal to be 100% wide, maxxing out at that width. Currently modals use flex sizing which is great when it works, but can be awful when it decides to shrink inexplicably. That behavior will still be there by default, but you can now specify a max width for the modal to try to target. Note that it's a maxWidth and not width, because all modals should be designed to be responsive for smaller sizes.

### Changes

* Add `maxWidth` param to modals
* Set `maxWidth` for custom node modals to prevent weirdness

### Steps to Test

1. Run app on `modal-max-width` branch
2. Open up add custom modal
3. Shrink down your browser
4. Make sure it never looks weird

## Screenshots

### Old Modal vs New Modal

<img width="495" alt="screen shot 2018-02-19 at 12 55 44 pm" src="https://user-images.githubusercontent.com/649992/36391654-684b06cc-1575-11e8-9bdd-2e05059c45b9.png">

<img width="599" alt="screen shot 2018-02-19 at 1 06 15 pm" src="https://user-images.githubusercontent.com/649992/36391716-b22ca73c-1575-11e8-9bb2-60b7aeeef6b1.png">



The difference in banner is just because I was running the old one on beta.mycrypto.com, and the new one on localhost.