### PR TITLE
Reduce Shapeshift Requests

### DIFF
--- a/common/api/shapeshift.ts
+++ b/common/api/shapeshift.ts
@@ -118,26 +118,20 @@ class ShapeshiftService {
 
   public getAllRates = async () => {
     const marketInfo = await this.getMarketInfo();
-    const pairRates = await this.getPairRates(marketInfo);
+    const pairRates = await this.filterPairs(marketInfo);
     const checkAvl = await this.checkAvl(pairRates);
     const mappedRates = this.mapMarketInfo(checkAvl);
     return mappedRates;
   };
 
-  private getPairRates(marketInfo: ShapeshiftMarketInfo[]) {
-    const filteredMarketInfo = marketInfo.filter(obj => {
+  private filterPairs(marketInfo: ShapeshiftMarketInfo[]) {
+    return marketInfo.filter(obj => {
       const { pair } = obj;
       const pairArr = pair.split('_');
       return this.whitelist.includes(pairArr[0]) && this.whitelist.includes(pairArr[1])
         ? true
         : false;
     });
-    const pairRates = filteredMarketInfo.map(p => {
-      const { pair } = p;
-      const singlePair = Promise.resolve(this.getSinglePairRate(pair));
-      return { ...p, ...singlePair };
-    });
-    return pairRates;
   }
 
   private async checkAvl(pairRates: IPairData[]) {
@@ -170,12 +164,6 @@ class ShapeshiftService {
 
   private getAvlCoins() {
     return fetch(`${this.url}/getcoins`)
-      .then(checkHttpStatus)
-      .then(parseJSON);
-  }
-
-  private getSinglePairRate(pair: string) {
-    return fetch(`${this.url}/rate/${pair}`)
       .then(checkHttpStatus)
       .then(parseJSON);
   }

--- a/common/containers/Tabs/Swap/components/CurrencySwap.scss
+++ b/common/containers/Tabs/Swap/components/CurrencySwap.scss
@@ -66,4 +66,11 @@
   &-submit {
     margin-top: 0.5rem;
   }
+
+  &-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 175px;
+  }
 }

--- a/common/containers/Tabs/Swap/components/CurrencySwap.tsx
+++ b/common/containers/Tabs/Swap/components/CurrencySwap.tsx
@@ -375,7 +375,9 @@ export default class CurrencySwap extends PureComponent<Props, State> {
             </div>
           </React.Fragment>
         ) : (
-          <Spinner />
+          <div className="CurrencySwap-loader">
+            <Spinner size="x3" />
+          </div>
         )}
       </article>
     );

--- a/common/containers/Tabs/Swap/components/CurrentRates.scss
+++ b/common/containers/Tabs/Swap/components/CurrentRates.scss
@@ -27,6 +27,14 @@
     &-rate {
       color: #fff;
 
+      &.is-loading {
+        display: flex;
+        align-items: center;
+        align-self: center;
+        justify-content: center;
+        height: 50px;
+      }
+
       &-input {
         display: inline-block;
         width: 16%;

--- a/common/containers/Tabs/Swap/components/CurrentRates.tsx
+++ b/common/containers/Tabs/Swap/components/CurrentRates.tsx
@@ -152,25 +152,25 @@ class CurrentRates extends PureComponent<Props> {
     } else {
       // TODO - de-dup
       children = (
-        <>
+        <React.Fragment>
           <div className="SwapRates-panel-side col-sm-6">
-            <div className="SwapRates-panel-rate">
+            <div className="SwapRates-panel-rate is-loading">
               <Spinner size="x1" light={true} />
             </div>
-            <div className="SwapRates-panel-rate">
+            <div className="SwapRates-panel-rate is-loading">
               <Spinner size="x1" light={true} />
             </div>
           </div>
 
           <div className="SwapRates-panel-side col-sm-6">
-            <div className="SwapRates-panel-rate">
+            <div className="SwapRates-panel-rate is-loading">
               <Spinner size="x1" light={true} />
             </div>
-            <div className="SwapRates-panel-rate">
+            <div className="SwapRates-panel-rate is-loading">
               <Spinner size="x1" light={true} />
             </div>
           </div>
-        </>
+        </React.Fragment>
       );
     }
 


### PR DESCRIPTION
Closes #1354

### Description

This was an intensely satisfying PR. It reduces the number of requests to Shapeshift by n<sup>2</sup> where n is the number of swappable tokens. It does so by simply removing the requests for each and every pair, and instead using the data we get initially from https://shapeshift.io/marketinfo. That endpoint already includes rates for every swap pair, so the extra requests are unnecessary.

While I was in the neighborhood, I resized the spinners to be the same size as the content that loads in. This'll prevent the page from "jumping" when they load.

### Changes

* Remove unnecessary swap rates requests
* Add explicit heights to loaders to make them match the size of the content that will load in

### Steps to Test

1. Load /swap
2. Confirm content doesn't jump
3. Confirm rates are correct
4. Initiate swap
5. Confirm swap works as expected

Unfortunately as an NYC resident, I can't do a swap all the way through, so it'd be great if someone could test and make sure this works.
