### PR TITLE
Corrected Confirm Password Typo

### DIFF
--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -422,7 +422,7 @@
     "STEELY_REFERRAL": "Get a Steely",
     "ETHERCARD_REFERAL": "Get an ether.card",
     "DISCLAIMER": "Disclaimer",
-    "INPUT_CONFIRM_PASSWORD_LABEL": "Confirm password",
+    "INPUT_CONFIRM_PASSWORD_LABEL": "Confirm Password",
     "INPUT_PASSWORD_LABEL": "Password",
     "INPUT_USERNAME_LABEL": "Username",
     "INPUT_PASSWORD_PLACEHOLDER": "Password must use at least $pass_length characters",


### PR DESCRIPTION
Closes #1821 

### Description

Confirm password -> Confirm Password

### Changes

Corrected typo on Generate Keystore File page

### Steps to Test
Go to Generate Keystore File Page and you'll see the changed text in placeholder
