### PR TITLE
Fix unit value

### DIFF
--- a/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
+++ b/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
@@ -157,7 +157,7 @@ class RequestPayment extends React.Component<Props, {}> {
       !gasLimit ||
       !gasLimit.raw.length ||
       !currentTo.length ||
-      (unit !== 'ether' && !tokenContractAddress.length)
+      (unit !== 'ETH' && !tokenContractAddress.length)
     ) {
       return '';
     }


### PR DESCRIPTION
Payment Request QR code doesn't show due to changing the default unit value from `ether` to `ETH`. 

This PR updates the hard-coded check for `ether` to `ETH`.

A more in-depth long-term fix should include the use of a selector to check against ether unit's instead of hard-coding in the component.