### PR TITLE
Align footer to bottom

### DIFF
--- a/common/components/Footer/PreFooter.scss
+++ b/common/components/Footer/PreFooter.scss
@@ -1,9 +1,9 @@
-@import "common/sass/variables";
+@import 'common/sass/variables';
 
 .pre-footer {
   padding: 1rem;
-  box-shadow: 16px 16px 47px 0 rgba(0, 0, 0, .07);
-  margin-top: 5rem;
+  box-shadow: 16px 16px 47px 0 rgba(0, 0, 0, 0.07);
+  margin-top: 2rem;
   background-color: white;
   text-align: center;
 

--- a/common/containers/TabSection/index.tsx
+++ b/common/containers/TabSection/index.tsx
@@ -24,13 +24,12 @@ class TabSection extends Component<Props, {}> {
 
     return (
       <div className="page-layout">
-        <main>
-          <Header />
-          <div className="Tab container">
-            {isUnavailableOffline && isOffline ? <OfflineTab /> : children}
-          </div>
-          <Footer latestBlock={latestBlock} />
-        </main>
+        <Header />
+        <div className="Tab container">
+          {isUnavailableOffline && isOffline ? <OfflineTab /> : children}
+        </div>
+        <div className="flex-spacer" />
+        <Footer latestBlock={latestBlock} />
         <Notifications />
         <AlphaAgreement />
       </div>

--- a/common/sass/styles/scaffolding.scss
+++ b/common/sass/styles/scaffolding.scss
@@ -34,6 +34,20 @@ body {
   height: 100%;
 }
 
+#app {
+  height: 100%;
+}
+
+.page-layout {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  > .flex-spacer {
+    flex-grow: 2;
+  }
+}
+
 input,
 button,
 select,


### PR DESCRIPTION
No issue currently open for this.

### Description

Align the footer to the bottom of the page 

### Changes

- Add flexbox styles to `.page-layout` to align the footer to the bottom of the page
	- added `display: flex; flex-direction: column; flex-wrap: nowrap;`
	- added `<div className="flex-spacer" />` to fill empty space and push the footer (and prefooter) to the bottom of the page
	- reduce the margin on `<Prefooter />` from `5rem` to `2rem`

Before: 
<img width="1792" alt="screen shot 2018-02-20 at 2 36 02 pm" src="https://user-images.githubusercontent.com/13836920/36450774-39816cd2-164c-11e8-889c-9bd5af1fbfad.png">

After: 
<img width="1792" alt="screen shot 2018-02-20 at 2 42 22 pm" src="https://user-images.githubusercontent.com/13836920/36450793-4d9e3e52-164c-11e8-96ac-cd7a53c3c8a9.png">

