### PR TITLE
Add Electron Build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,69 @@
-dist: trusty
-sudo: required
+
 language: node_js
 
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.3
+      env:
+        - ELECTRON_CACHE=$HOME/.cache/electron
+        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+
 cache:
+  yarn: true
   directories:
     - node_modules
+    - $HOME/.cache/electron
+    - $HOME/.cache/electron-builder
 
-services:
-  - docker
+before_cache:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      rm -rf $HOME/.cache/electron-builder/wine
+    fi
 
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-# uncomment once integration tests are included in CI
-#  - docker pull dternyak/eth-priv-to-addr:latest
-  - sudo apt-get install libusb-1.0
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export CHROME_BIN=chromium-browser
+      export DISPLAY=:99.0
+      sh -e /etc/init.d/xvfb start
+      # uncomment once integration tests are included in CI
+      # docker pull dternyak/eth-priv-to-addr:latest
+      sudo apt-get install libusb-1.0     
+    fi
   
 install:
-  - npm install --silent
+  - yarn --silent
 
-jobs:
-  include:
-    - stage: test
-      script: npm run prettier:diff
-    - stage: test
-      script: npm run test:coverage -- --maxWorkers=2 && npm run report-coverage
-    - stage: test
-      script: npm run tslint && npm run tscheck && npm run freezer && npm run freezer:validate
+script:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      npm run prettier:diff
+      npm run test:coverage -- --maxWorkers=2
+      npm run report-coverage
+      npm run tslint
+      npm run tscheck
+      npm run freezer
+      npm run freezer:validate
+    fi
+
+  - | 
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      npm run build:electron
+      ls -la dist/electron-builds
+    fi
 
 notifications:
   email:
     on_success: never
     on_failure: never
+
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,3 @@ notifications:
   email:
     on_success: never
     on_failure: never
-
-branches:
-  except:
-    - "/^v\\d+\\.\\d+\\.\\d+$/"


### PR DESCRIPTION
Implements a build matrix, causing Travis to run our tests in both Linux and OSX environments in parallel. The `.travis.yml` file has also been modified to run our traditional test suite when in Linux, and build our Electron app for all platforms when in OSX.

A downside to this approach is that (I think) Travis provides fewer OSX machines to execute CI, so the Electron build tasks may take a little longer to actually spin up (and thus increase the time it takes to complete the Travis pass/fail status check).  Seems like an acceptable tradeoff, however. 
