### PR TITLE
Don't show new welcome message on Electron

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -113,7 +113,7 @@ class RootClass extends Component<Props, State> {
               {!process.env.DOWNLOADABLE_BUILD && (
                 <React.Fragment>
                   <OnboardModal />
-                  <WelcomeModal />
+                  {!process.env.BUILD_ELECTRON && <WelcomeModal />}
                 </React.Fragment>
               )}
             </React.Fragment>


### PR DESCRIPTION
Electron hasn't yet graduated to a stable launch, and as such, we shouldn't show the stable welcome message on Electron.