### PR TITLE
Using redux saga selector to access dynamically the ENS network config filtering by selected network

### DIFF
--- a/common/libs/ens/networkConfigs/index.ts
+++ b/common/libs/ens/networkConfigs/index.ts
@@ -12,4 +12,10 @@ interface IEnsAddresses {
   registry: string;
 }
 
-export default { main, rinkeby, ropsten };
+const ensNetworksByKey: { [key: string]: IEnsAddresses } = {
+  ETH: main,
+  Rinkeby: rinkeby,
+  Ropsten: ropsten
+};
+
+export default { main, rinkeby, ropsten, ensNetworksByKey };


### PR DESCRIPTION
Closes  #1855

### Description

`cocacola.eth` ENS name is shown as **available** in Ropsten when in fact **it is already reserved**.

 `saga/ens/modeMap.ts` used always **main** as ENS network: `const { main } = networkConfigs;`

### Changes

* `libs/ens/networkConfigs/index.ts`: Adding dynamic ENS network selection using now `ensNetworksByKey`.
* `saga/ens/modeMap.ts`: Now using `getSelectedNetwork` saga selector to access selected network.
* Structural parts of the codebase should not be affected.

### Steps to Test

1. Open -> https://mycrypto.com/ens
2. Select Ropsten as working network.
3. Search by `cocacola`.

Your search **result now should be**: 

```
cocacola.eth is already owned:
Owner: 0x796df1a602c3e910cabadea6a4c2573c38e56b54
```
