### PR TITLE
Fix textarea styles

### DIFF
--- a/common/components/ui/Input.scss
+++ b/common/components/ui/Input.scss
@@ -62,6 +62,9 @@
     box-shadow: inset 0 1px 0 0 rgba(63, 63, 68, 0.05);
     transition: border-color 120ms, box-shadow 120ms;
     margin-bottom: 1rem;
+    &[placeholder] {
+      text-overflow: ellipsis;
+    }
 
     &.border-rad-right-0 {
       border-top-right-radius: 0;
@@ -98,4 +101,8 @@
   .Select-input {
     left: 24px;
   }
+}
+
+textarea.input-group-input {
+  height: initial;
 }


### PR DESCRIPTION
Closes #1392 

### Description

Fixes textarea height being set to `3rem`. Adds truncation on input placeholders

### Changes 

- Add `.input-group-input[placeholder] { text-overflow: ellipsis }`
- Add `textarea.input-group-input { height: initial }`

### Screenshots 

#### Textareas 
<img width="407" alt="screen shot 2018-03-27 at 4 54 43 pm" src="https://user-images.githubusercontent.com/13836920/37994473-a7426b14-31df-11e8-8966-b45aca34860e.png">
<img width="836" alt="screen shot 2018-03-27 at 4 54 52 pm" src="https://user-images.githubusercontent.com/13836920/37994481-ab80194c-31df-11e8-9f96-ac6acc4c0f5d.png">

#### Truncated Placeholder
<img width="611" alt="screen shot 2018-03-27 at 4 54 24 pm" src="https://user-images.githubusercontent.com/13836920/37994499-b5144f00-31df-11e8-9525-c3460b2bf206.png">

