### PR TITLE
Fix unlock header toggle logic.

### DIFF
--- a/common/components/ui/UnlockHeader.tsx
+++ b/common/components/ui/UnlockHeader.tsx
@@ -25,7 +25,7 @@ export class UnlockHeader extends React.PureComponent<Props, State> {
 
   public componentDidUpdate(prevProps: Props) {
     if (this.props.wallet !== prevProps.wallet) {
-      this.setState({ isExpanded: !this.state.isExpanded });
+      this.setState({ isExpanded: !this.props.wallet });
     }
   }
 


### PR DESCRIPTION
Closes #1418

### Description

Simply fix the logic to put the wallet decrypter into the right display.

### Changes

* High level
* Changes that
* You Made

### Steps to Test

1. Unlock a wallet
2. Change networks
3. Confirm your wallet is locked again, and you see decrypt
4. Unlock a wallet
5. Click "change wallet" button
6. Change networks
7. Confirm you see the same original view
