### PR TITLE
Fix Estimate Gas

### DIFF
--- a/common/libs/nodes/rpc/utils.ts
+++ b/common/libs/nodes/rpc/utils.ts
@@ -1,7 +1,7 @@
 // Ref: https://github.com/ethereum/wiki/wiki/JSON-RPC
 
 import BN from 'bn.js';
-import { toBuffer, addHexPrefix, bufferToHex } from 'ethereumjs-util';
+import { toBuffer, addHexPrefix, bufferToHex, stripHexPrefix, padToEven } from 'ethereumjs-util';
 import trimStart from 'lodash/trimStart';
 
 // When encoding QUANTITIES (integers, numbers): encode as hex, prefix with "0x", the most compact representation (slight exception: zero should be represented as "0x0").
@@ -12,5 +12,10 @@ export function hexEncodeQuantity(value: BN | Buffer): string {
 
 // When encoding UNFORMATTED DATA (byte arrays, account addresses, hashes, bytecode arrays): encode as hex, prefix with "0x", two hex digits per byte.
 export function hexEncodeData(value: string | Buffer): string {
-  return bufferToHex(toBuffer(value));
+  // convert the value to a buffer
+  // convert the value to a hex prefixed hex string
+  // strip the hex prefix
+  // pad the data to even (two hex digits per byte)
+  // add the hex prefix back in
+  return addHexPrefix(padToEven(stripHexPrefix(bufferToHex(toBuffer(value)))));
 }

--- a/common/sagas/transaction/network/gas.ts
+++ b/common/sagas/transaction/network/gas.ts
@@ -78,6 +78,15 @@ export function* shouldEstimateGas(): SagaIterator {
       transaction
     );
 
+    // gas estimation calls with
+    // '0x' as an address (contract creation)
+    // fail, so instead we set it as undefined
+    // interestingly, the transaction itself as '0x' as the
+    // to address works fine.
+    if (rest.to === '0x') {
+      rest.to = undefined as any;
+    }
+
     yield put(estimateGasRequested(rest));
   }
 }
@@ -101,6 +110,7 @@ export function* estimateGas(): SagaIterator {
     try {
       const from: string = yield apply(walletInst, walletInst.getAddressString);
       const txObj = { ...payload, from };
+
       const { gasLimit } = yield race({
         gasLimit: apply(node, node.estimateGas, [txObj]),
         timeout: call(delay, 10000)


### PR DESCRIPTION
Patches #1617
After testing, only `estimateGas` is affected by this issue. So whenever an estimation call is sent, a zero value `to` value e.g `0x` is set to undefined instead.