### PR TITLE
Roll Back enzyme-to-json Revoked Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "empty": "0.10.1",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
-    "enzyme-to-json": "3.3.2",
+    "enzyme-to-json": "3.3.1",
     "express": "4.16.2",
     "extract-text-webpack-plugin": "3.0.2",
     "favicons-webpack-plugin": "0.0.7",


### PR DESCRIPTION
Apparently the maintainer of this package released a breaking update, and rather than patch again to fix it, rolled back the version, so 3.3.2 no longer exists: https://github.com/adriantoine/enzyme-to-json/issues/98. This breaks the build.