### PR TITLE
Strip hex prefix for bytes inputs

### DIFF
--- a/common/libs/contracts/ABIFunction.ts
+++ b/common/libs/contracts/ABIFunction.ts
@@ -1,5 +1,5 @@
 import abi from 'ethereumjs-abi';
-import { toChecksumAddress, addHexPrefix } from 'ethereumjs-util';
+import { toChecksumAddress, addHexPrefix, stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';
 import {
   FuncParams,
@@ -97,7 +97,7 @@ export default class AbiFunction {
 
   private parsePreEncodedValue = (type: string, value: any) => {
     if (type === 'bytes') {
-      return Buffer.from(value, 'hex');
+      return Buffer.from(stripHexPrefix(value), 'hex');
     }
     return BN.isBN(value) ? value.toString() : value;
   };


### PR DESCRIPTION

Closes #1726

### Description

We weren't stripping the hex prefix before turning it into a buffer. Unfortunately, a hex prefixed hex string is invalid in the context of `Buffer.from(<hexstring>, 'hex')`, which returns an empty buffer(!) instead of throwing.

