### PR TITLE
Mark depreciated react lifecycles as unsafe

### DIFF
--- a/common/components/BalanceSidebar/EquivalentValues.tsx
+++ b/common/components/BalanceSidebar/EquivalentValues.tsx
@@ -88,7 +88,7 @@ class EquivalentValues extends React.Component<Props, State> {
     };
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { balance, tokenBalances, isOffline, network } = this.props;
     if (
       nextProps.balance !== balance ||

--- a/common/components/BalanceSidebar/TokenBalances/Balances.tsx
+++ b/common/components/BalanceSidebar/TokenBalances/Balances.tsx
@@ -29,7 +29,7 @@ export default class TokenBalances extends React.PureComponent<Props, State> {
     showCustomTokenForm: false
   };
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.tokenBalances !== this.props.tokenBalances) {
       const trackedTokens = nextProps.tokenBalances.reduce<TrackedTokens>((prev, t) => {
         prev[t.symbol] = !t.balance.isZero();

--- a/common/components/CurrentCustomMessage.tsx
+++ b/common/components/CurrentCustomMessage.tsx
@@ -29,7 +29,7 @@ class CurrentCustomMessageClass extends PureComponent<Props, State> {
     this.setAddressState(this.props);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.wallet !== nextProps.wallet) {
       this.setAddressState(nextProps);
     }

--- a/common/components/GenerateKeystoreModal/index.tsx
+++ b/common/components/GenerateKeystoreModal/index.tsx
@@ -41,7 +41,7 @@ export default class GenerateKeystoreModal extends React.Component<Props, State>
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.privateKey !== this.props.privateKey) {
       this.setState({ privateKey: nextProps.privateKey || '' });
     }

--- a/common/components/SendButtonFactory/OnlineSend.tsx
+++ b/common/components/SendButtonFactory/OnlineSend.tsx
@@ -64,7 +64,7 @@ class OnlineSendClass extends Component<Props, State> {
     );
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.transactionBroadcasted && this.state.showModal) {
       this.closeModal();
     }

--- a/common/components/SubTabs/index.tsx
+++ b/common/components/SubTabs/index.tsx
@@ -39,7 +39,7 @@ export default class SubTabs extends React.PureComponent<Props, State> {
     window.removeEventListener('resize', this.handleResize);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     // When new tabs come in, we'll need to uncollapse so that they can
     // be measured and collapsed again, if needed.
     if (this.props.tabs !== nextProps.tabs) {

--- a/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
+++ b/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
@@ -76,7 +76,7 @@ class TXMetaDataPanel extends React.Component<Props, State> {
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (
       (this.props.offline && !nextProps.offline) ||
       this.props.network.unit !== nextProps.network.unit

--- a/common/components/TXMetaDataPanel/components/SimpleGas.tsx
+++ b/common/components/TXMetaDataPanel/components/SimpleGas.tsx
@@ -57,7 +57,7 @@ class SimpleGas extends React.Component<Props> {
     this.props.fetchGasEstimates();
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (!this.state.hasSetRecommendedGasPrice && nextProps.gasEstimates) {
       this.setState({ hasSetRecommendedGasPrice: true });
       this.props.setGasPrice(nextProps.gasEstimates.fast.toString());

--- a/common/components/TogglablePassword.tsx
+++ b/common/components/TogglablePassword.tsx
@@ -40,7 +40,7 @@ export default class TogglablePassword extends React.PureComponent<Props, State>
     isVisible: !!this.props.isVisible
   };
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.isVisible !== nextProps.isVisible) {
       this.setState({ isVisible: !!nextProps.isVisible });
     }

--- a/common/components/TransactionStatus/TransactionStatus.tsx
+++ b/common/components/TransactionStatus/TransactionStatus.tsx
@@ -31,7 +31,7 @@ class TransactionStatus extends React.Component<Props> {
     this.props.fetchTransactionData(this.props.txHash);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.txHash !== nextProps.txHash) {
       this.props.fetchTransactionData(nextProps.txHash);
     }

--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -226,7 +226,7 @@ const WalletDecrypt = withRouter<Props>(
       hasAcknowledgedInsecure: false
     };
 
-    public componentWillReceiveProps(nextProps: Props) {
+    public UNSAFE_componentWillReceiveProps(nextProps: Props) {
       // Reset state when unlock is hidden / revealed
       if (nextProps.hidden !== this.props.hidden) {
         this.setState({

--- a/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
+++ b/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
@@ -73,7 +73,7 @@ class DeterministicWalletsModalClass extends React.PureComponent<Props, State> {
     this.getAddresses();
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { publicKey, chainCode, seed, dPath } = this.props;
     if (
       nextProps.publicKey !== publicKey ||

--- a/common/components/WalletDecrypt/components/LedgerNano.tsx
+++ b/common/components/WalletDecrypt/components/LedgerNano.tsx
@@ -50,7 +50,7 @@ class LedgerNanoSDecryptClass extends PureComponent<Props, State> {
     });
   };
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.dPath !== nextProps.dPath && nextProps.dPath) {
       this.setState({ dPath: nextProps.dPath });
     }

--- a/common/components/WalletDecrypt/components/Mnemonic.tsx
+++ b/common/components/WalletDecrypt/components/Mnemonic.tsx
@@ -39,7 +39,7 @@ class MnemonicDecryptClass extends PureComponent<Props, State> {
     dPath: this.props.dPath
   };
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.dPath !== nextProps.dPath) {
       this.setState({ dPath: nextProps.dPath });
     }

--- a/common/components/WalletDecrypt/components/Trezor.tsx
+++ b/common/components/WalletDecrypt/components/Trezor.tsx
@@ -41,7 +41,7 @@ class TrezorDecryptClass extends PureComponent<Props, State> {
     isLoading: false
   };
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.dPath !== nextProps.dPath && nextProps.dPath) {
       this.setState({ dPath: nextProps.dPath });
     }

--- a/common/components/renderCbs/UnitConverter.tsx
+++ b/common/components/renderCbs/UnitConverter.tsx
@@ -29,7 +29,7 @@ const initialState = { userInput: '' };
 class UnitConverterClass extends Component<Props, State> {
   public state: State = initialState;
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { userInput } = this.state;
 
     if (this.props.decimal !== nextProps.decimal) {

--- a/common/components/ui/QRCode.tsx
+++ b/common/components/ui/QRCode.tsx
@@ -15,12 +15,12 @@ interface State {
 
 export default class QRCode extends React.PureComponent<Props, State> {
   public state: State = {};
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     // Start generating QR codes immediately
     this.generateQrCode(this.props.data);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     // Regenerate QR codes if props change
     if (nextProps.data !== this.props.data) {
       this.generateQrCode(nextProps.data);

--- a/common/components/ui/SwapDropdown.tsx
+++ b/common/components/ui/SwapDropdown.tsx
@@ -34,7 +34,7 @@ class SwapDropdown extends PureComponent<Props, State> {
 
   public dropdown: HTMLDivElement | null;
 
-  public componentWillMount() {
+  public UNSAFE_componentWillMount() {
     this.buildOptions(this.props.options);
     document.addEventListener('click', this.handleBodyClick);
   }
@@ -43,7 +43,7 @@ class SwapDropdown extends PureComponent<Props, State> {
     document.removeEventListener('click', this.handleBodyClick);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.options !== nextProps.options) {
       this.buildOptions(nextProps.options);
     }

--- a/common/containers/Tabs/CheckTransaction/components/TxHashInput.tsx
+++ b/common/containers/Tabs/CheckTransaction/components/TxHashInput.tsx
@@ -33,7 +33,7 @@ class TxHashInput extends React.Component<Props, State> {
     this.state = { hash: props.hash || '' };
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.hash !== nextProps.hash && nextProps.hash) {
       this.setState({ hash: nextProps.hash });
     }

--- a/common/containers/Tabs/CheckTransaction/index.tsx
+++ b/common/containers/Tabs/CheckTransaction/index.tsx
@@ -34,7 +34,7 @@ class CheckTransaction extends React.Component<Props, State> {
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { network } = this.props;
     if (network.chainId !== nextProps.network.chainId) {
       this.setState({ hash: '' });

--- a/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
@@ -63,7 +63,7 @@ class InteractForm extends Component<Props, State> {
     };
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const prevProps = this.props;
     if (nextProps.currentTo.raw !== prevProps.currentTo.raw) {
       nextProps.resetState();

--- a/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
+++ b/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
@@ -68,7 +68,7 @@ class RequestPayment extends React.Component<Props, {}> {
     this.props.resetTransactionRequested();
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.wallet && this.props.wallet !== nextProps.wallet) {
       this.setWalletAsyncState(nextProps.wallet);
     }

--- a/common/containers/Tabs/SendTransaction/components/WalletInfo.tsx
+++ b/common/containers/Tabs/SendTransaction/components/WalletInfo.tsx
@@ -30,7 +30,7 @@ export default class WalletInfo extends React.PureComponent<Props, State> {
     this.setStateFromWallet(this.props.wallet);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.wallet !== nextProps.wallet) {
       this.setStateFromWallet(nextProps.wallet);
     }

--- a/common/containers/Tabs/Swap/components/CurrencySwap.tsx
+++ b/common/containers/Tabs/Swap/components/CurrencySwap.tsx
@@ -117,7 +117,7 @@ export default class CurrencySwap extends PureComponent<Props, State> {
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.options !== this.props.options) {
       this.setState({ options: Object.values(nextProps.options.byId) });
     }

--- a/common/containers/Tabs/Swap/components/CurrentRates.tsx
+++ b/common/containers/Tabs/Swap/components/CurrentRates.tsx
@@ -49,7 +49,7 @@ class CurrentRates extends PureComponent<Props> {
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (this.props.isOffline && !nextProps.isOffline) {
       this.loadRates();
     }


### PR DESCRIPTION
### Description

In preparation of React's [async rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props) and depreciation of bug prone lifecycle methods, all unsafe lifecycle methods have been marked as such for better visibility. 

### Changes

* componentWillMount -> UNSAFE_componentWillMount
* componentWillReceiveProps -> UNSAFE_componentWillReceiveProps
* componentWillUpdate -> UNSAFE_componentWillUpdate


