### PR TITLE
Fix failing builds from node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "less-loader": "4.1.0",
     "lint-staged": "7.0.0",
     "minimist": "1.2.0",
-    "node-sass": "4.8.1",
+    "node-sass": "4.8.3",
     "nodemon": "1.17.2",
     "null-loader": "0.1.1",
     "prettier": "1.11.1",


### PR DESCRIPTION
Closes #1344.

Bump node-sass to `4.8.3` to fix the malloc crash.