### PR TITLE
Add Jenkins Config for Mac Signing

### DIFF
--- a/jenkins/Jenkinsfile.darwin.signing
+++ b/jenkins/Jenkinsfile.darwin.signing
@@ -1,0 +1,44 @@
+pipeline {
+    agent {
+        node {
+            label 'master'
+        }
+    }
+    stages {
+        stage('Install') { 
+            environment {
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+                CSC_LINK = 'REDACTED'
+                CSC_KEY_PASSWORD = 'REDACTED'
+            }
+            steps {
+                sh 'rm -rf node_modules'
+                sh 'yarn'
+            }
+        }
+        stage('Build') {
+            environment {
+                ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 1   
+                AWS_ACCESS_KEY_ID = 'REDACTED'
+                AWS_SECRET_ACCESS_KEY = 'REDACTED'
+                ETH_SIGNING_KEY = 'REDACTED'
+                S3_BUCKET_NAME = 'REDACTED'
+            }
+            steps {
+                sh 'npm run jenkins:build:mac'
+            }
+        }
+        stage('Upload') {
+            environment {
+                CSC_LINK = 'REDACTED'
+                CSC_KEY_PASSWORD = 'REDACTED'
+            }
+            steps {
+                sh 'npm run jenkins:upload'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds config to enable the signing of Mac builds directly in Jenkins.