### PR TITLE
Allow Network Change Offline

### DIFF
--- a/common/sagas/config/node.ts
+++ b/common/sagas/config/node.ts
@@ -160,6 +160,7 @@ export function* handleNodeChangeIntent({
     );
   }
 
+  const isOffline = yield select(getOffline);
   if (isAutoNode(nodeIdToSwitchTo)) {
     shepherd.auto();
     if (getShepherdNetwork() !== nextNodeConfig.network) {
@@ -167,19 +168,21 @@ export function* handleNodeChangeIntent({
     }
   } else {
     try {
-      yield apply(shepherd, shepherd.manual, [nodeIdToSwitchTo, false]);
+      yield apply(shepherd, shepherd.manual, [nodeIdToSwitchTo, isOffline]);
     } catch (err) {
       console.error(err);
       return yield* bailOut(translateRaw('ERROR_32'));
     }
   }
 
-  let currentBlock;
+  let currentBlock = '???';
   try {
     currentBlock = yield apply(shepherdProvider, shepherdProvider.getCurrentBlock);
   } catch (err) {
-    console.error(err);
-    return yield* bailOut(translateRaw('ERROR_32'));
+    if (!isOffline) {
+      console.error(err);
+      return yield* bailOut(translateRaw('ERROR_32'));
+    }
   }
 
   yield put(setLatestBlock(currentBlock));

--- a/spec/reducers/config/config.spec.ts
+++ b/spec/reducers/config/config.spec.ts
@@ -133,7 +133,7 @@ describe('handleNodeChangeIntent*', () => {
         : acc
   );
   const newNodeConfig: StaticNodeConfig = (staticNodesExpectedState as any).initialState[newNodeId];
-
+  const isOffline = false;
   const changeNodeIntentAction = changeNodeIntent(newNodeId);
   const latestBlock = '0xa';
 
@@ -174,21 +174,25 @@ describe('handleNodeChangeIntent*', () => {
     expect(data.gen.next(newNodeConfig).value).toMatchSnapshot();
   });
 
-  it('should show error and revert to previous node if check times out', () => {
-    data.clone1 = data.gen.clone();
-    data.clone1.next(true);
-    expect(data.clone1.throw('err').value).toEqual(select(getNodeId));
-    expect(data.clone1.next(defaultNodeId).value).toEqual(
+  it('should select isOffline', () => {
+    expect(data.gen.next(true).value).toEqual(select(getOffline));
+  });
+
+  it('should show error and revert to previous node if online check times out', () => {
+    data.nodeError = data.gen.clone();
+    data.nodeError.next(isOffline);
+    expect(data.nodeError.throw('err').value).toEqual(select(getNodeId));
+    expect(data.nodeError.next(defaultNodeId).value).toEqual(
       put(showNotification('danger', translateRaw('ERROR_32'), 5000))
     );
-    expect(data.clone1.next().value).toEqual(
+    expect(data.nodeError.next().value).toEqual(
       put(changeNode({ networkId: defaultNodeConfig.network, nodeId: defaultNodeId }))
     );
-    expect(data.clone1.next().done).toEqual(true);
+    expect(data.nodeError.next().done).toEqual(true);
   });
 
   it('should sucessfully switch to the manual node', () => {
-    expect(data.gen.next(latestBlock).value).toEqual(
+    expect(data.gen.next(isOffline).value).toEqual(
       apply(shepherd, shepherd.manual, [newNodeId, false])
     );
   });


### PR DESCRIPTION
Closes #1681

### Description

I think this is a fair compromise between the UX of not letting users switch to nodes that won't connect vs allowing users to switch to other networks when offline. Allows a user to switch without fail if they're currently offline. Still attempts to fetch a block and get them back online, even if offline though.

However, maybe the UX tradeoff isn't worth it, and we should just let users switch to offline nodes no matter what. I'm definitely open to that discussion!

### Steps to Test

1. Load the page and make sure you're connected to a network
2. Attempt to switch to another node, make sure that works
3. Set yourself offline, and quickly switch to another node (Simulating connecting to an "offline node"), confirm it doesn't allow you to connect
4. Get yourself into the offline state (triggered by causing a node request, e.g. balance)
5. Attempt to switch to another node again, confirm it allows you to connect