### PR TITLE
Harden Jenkins Pipelines

### DIFF
--- a/jenkins/Jenkinsfile.darwin
+++ b/jenkins/Jenkinsfile.darwin
@@ -5,13 +5,27 @@ pipeline {
         }
     }
     stages {
-        stage('Build') { 
+        stage('Install') { 
             environment {
-                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
             }
             steps {
                 sh 'rm -rf node_modules'
                 sh 'npm install'
+            }
+        }
+        stage('Build') {
+            environment {
+                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1   
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+            }
+            steps {
                 sh 'npm run jenkins:build:mac'
             }
         }

--- a/jenkins/Jenkinsfile.linux.develop
+++ b/jenkins/Jenkinsfile.linux.develop
@@ -7,13 +7,27 @@ pipeline {
         }
     }
     stages {
-        stage('Build') { 
+        stage('Install') { 
             environment {
-                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
             }
             steps {
                 sh 'rm -rf node_modules'
                 sh 'npm install'
+            }
+        }
+        stage('Build') { 
+            environment {
+                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+            }
+            steps {
                 sh 'npm run jenkins:build:linux'
             }
         }

--- a/jenkins/Jenkinsfile.linux.master
+++ b/jenkins/Jenkinsfile.linux.master
@@ -7,17 +7,37 @@ pipeline {
         }
     }
     stages {
-        stage('Build') { 
+        stage('Install') { 
             environment {
-                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+                CSC_LINK = 'REDACTED'
+                CSC_KEY_PASSWORD = 'REDACTED'
             }
             steps {
                 sh 'rm -rf node_modules'
                 sh 'npm install'
+            }
+        }
+        stage('Build') { 
+            environment {
+                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+            }
+            steps {
                 sh 'npm run jenkins:build:linux'
             }
         }
         stage('Upload') {
+            environment {
+                CSC_LINK = 'REDACTED'
+                CSC_KEY_PASSWORD = 'REDACTED'
+            }
             steps {
                 sh 'npm run jenkins:upload'
             }


### PR DESCRIPTION
In the past, there have been NPM-based [attacks that steal environment variables](https://www.bleepingcomputer.com/news/security/javascript-packages-caught-stealing-environment-variables/) on `npm install`. This PR hardens our Jenkins setup by separating out the build pipeline into three steps: (1) module install, (2) project build, and (3) build artifact upload. For each step, sensitive environment variables are explicitly overwritten with `REDACTED` if they're not required for that step.