### PR TITLE
Derive available tx metadata

### DIFF
--- a/common/selectors/transaction/meta.ts
+++ b/common/selectors/transaction/meta.ts
@@ -22,7 +22,9 @@ const getFrom = (state: AppState) => {
       if (from) {
         return toChecksumAddress(from.toString('hex'));
       }
-    } catch {}
+    } catch (e) {
+      console.warn(e);
+    }
   }
   return getMetaState(state).from;
 };

--- a/common/selectors/transaction/meta.ts
+++ b/common/selectors/transaction/meta.ts
@@ -3,13 +3,58 @@ import { getTransactionState } from './transaction';
 import { getToken } from 'selectors/wallet';
 import { isNetworkUnit } from 'selectors/config/wallet';
 import { getDecimalFromEtherUnit } from 'libs/units';
+import { getSerializedTransaction } from 'selectors/transaction';
+import EthTx from 'ethereumjs-tx';
+import { getCustomTokens } from 'selectors/customTokens';
+import { getNetworkConfig } from 'selectors/config';
+import { Token } from '../../../shared/types/network';
+import { stripHexPrefixAndLower } from 'libs/values';
+import { toChecksumAddress } from 'ethereumjs-util';
 
 const getMetaState = (state: AppState) => getTransactionState(state).meta;
-const getFrom = (state: AppState) => getMetaState(state).from;
+const getFrom = (state: AppState) => {
+  const serializedTransaction = getSerializedTransaction(state);
+  // attempt to get the from address from the transaction
+  if (serializedTransaction) {
+    const transactionInstance = new EthTx(serializedTransaction);
+    try {
+      const from = transactionInstance.from;
+      if (from) {
+        return toChecksumAddress(from.toString('hex'));
+      }
+    } catch {}
+  }
+  return getMetaState(state).from;
+};
 const getDecimal = (state: AppState) => getMetaState(state).decimal;
+
 const getTokenTo = (state: AppState) => getMetaState(state).tokenTo;
 const getTokenValue = (state: AppState) => getMetaState(state).tokenValue;
-const getUnit = (state: AppState) => getMetaState(state).unit;
+const getUnit = (state: AppState) => {
+  const serializedTransaction = getSerializedTransaction(state);
+  // attempt to get the to address from the transaction
+  if (serializedTransaction) {
+    const transactionInstance = new EthTx(serializedTransaction);
+    const { to } = transactionInstance;
+    if (to) {
+      // see if any tokens match
+      let networkTokens: null | Token[] = null;
+      const customTokens = getCustomTokens(state);
+      const networkConfig = getNetworkConfig(state);
+      if (!networkConfig.isCustom) {
+        networkTokens = networkConfig.tokens;
+      }
+      const mergedTokens = networkTokens ? [...networkTokens, ...customTokens] : customTokens;
+      const stringTo = toChecksumAddress(stripHexPrefixAndLower(to.toString('hex')));
+      const result = mergedTokens.find(t => t.address === stringTo);
+      if (result) {
+        return result.symbol;
+      }
+    }
+  }
+
+  return getMetaState(state).unit;
+};
 const getPreviousUnit = (state: AppState) => getMetaState(state).previousUnit;
 const getDecimalFromUnit = (state: AppState, unit: string) => {
   if (isNetworkUnit(state, unit)) {


### PR DESCRIPTION
Previously we were getting some data such as `to` and `unit` from redux state even when the transaction in context was available. This PR changes the selectors so that they return derived data from the current loaded transaction if available. This isolates the confirmation modal to only derived data when possible.

Closes #1200 