### PR TITLE
Add getNetVersion to ignored methods for web3

### DIFF
--- a/common/libs/nodes/index.ts
+++ b/common/libs/nodes/index.ts
@@ -40,6 +40,7 @@ export const makeProviderConfig = (options: DeepPartial<IProviderConfig> = {}): 
     }
   };
 };
+
 let shepherdProvider: INode;
 shepherd
   .init()
@@ -102,7 +103,12 @@ shepherd.useProvider('rpc', 'ella', regEllaConf, 'https://jsonrpc.ellaism.org');
  */
 const web3EthConf = makeProviderConfig({
   network: makeWeb3Network('ETH'),
-  supportedMethods: { sendRawTx: false, sendTransaction: false, signMessage: false }
+  supportedMethods: {
+    sendRawTx: false,
+    sendTransaction: false,
+    signMessage: false,
+    getNetVersion: false
+  }
 });
 shepherd.useProvider('rpc', 'web3_eth_mycrypto', web3EthConf, 'https://api.mycryptoapi.com/eth');
 shepherd.useProvider('etherscan', 'web3_eth_ethscan', web3EthConf, 'https://api.etherscan.io/api');
@@ -121,7 +127,12 @@ shepherd.useProvider(
 
 const web3RopConf = makeProviderConfig({
   network: makeWeb3Network('Ropsten'),
-  supportedMethods: { sendRawTx: false, sendTransaction: false, signMessage: false }
+  supportedMethods: {
+    sendRawTx: false,
+    sendTransaction: false,
+    signMessage: false,
+    getNetVersion: false
+  }
 });
 shepherd.useProvider(
   'infura',
@@ -132,7 +143,12 @@ shepherd.useProvider(
 
 const web3KovConf = makeProviderConfig({
   network: makeWeb3Network('Kovan'),
-  supportedMethods: { sendRawTx: false, sendTransaction: false, signMessage: false }
+  supportedMethods: {
+    sendRawTx: false,
+    sendTransaction: false,
+    signMessage: false,
+    getNetVersion: false
+  }
 });
 shepherd.useProvider(
   'etherscan',
@@ -143,7 +159,12 @@ shepherd.useProvider(
 
 const web3RinConf = makeProviderConfig({
   network: makeWeb3Network('Rinkeby'),
-  supportedMethods: { sendRawTx: false, sendTransaction: false, signMessage: false }
+  supportedMethods: {
+    sendRawTx: false,
+    sendTransaction: false,
+    signMessage: false,
+    getNetVersion: false
+  }
 });
 shepherd.useProvider(
   'infura',


### PR DESCRIPTION
This adds `getNetVersion` to ignored methods when web3 network is selected, so only the web3 provider will process `getNetVersion`. This is because we do checks on this method for metamask, so its needed to have it only come from metamask.

TODO: 
 - [ ] Publish next shepherd version and add it to package.json to complete this fix (https://github.com/MyCryptoHQ/shepherd/pull/51)