### PR TITLE
Fix Parity QR Signer on Non Send Pages

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -13,6 +13,7 @@ import CheckTransaction from 'containers/Tabs/CheckTransaction';
 import ErrorScreen from 'components/ErrorScreen';
 import PageNotFound from 'components/PageNotFound';
 import LogOutPrompt from 'components/LogOutPrompt';
+import QrSignerModal from 'containers/QrSignerModal';
 import { TitleBar } from 'components/ui';
 import { Store } from 'redux';
 import { pollOfflineStatus, TPollOfflineStatus } from 'actions/config';
@@ -102,6 +103,7 @@ class RootClass extends Component<Props, State> {
             {routes}
             <LegacyRoutes />
             <LogOutPrompt />
+            <QrSignerModal />
           </React.Fragment>
         </Router>
       </Provider>

--- a/common/containers/Tabs/SendTransaction/index.tsx
+++ b/common/containers/Tabs/SendTransaction/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import translate from 'translations';
 import TabSection from 'containers/TabSection';
-import QrSignerModal from 'containers/QrSignerModal';
 import { UnlockHeader } from 'components/ui';
 import { getWalletInst } from 'selectors/wallet';
 import { AppState } from 'reducers';
@@ -109,7 +108,6 @@ class SendTransaction extends React.Component<Props> {
             </div>
           )}
         </section>
-        <QrSignerModal />
       </TabSection>
     );
   }


### PR DESCRIPTION
Closes #1481

### Description

Renders QR signer modal always, in case there's a tx to be signed.

### Steps to Test

1. Deploy or interact with contract with parity signer wallet
2. Confirm QR signer pops up

### Screenshots

![screen shot 2018-04-12 at 8 17 59 pm](https://user-images.githubusercontent.com/649992/38710537-ee29cb6a-3e8e-11e8-8bd4-b66efed515fe.png)
