### PR TITLE
Add MUSIC Network

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -55,7 +55,7 @@ export const ELLA_DEFAULT: DPath = {
 
 export const MUSIC_DEFAULT: DPath = {
   label: 'Default (MUSIC)',
-  value: "m/44'/184'/0'/0"
+  value: "m/44'/60'/0'/0"
 };
 
 export const ETH_SINGULAR: DPath = {

--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -53,6 +53,11 @@ export const ELLA_DEFAULT: DPath = {
   value: "m/44'/163'/0'/0"
 };
 
+export const MUSIC_DEFAULT: DPath = {
+  label: 'Default (MUSIC)',
+  value: "m/44'/184'/0'/0"
+};
+
 export const ETH_SINGULAR: DPath = {
   label: 'SingularDTV',
   value: "m/0'/0'/0'"
@@ -69,7 +74,8 @@ export const DPaths: DPath[] = [
   UBQ_DEFAULT,
   POA_DEFAULT,
   TOMO_DEFAULT,
-  ELLA_DEFAULT
+  ELLA_DEFAULT,
+  MUSIC_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/libs/nodes/index.ts
+++ b/common/libs/nodes/index.ts
@@ -99,6 +99,9 @@ shepherd.useProvider('rpc', 'tomo', regTomoConf, 'https://core.tomocoin.io');
 const regEllaConf = makeProviderConfig({ network: 'ELLA' });
 shepherd.useProvider('rpc', 'ella', regEllaConf, 'https://jsonrpc.ellaism.org');
 
+const regMusicConf = makeProviderConfig({ network: 'MUSIC' });
+shepherd.useProvider('rpc', 'music', regMusicConf, 'https://mewapi.musicoin.tw');
+
 /**
  * Pseudo-networks to support metamask / web3 interaction
  */

--- a/common/reducers/config/networks/staticNetworks.ts
+++ b/common/reducers/config/networks/staticNetworks.ts
@@ -16,7 +16,8 @@ import {
   EXP_DEFAULT,
   POA_DEFAULT,
   TOMO_DEFAULT,
-  UBQ_DEFAULT
+  UBQ_DEFAULT,
+  MUSIC_DEFAULT
 } from 'config/dpaths';
 import { ConfigAction } from 'actions/config';
 import { makeExplorer } from 'utils/helpers';
@@ -246,6 +247,28 @@ export const INITIAL_STATE: State = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: ELLA_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: ELLA_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  MUSIC: {
+    name: 'MUSIC',
+    unit: 'MUSIC',
+    chainId: 7762959,
+    isCustom: false,
+    color: '#ffbb00',
+    blockExplorer: makeExplorer({
+      name: 'Musicoin Explorer',
+      origin: 'https://explorer.musicoin.org',
+      addressPath: 'account'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [InsecureWalletName.MNEMONIC_PHRASE]: MUSIC_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/reducers/config/networks/staticNetworks.ts
+++ b/common/reducers/config/networks/staticNetworks.ts
@@ -268,6 +268,7 @@ export const INITIAL_STATE: State = {
     tokens: [],
     contracts: [],
     dPathFormats: {
+      [SecureWalletName.TREZOR]: MUSIC_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: MUSIC_DEFAULT
     },
     gasPriceSettings: {

--- a/common/reducers/config/nodes/staticNodes.ts
+++ b/common/reducers/config/nodes/staticNodes.ts
@@ -184,6 +184,21 @@ export const INITIAL_STATE: StaticNodesState = {
     service: 'ellaism.org',
     lib: shepherdProvider,
     estimateGas: true
+  },
+
+  music_auto: {
+    network: 'MUSIC',
+    isCustom: false,
+    service: 'AUTO',
+    lib: shepherdProvider,
+    estimateGas: true
+  },
+  music: {
+    network: 'MUSIC',
+    isCustom: false,
+    service: 'musicoin.tw',
+    lib: shepherdProvider,
+    estimateGas: true
   }
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -10,7 +10,8 @@ type StaticNetworkIds =
   | 'EXP'
   | 'POA'
   | 'TOMO'
-  | 'ELLA';
+  | 'ELLA'
+  | 'MUSIC';
 
 export interface BlockExplorerConfig {
   name: string;

--- a/shared/types/node.d.ts
+++ b/shared/types/node.d.ts
@@ -50,7 +50,9 @@ declare enum StaticNodeId {
   TOMO_AUTO = 'tomo_auto',
   TOMO = 'tomo',
   ELLA_AUTO = 'ella_auto',
-  ELLA = 'ella'
+  ELLA = 'ella',
+  MUSIC_AUTO = 'music_auto',
+  MUSIC = 'music'
 }
 
 type StaticNodeConfigs = { [key in StaticNodeId]: StaticNodeConfig } & { web3?: StaticNodeConfig };

--- a/spec/reducers/config/__snapshots__/config.spec.ts.snap
+++ b/spec/reducers/config/__snapshots__/config.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ELLA",
+      "MUSIC",
     ],
     "selector": [Function],
   },


### PR DESCRIPTION
Closes #1474

### Description

Adds in the MUSIC network and a node for it. Would love a confirmation from @varunram and @frankurcrazy that this looks like it's configured alright. One thing of note was I found that the address I got from entering my mnemonic on the Music Wallet app wasn't the same as the one I got with the dpath provided.

### Steps to Test

1. Select MUSIC from network dropdown
2. Make sure it works?
