### PR TITLE
Prevent Scrolling From Altering Amount Field

### DIFF
--- a/common/components/ui/Input.tsx
+++ b/common/components/ui/Input.tsx
@@ -28,10 +28,11 @@ class Input extends React.Component<HTMLProps<HTMLInputElement>, State> {
     );
   }
 
-  // When number inputs are scrolled on while in focus, the number changes.
+  // When number inputs are scrolled on while in focus, the number changes. So we blur
+  // it if it's focused to prevent that behavior, without preventing the scroll.
   private preventNumberScroll(ev: React.WheelEvent<HTMLInputElement>) {
     if (document.activeElement === ev.currentTarget) {
-      ev.preventDefault();
+      ev.currentTarget.blur();
     }
   }
 }

--- a/common/components/ui/Input.tsx
+++ b/common/components/ui/Input.tsx
@@ -9,6 +9,7 @@ class Input extends React.Component<HTMLProps<HTMLInputElement>, State> {
   public state: State = {
     hasBlurred: false
   };
+
   public render() {
     return (
       <input
@@ -19,11 +20,19 @@ class Input extends React.Component<HTMLProps<HTMLInputElement>, State> {
             this.props.onBlur(e);
           }
         }}
+        onWheel={this.props.type === 'number' ? this.preventNumberScroll : undefined}
         className={`input-group-input  ${this.props.className} ${
           this.state.hasBlurred ? 'has-blurred' : ''
         } ${!!this.props.value && this.props.value.toString().length > 0 ? 'has-value' : ''}`}
       />
     );
+  }
+
+  // When number inputs are scrolled on while in focus, the number changes.
+  private preventNumberScroll(ev: React.WheelEvent<HTMLInputElement>) {
+    if (document.activeElement === ev.currentTarget) {
+      ev.preventDefault();
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1201.

### Description

Blurs number inputs when scrolled on. While preventing default was an option, it had the annoying side effect of making focused number inputs no scroll zones, stopping your page from scrolling if you were moused over one. I found that behavior to be _really_ annoying, so I went with blurring instead. My assumption is that if you're scrolling, you're probably done with the input anyway.

### Changes

* Blur number inputs when scrolled while focused.

### Steps to Test

1. Run app on `fix-amount-scroll`
2. Go to /account page
3. Unlock wallet
4. Focus and set amount field to some numeric value
5. Scroll on it
6. Confirm number doesn't change
