### PR TITLE
Fix keystore worker in dev

### DIFF
--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -280,7 +280,9 @@ module.exports = function(opts = {}) {
     path: path.resolve(config.path.output, options.outputDir),
     filename: options.isProduction ? `[name].${commitHash}.js` : '[name].js',
     publicPath: isDownloadable && options.isProduction ? './' : '/',
-    crossOriginLoading: 'anonymous'
+    crossOriginLoading: 'anonymous',
+    // Fix workers & HMR https://github.com/webpack/webpack/issues/6642
+    globalObject: options.isProduction ? undefined : 'self'
   };
 
   // The final bundle


### PR DESCRIPTION
Closes #1464

### Description

As of Webpack 4, workers unfortunately get some HMR code injected with them. These refer to the global `window` object, which doesn't exist in the worker context. So in dev, the global object will be changed to `self` which works in all newer JS environments.

### Steps to Test

1. Generate a keystore file in dev
