### PR TITLE
Add ETC Chainkorea node

### DIFF
--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -78,6 +78,12 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       type: 'rpc',
       service: 'Ethereum Commonwealth',
       url: 'https://etc-geth.0xinfra.com/'
+    },
+    {
+      name: makeNodeName('ETC', 'chainkorea'),
+      type: 'rpc',
+      service: 'Chainkorea',
+      url: 'https://node.classicexplorer.org/'
     }
   ],
 


### PR DESCRIPTION
Node used and maintained by Chainkorea (https://github.com/chainkorea)

+ HTTPS & Load Balancing through AWS (https://github.com/chainkorea/docker-etc-lb)
+ Blockchain up to date.
+ Response time ~150-350ms
+ KR servers
+ Live stats page on https://classicstats.net