### PR TITLE
Wallet Selection Optimization

### DIFF
--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -390,12 +390,14 @@ const WalletDecrypt = withRouter<Props>(
       }
 
       let timeout = 0;
-      const web3Available = await isWeb3NodeAvailable();
-      if (wallet.attemptUnlock && web3Available) {
-        // timeout is only the maximum wait time before secondary view is shown
-        // send view will be shown immediately on web3 resolve
-        timeout = 1000;
-        wallet.unlock();
+      if (wallet.attemptUnlock) {
+        const web3Available = await isWeb3NodeAvailable();
+        if (web3Available) {
+          // timeout is only the maximum wait time before secondary view is shown
+          // send view will be shown immediately on web3 resolve
+          timeout = 1500;
+          wallet.unlock();
+        }
       }
 
       window.setTimeout(() => {


### PR DESCRIPTION
No issue associated

### Description

Clicking on any wallet option was bootstrapping the web3 node via the `isWeb3NodeAvailable` async call. Recently, I've noticed that this call can hang sometimes and lock the UI. It doesn't need to run for every wallet option, just the web3 option.

### Changes

* Only call `isWeb3NodeAvailable` if the wallet option wants to do instant unlock

### Steps to Test

1. Unlock web3 wallet, make sure instant unlock still works
