### PR TITLE
Show version in Electron

### DIFF
--- a/common/containers/Tabs/SupportPage/index.tsx
+++ b/common/containers/Tabs/SupportPage/index.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import translate from 'translations';
 import TabSection from 'containers/TabSection';
 import logo from 'assets/images/logo-mycrypto-transparent.svg';
-import { donationAddressMap, socialMediaLinks, productLinks, affiliateLinks } from 'config';
+import {
+  donationAddressMap,
+  socialMediaLinks,
+  productLinks,
+  affiliateLinks,
+  VERSION
+} from 'config';
 import DisclaimerModal from 'components/DisclaimerModal';
 import { NewTabLink } from 'components/ui';
 import './index.scss';
@@ -47,6 +53,7 @@ export default class SupportPage extends React.Component<{}, State> {
                   <div className="SupportPage-mycrypto-legal-text">
                     <a onClick={this.openDisclaimer}>{translate('DISCLAIMER')}</a>
                   </div>
+                  <div className="SupportPage-mycrypto-legal-text">v{VERSION}</div>
                 </div>
               </div>
             </div>

--- a/electron-app/main/menu.ts
+++ b/electron-app/main/menu.ts
@@ -33,7 +33,7 @@ const MENU: MenuItemConstructorOptions[] = [
   }
 ];
 
-const HELP_MENU = {
+const HELP_MENU: MenuItemConstructorOptions = {
   role: 'help',
   submenu: [
     {
@@ -74,7 +74,7 @@ if (process.platform === 'darwin') {
   MENU.push({
     ...HELP_MENU,
     submenu: [
-      ...HELP_MENU.submenu,
+      ...(HELP_MENU.submenu as MenuItemConstructorOptions[]),
       {
         label: 'Speech',
         submenu: [{ role: 'startspeaking' }, { role: 'stopspeaking' }]

--- a/electron-app/main/menu.ts
+++ b/electron-app/main/menu.ts
@@ -1,5 +1,6 @@
 import { MenuItemConstructorOptions, shell } from 'electron';
 import { APP_TITLE, REPOSITORY } from '../constants';
+import packageJson from '../../package.json';
 
 const MENU: MenuItemConstructorOptions[] = [
   {
@@ -35,6 +36,11 @@ const MENU: MenuItemConstructorOptions[] = [
 const HELP_MENU = {
   role: 'help',
   submenu: [
+    {
+      label: `v${packageJson.version}`,
+      enabled: false
+    },
+    { type: 'separator' },
     {
       label: 'Help / FAQ',
       click() {


### PR DESCRIPTION
Closes #1728

### Description

Adds version to help menu and on support us page that more or less has all of the same footer information.

### Screenshots

<img width="359" alt="screen shot 2018-05-08 at 4 12 03 pm" src="https://user-images.githubusercontent.com/649992/39780536-9306273c-52da-11e8-8c38-fe257f11c2a1.png">


<img width="937" alt="screen shot 2018-05-08 at 4 00 47 pm" src="https://user-images.githubusercontent.com/649992/39780540-976c9748-52da-11e8-9865-50050748ac4b.png">
