### PR TITLE
Add ETSC Network support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -58,6 +58,11 @@ export const ETH_SINGULAR: DPath = {
   value: "m/0'/0'/0'"
 };
 
+export const ETSC_DEFAULT: DPath = {
+  label: 'Default (ETSC)',
+  value: "m/44'/1128'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -69,7 +74,8 @@ export const DPaths: DPath[] = [
   UBQ_DEFAULT,
   POA_DEFAULT,
   TOMO_DEFAULT,
-  ELLA_DEFAULT
+  ELLA_DEFAULT,
+  ETSC_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/libs/nodes/index.ts
+++ b/common/libs/nodes/index.ts
@@ -103,6 +103,9 @@ shepherd.useProvider('rpc', 'tomo', regTomoConf, 'https://core.tomocoin.io');
 const regEllaConf = makeProviderConfig({ network: 'ELLA' });
 shepherd.useProvider('rpc', 'ella', regEllaConf, 'https://jsonrpc.ellaism.org');
 
+const regETSCConf = makeProviderConfig({ network: 'ETSC' });
+shepherd.useProvider('rpc', 'etsc', regETSCConf, 'https://node.ethereumsocial.kr');
+
 /**
  * Pseudo-networks to support metamask / web3 interaction
  */

--- a/common/reducers/config/networks/staticNetworks.ts
+++ b/common/reducers/config/networks/staticNetworks.ts
@@ -16,7 +16,8 @@ import {
   EXP_DEFAULT,
   POA_DEFAULT,
   TOMO_DEFAULT,
-  UBQ_DEFAULT
+  UBQ_DEFAULT,
+  ETSC_DEFAULT
 } from 'config/dpaths';
 import { ConfigAction } from 'actions/config';
 import { makeExplorer } from 'utils/helpers';
@@ -247,6 +248,28 @@ export const INITIAL_STATE: State = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: ELLA_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: ELLA_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  ETSC: {
+    name: 'ETSC',
+    unit: 'ETSC',
+    chainId: 28,
+    isCustom: false,
+    color: '#4295d1',
+    blockExplorer: makeExplorer({
+      name: 'Ethereum Social Explorer',
+      origin: 'https://explorer.ethereumsocial.kr'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETSC_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETSC_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/reducers/config/nodes/staticNodes.ts
+++ b/common/reducers/config/nodes/staticNodes.ts
@@ -184,6 +184,20 @@ export const INITIAL_STATE: StaticNodesState = {
     service: 'ellaism.org',
     lib: shepherdProvider,
     estimateGas: true
+  },
+  etsc_auto: {
+    network: 'ETSC',
+    isCustom: false,
+    service: 'AUTO',
+    lib: shepherdProvider,
+    estimateGas: true
+  },
+  etsc: {
+    network: 'ETSC',
+    isCustom: false,
+    service: 'ethereumsocial.kr',
+    lib: shepherdProvider,
+    estimateGas: true
   }
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -10,7 +10,8 @@ type StaticNetworkIds =
   | 'EXP'
   | 'POA'
   | 'TOMO'
-  | 'ELLA';
+  | 'ELLA'
+  | 'ETSC';
 
 export interface BlockExplorerConfig {
   name: string;

--- a/shared/types/node.d.ts
+++ b/shared/types/node.d.ts
@@ -50,7 +50,9 @@ declare enum StaticNodeId {
   TOMO_AUTO = 'tomo_auto',
   TOMO = 'tomo',
   ELLA_AUTO = 'ella_auto',
-  ELLA = 'ella'
+  ELLA = 'ella',
+  ETSC_AUTO = 'etsc_auto',
+  ETSC = 'etsc'
 }
 
 type StaticNodeConfigs = { [key in StaticNodeId]: StaticNodeConfig } & { web3?: StaticNodeConfig };

--- a/spec/reducers/config/__snapshots__/config.spec.ts.snap
+++ b/spec/reducers/config/__snapshots__/config.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ELLA",
+      "ETSC",
     ],
     "selector": [Function],
   },


### PR DESCRIPTION
Closes #1259 

### Description

Adds Ethereum Social (ETSC) network node and the following configure.

Currently there was a chain switch ( see https://medium.com/@akx20000/a-new-beginning-ethereum-social-project-aka-etsc-1e5e851eee00 for more information ) and now the node api ( which is https://node.ethereumsocial.kr ) is back online with the new chain configure ( You can see https://stats.ethereumsocial.kr for the status dashboard of the blockchain network ). 

This PR improve stability for ETSC users and it has been tested on both MyEtherWallet and ClassicEtherWallet. 

### Changes

Added ETSC node & it's settings based on the new chain spec

Spec:

Color Branding: #4295d1
Chain id & network id : both 28
HD wallet path: same with ethereum (eth)
Explorer: https://explorer.ethereumsocial.kr
Node API: https://node.ethereumsocial.kr ( Using AWS Cloudformation as a configure + 4 geth node clustering )

### Steps to Test

1. Select ETSC from network dropdown
2. Test them
3. .....

4. Profit!

