### PR TITLE
Ignore dist for jest tests

### DIFF
--- a/jest_config/jest.config.json
+++ b/jest_config/jest.config.json
@@ -12,7 +12,7 @@
     "\\.(css|scss)$": "<rootDir>/jest_config/__mocks__/styleMock.ts",
     "\\.worker.ts": "<rootDir>/jest_config/__mocks__/workerMock.js"
   },
-  "testPathIgnorePatterns": [],
+  "testPathIgnorePatterns": ["dist"],
   "setupFiles": [
     "<rootDir>/jest_config/setupJest.js",
     "<rootDir>/jest_config/__mocks__/localStorage.ts"


### PR DESCRIPTION
### Description

If jest tests ever get copied to dist, they'll get matched and run (and promptly fail). This ignores the directory for jest.

### Changes

* Add `dist` as a ignored directory for jest

### Steps to Test

1. Transpile tests into dist
2. Run `yarn test`
3. Tests should run and complete

