### PR TITLE
Use proxy.mycryptoapi.com for rates

### DIFF
--- a/common/api/rates.ts
+++ b/common/api/rates.ts
@@ -47,11 +47,11 @@ export const rateSymbols: IRateSymbols = {
 
 // TODO - internationalize
 const ERROR_MESSAGE = 'Could not fetch rate data.';
-const CCApi = 'https://min-api.cryptocompare.com';
+const CCApi = 'https://proxy.mycryptoapi.com/cc';
 
 const CCRates = (symbols: string[]) => {
   const tsyms = rateSymbols.symbols.all.concat(symbols as any).join(',');
-  return `${CCApi}/data/price?fsym=ETH&tsyms=${tsyms}`;
+  return `${CCApi}/price?fsym=ETH&tsyms=${tsyms}`;
 };
 
 export interface CCResponse {


### PR DESCRIPTION
No [public] issue associated with this PR.

### What?
Replaces cryptocompare with proxy.mycryptoapi.com for rate requests.

### Why?
In an effort to increase user privacy, an effort is made to reduce requests to third parties directly.

### How to test
1. Open dev tools
2. Unlock any wallet format
3. Check to make sure equivalent values still load
4. Verify that requests is are being made proxy.mycryptoapi.com instead of min-api.cryptocompare.com