### PR TITLE
Add RSK network with checksum

### DIFF
--- a/common/actions/addressBook/actionCreators.ts
+++ b/common/actions/addressBook/actionCreators.ts
@@ -20,7 +20,7 @@ export function setAddressLabel(payload: AddressLabel): SetAddressLabel {
 }
 
 export type TClearAddressLabel = typeof clearAddressLabel;
-export function clearAddressLabel(payload: string): ClearAddressLabel {
+export function clearAddressLabel(payload: AddressLabel): ClearAddressLabel {
   return {
     type: TypeKeys.CLEAR_ADDRESS_LABEL,
     payload
@@ -52,7 +52,7 @@ export function saveAddressLabelEntry(payload: string): SaveAddressLabelEntry {
 }
 
 export type TClearAddressLabelEntry = typeof clearAddressLabelEntry;
-export function clearAddressLabelEntry(payload: string): ClearAddressLabelEntry {
+export function clearAddressLabelEntry(payload: AddressLabel): ClearAddressLabelEntry {
   return {
     type: TypeKeys.CLEAR_ADDRESS_LABEL_ENTRY,
     payload

--- a/common/actions/addressBook/actionTypes.ts
+++ b/common/actions/addressBook/actionTypes.ts
@@ -3,6 +3,7 @@ import { TypeKeys } from './constants';
 export interface AddressLabel {
   address: string;
   label: string;
+  chainId: number;
 }
 
 export interface AddressLabelEntry extends AddressLabel {
@@ -22,7 +23,7 @@ export interface SetAddressLabel {
 
 export interface ClearAddressLabel {
   type: TypeKeys.CLEAR_ADDRESS_LABEL;
-  payload: string;
+  payload: AddressLabel;
 }
 
 export interface SetAddressLabelEntry {
@@ -42,7 +43,7 @@ export interface SaveAddressLabelEntry {
 
 export interface ClearAddressLabelEntry {
   type: TypeKeys.CLEAR_ADDRESS_LABEL_ENTRY;
-  payload: string;
+  payload: AddressLabel;
 }
 
 export interface RemoveAddressLabelEntry {

--- a/common/actions/deterministicWallets/actionCreators.ts
+++ b/common/actions/deterministicWallets/actionCreators.ts
@@ -3,7 +3,7 @@ import { TypeKeys } from './constants';
 export function getDeterministicWallets(
   args: interfaces.GetDeterministicWalletsArgs
 ): interfaces.GetDeterministicWalletsAction {
-  const { seed, dPath, publicKey, chainCode, limit, offset } = args;
+  const { seed, dPath, publicKey, chainCode, limit, offset, chainId } = args;
   return {
     type: TypeKeys.DW_GET_WALLETS,
     payload: {
@@ -12,7 +12,8 @@ export function getDeterministicWallets(
       publicKey,
       chainCode,
       limit: limit || 5,
-      offset: offset || 0
+      offset: offset || 0,
+      chainId
     }
   };
 }

--- a/common/actions/deterministicWallets/actionTypes.ts
+++ b/common/actions/deterministicWallets/actionTypes.ts
@@ -26,6 +26,7 @@ export interface GetDeterministicWalletsAction {
     chainCode?: string;
     limit: number;
     offset: number;
+    chainId: number;
   };
 }
 
@@ -61,6 +62,7 @@ export interface GetDeterministicWalletsArgs {
   chainCode?: string;
   limit?: number;
   offset?: number;
+  chainId: number;
 }
 
 /*** Union Type ***/

--- a/common/components/AddressBookTable.tsx
+++ b/common/components/AddressBookTable.tsx
@@ -20,6 +20,8 @@ import {
 import { Input, Identicon } from 'components/ui';
 import AddressBookTableRow from './AddressBookTableRow';
 import './AddressBookTable.scss';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface DispatchProps {
   changeAddressLabelEntry: TChangeAddressLabelEntry;
@@ -32,6 +34,7 @@ interface StateProps {
   entry: ReturnType<typeof getAddressBookTableEntry>;
   addressLabels: ReturnType<typeof getAddressLabels>;
   labelAddresses: ReturnType<typeof getLabelAddresses>;
+  network: NetworkConfig;
 }
 
 type Props = DispatchProps & StateProps;
@@ -115,10 +118,10 @@ class AddressBookTable extends React.Component<Props, State> {
               />
             </div>
             <div className="AddressBookTable-row-identicon AddressBookTable-row-identicon-non-mobile">
-              <Identicon address={temporaryAddress} />
+              <Identicon address={temporaryAddress} network={this.props.network} />
             </div>
             <div className="AddressBookTable-row-identicon AddressBookTable-row-identicon-mobile">
-              <Identicon address={temporaryAddress} size="3rem" />
+              <Identicon address={temporaryAddress} network={this.props.network} size="3rem" />
             </div>
           </div>
           <div className="AddressBookTable-row AddressBookTable-row-error AddressBookTable-row-error--mobile">
@@ -207,7 +210,8 @@ class AddressBookTable extends React.Component<Props, State> {
         id,
         address,
         label: newLabel,
-        isEditing: true
+        isEditing: true,
+        chainId: this.props.network.chainId
       });
     const onSave = () => {
       this.props.saveAddressLabelEntry(id);
@@ -222,7 +226,8 @@ class AddressBookTable extends React.Component<Props, State> {
           temporaryAddress: address,
           label,
           temporaryLabel: label,
-          overrideValidation: true
+          overrideValidation: true,
+          chainId: this.props.network.chainId
         });
       }
 
@@ -243,6 +248,7 @@ class AddressBookTable extends React.Component<Props, State> {
         onLabelInputBlur={onLabelInputBlur}
         onEditClick={() => this.setEditingRow(index)}
         onRemoveClick={() => this.props.removeAddressLabelEntry(id)}
+        network={this.props.network}
       />
     );
   };
@@ -264,7 +270,8 @@ class AddressBookTable extends React.Component<Props, State> {
     this.props.changeAddressLabelEntry({
       id: ADDRESS_BOOK_TABLE_ID,
       address,
-      label
+      label,
+      chainId: this.props.network.chainId
     });
 
     this.setState(
@@ -289,7 +296,8 @@ class AddressBookTable extends React.Component<Props, State> {
     this.props.changeAddressLabelEntry({
       id: ADDRESS_BOOK_TABLE_ID,
       address,
-      label
+      label,
+      chainId: this.props.network.chainId
     });
 
     this.setState({ labelTouched: true }, () => label.length === 0 && this.clearLabelTouched());
@@ -308,7 +316,8 @@ const mapStateToProps: MapStateToProps<StateProps, {}, AppState> = state => ({
   rows: getAddressLabelRows(state),
   entry: getAddressBookTableEntry(state),
   addressLabels: getAddressLabels(state),
-  labelAddresses: getLabelAddresses(state)
+  labelAddresses: getLabelAddresses(state),
+  network: getNetworkConfig(state)
 });
 
 const mapDispatchToProps: DispatchProps = {

--- a/common/components/AddressBookTableRow.tsx
+++ b/common/components/AddressBookTableRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import translate, { translateRaw } from 'translations';
 import noop from 'lodash/noop';
 import { Input, Identicon } from 'components/ui';
+import { NetworkConfig } from 'types/network';
 
 interface Props {
   index: number;
@@ -10,6 +11,7 @@ interface Props {
   temporaryLabel: string;
   labelError?: string;
   isEditing: boolean;
+  network: NetworkConfig;
   onChange(label: string): void;
   onSave(): void;
   onLabelInputBlur(): void;
@@ -63,10 +65,10 @@ class AddressBookTableRow extends React.Component<Props> {
               />
             </div>
             <div className="AddressBookTable-row-identicon AddressBookTable-row-identicon-non-mobile">
-              <Identicon address={address} />
+              <Identicon address={address} network={this.props.network} />
             </div>
             <div className="AddressBookTable-row-identicon AddressBookTable-row-identicon-mobile">
-              <Identicon address={address} size="3rem" />
+              <Identicon address={address} size="3rem" network={this.props.network} />
             </div>
           </div>
           <div className="AddressBookTable-row-input">

--- a/common/components/AddressField.tsx
+++ b/common/components/AddressField.tsx
@@ -3,20 +3,23 @@ import { AddressFieldFactory } from './AddressFieldFactory';
 import { donationAddressMap } from 'config';
 import translate from 'translations';
 import { Input } from 'components/ui';
-import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
+import { NetworkConfig } from 'types/network';
 
 interface Props {
   isReadOnly?: boolean;
   isSelfAddress?: boolean;
   isCheckSummed?: boolean;
   showLabelMatch?: boolean;
+  network: NetworkConfig;
 }
 
 export const AddressField: React.SFC<Props> = ({
   isReadOnly,
   isSelfAddress,
   isCheckSummed,
-  showLabelMatch
+  showLabelMatch,
+  network
 }) => (
   <AddressFieldFactory
     isSelfAddress={isSelfAddress}
@@ -31,7 +34,11 @@ export const AddressField: React.SFC<Props> = ({
             className={`input-group-input ${!isValid && !isLabelEntry ? 'invalid' : ''}`}
             isValid={isValid}
             type="text"
-            value={isCheckSummed ? toChecksumAddress(currentTo.raw) : currentTo.raw}
+            value={
+              isCheckSummed
+                ? toChecksumAddressByChainId(currentTo.raw, network.chainId)
+                : currentTo.raw
+            }
             placeholder={donationAddressMap.ETH}
             readOnly={!!(isReadOnly || readOnly)}
             spellCheck={false}

--- a/common/components/AddressFieldFactory/AddressFieldDropdown.tsx
+++ b/common/components/AddressFieldFactory/AddressFieldDropdown.tsx
@@ -7,10 +7,13 @@ import { getLabelAddresses } from 'selectors/addressBook';
 import { getToRaw } from 'selectors/transaction/fields';
 import { Address, Identicon } from 'components/ui';
 import './AddressFieldDropdown.scss';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface StateProps {
   labelAddresses: ReturnType<typeof getLabelAddresses>;
   currentTo: ReturnType<typeof getToRaw>;
+  network: NetworkConfig;
 }
 
 interface DispatchProps {
@@ -69,7 +72,7 @@ class AddressFieldDropdown extends React.Component<Props> {
           title={`${translateRaw('SEND_TO')}${label}`}
         >
           <div className="AddressFieldDropdown-dropdown-item-identicon">
-            <Identicon address={address} />
+            <Identicon address={address} network={this.props.network} />
           </div>
           <strong className="AddressFieldDropdown-dropdown-item-label">{label}</strong>
           <em className="AddressFieldDropdown-dropdown-item-address">
@@ -159,7 +162,8 @@ class AddressFieldDropdown extends React.Component<Props> {
 export default connect(
   (state: AppState) => ({
     labelAddresses: getLabelAddresses(state),
-    currentTo: getToRaw(state)
+    currentTo: getToRaw(state),
+    network: getNetworkConfig(state)
   }),
   { setCurrentTo }
 )(AddressFieldDropdown);

--- a/common/components/AddressFieldFactory/AddressInputFactory.tsx
+++ b/common/components/AddressFieldFactory/AddressInputFactory.tsx
@@ -19,6 +19,8 @@ import { isValidENSAddress } from 'libs/validators';
 import { Address } from 'libs/units';
 import AddressFieldDropdown from './AddressFieldDropdown';
 import './AddressInputFactory.scss';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface StateProps {
   currentTo: ICurrentTo;
@@ -26,6 +28,7 @@ interface StateProps {
   isValid: boolean;
   isLabelEntry: boolean;
   isResolving: boolean;
+  network: NetworkConfig;
 }
 
 interface OwnProps {
@@ -72,7 +75,8 @@ class AddressInputFactoryClass extends Component<Props> {
       showLabelMatch,
       isSelfAddress,
       isResolving,
-      isFocused
+      isFocused,
+      network
     } = this.props;
     const { value } = currentTo;
     const addr = addHexPrefix(value ? value.toString('hex') : '0');
@@ -107,7 +111,7 @@ class AddressInputFactoryClass extends Component<Props> {
             )}
         </div>
         <div className="AddressInput-identicon">
-          <Identicon address={addr} />
+          <Identicon address={addr} network={network} />
         </div>
       </div>
     );
@@ -132,6 +136,7 @@ export const AddressInputFactory = connect((state: AppState, ownProps: OwnProps)
     label: getCurrentToLabel(state),
     isResolving: getResolvingDomain(state),
     isValid: isValidCurrentTo(state),
-    isLabelEntry: isCurrentToLabelEntry(state)
+    isLabelEntry: isCurrentToLabelEntry(state),
+    network: getNetworkConfig(state)
   };
 })(AddressInputFactoryClass);

--- a/common/components/BalanceSidebar/AccountAddress.tsx
+++ b/common/components/BalanceSidebar/AccountAddress.tsx
@@ -13,10 +13,13 @@ import {
 } from 'actions/addressBook';
 import { getAccountAddressEntry, getAddressLabels } from 'selectors/addressBook';
 import { Address, Identicon, Input } from 'components/ui';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface StateProps {
   entry: ReturnType<typeof getAccountAddressEntry>;
   addressLabels: ReturnType<typeof getAddressLabels>;
+  network: NetworkConfig;
 }
 
 interface DispatchProps {
@@ -79,7 +82,7 @@ class AccountAddress extends React.Component<Props, State> {
         <h5 className="AccountInfo-section-header">{translate('SIDEBAR_ACCOUNTADDR')}</h5>
         <div className="AccountInfo-section AccountInfo-address-section">
           <div className="AccountInfo-address-icon">
-            <Identicon address={address} size="100%" />
+            <Identicon address={address} size="100%" network={this.props.network} />
           </div>
           <div className="AccountInfo-address-wrapper">
             {labelContent}
@@ -208,7 +211,8 @@ class AccountAddress extends React.Component<Props, State> {
           temporaryAddress: address,
           label,
           temporaryLabel: label,
-          overrideValidation: true
+          overrideValidation: true,
+          chainId: this.props.network.chainId
         });
       }
     } else {
@@ -233,7 +237,8 @@ class AccountAddress extends React.Component<Props, State> {
       id: ACCOUNT_ADDRESS_ID,
       address,
       label,
-      isEditing: true
+      isEditing: true,
+      chainId: this.props.network.chainId
     });
 
     this.setState(
@@ -257,7 +262,8 @@ class AccountAddress extends React.Component<Props, State> {
 
 const mapStateToProps: MapStateToProps<StateProps, {}, AppState> = (state: AppState) => ({
   entry: getAccountAddressEntry(state),
-  addressLabels: getAddressLabels(state)
+  addressLabels: getAddressLabels(state),
+  network: getNetworkConfig(state)
 });
 
 const mapDispatchToProps: DispatchProps = {

--- a/common/components/BalanceSidebar/AccountInfo.tsx
+++ b/common/components/BalanceSidebar/AccountInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 import { UnitDisplay, NewTabLink } from 'components/ui';
 import { IWallet, TrezorWallet, LedgerWallet, Balance } from 'libs/wallet';
 import translate, { translateRaw } from 'translations';
@@ -87,7 +87,7 @@ class AccountInfo extends React.Component<Props, State> {
     const wallet = this.props.wallet as LedgerWallet | TrezorWallet;
     return (
       <div>
-        <AccountAddress address={toChecksumAddress(address)} />
+        <AccountAddress address={toChecksumAddressByChainId(address, network.chainId)} />
 
         {typeof wallet.displayAddress === 'function' && (
           <div className="AccountInfo-section">

--- a/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm.tsx
+++ b/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { HELP_ARTICLE } from 'config';
-import { isPositiveIntegerOrZero, isValidETHAddress } from 'libs/validators';
+import { isPositiveIntegerOrZero, isValidAddress } from 'libs/validators';
 import translate, { translateRaw } from 'translations';
 import { HelpLink, Input } from 'components/ui';
 import './AddCustomTokenForm.scss';
-import { Token } from 'types/network';
+import { Token, NetworkConfig } from 'types/network';
+import { getNetworkConfig } from 'selectors/config';
+import { AppState } from 'reducers';
+import { connect } from 'react-redux';
 
 interface Props {
   allTokens: Token[];
+  network: NetworkConfig;
   onSave(params: Token): void;
   toggleForm(): void;
 }
@@ -28,7 +32,7 @@ interface State {
   decimal: string;
 }
 
-export default class AddCustomTokenForm extends React.PureComponent<Props, State> {
+export class AddCustomTokenForm extends React.PureComponent<Props, State> {
   public state: State = {
     tokenSymbolLookup: this.generateSymbolLookup(),
     tokenAddressLookup: this.generateAddressMap(),
@@ -110,7 +114,7 @@ export default class AddCustomTokenForm extends React.PureComponent<Props, State
       errors.decimal = 'Invalid decimal';
     }
     if (address) {
-      if (!isValidETHAddress(address)) {
+      if (!isValidAddress(address, this.props.network.chainId)) {
         errors.address = 'Not a valid address';
       }
       if (this.state.tokenAddressLookup[address]) {
@@ -164,3 +168,7 @@ export default class AddCustomTokenForm extends React.PureComponent<Props, State
     }, {});
   }
 }
+
+export default connect((state: AppState) => ({
+  network: getNetworkConfig(state)
+}))(AddCustomTokenForm);

--- a/common/components/PaperWallet/index.tsx
+++ b/common/components/PaperWallet/index.tsx
@@ -1,5 +1,6 @@
 import { Identicon, QRCode } from 'components/ui';
 import React from 'react';
+import { NetworkConfig } from 'types/network';
 
 import ethLogo from 'assets/images/logo-ethereum-1.png';
 import notesBg from 'assets/images/notes-bg.png';
@@ -92,6 +93,7 @@ const styles: any = {
 interface Props {
   address: string;
   privateKey: string;
+  network: NetworkConfig;
 }
 
 export default class PaperWallet extends React.Component<Props, {}> {
@@ -137,7 +139,7 @@ export default class PaperWallet extends React.Component<Props, {}> {
 
         <div style={styles.identiconContainer}>
           <div style={{ float: 'left' }}>
-            <Identicon address={address} size={'42px'} />
+            <Identicon address={address} size={'42px'} network={this.props.network} />
           </div>
           <p style={styles.identiconText}>Always look for this icon when sending to this wallet</p>
         </div>

--- a/common/components/PrintableWallet/index.tsx
+++ b/common/components/PrintableWallet/index.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import printElement from 'utils/printElement';
 import { stripHexPrefix } from 'libs/values';
 import translate, { translateRaw } from 'translations';
+import { NetworkConfig } from 'types/network';
 
-export const print = (address: string, privateKey: string) => () =>
+export const print = (address: string, privateKey: string, network: NetworkConfig) => () =>
   address &&
   privateKey &&
-  printElement(<PaperWallet address={address} privateKey={privateKey} />, {
+  printElement(<PaperWallet address={address} privateKey={privateKey} network={network} />, {
     popupFeatures: {
       scrollbars: 'no'
     },
@@ -28,20 +29,21 @@ export const print = (address: string, privateKey: string) => () =>
 interface Props {
   address: string;
   privateKey: string;
+  network: NetworkConfig;
 }
 
-const PrintableWallet: React.SFC<Props> = ({ address, privateKey }) => {
+const PrintableWallet: React.SFC<Props> = ({ address, privateKey, network }) => {
   const pkey = stripHexPrefix(privateKey);
 
   return (
     <div>
-      <PaperWallet address={address} privateKey={pkey} />
+      <PaperWallet address={address} privateKey={pkey} network={network} />
       <a
         role="button"
         aria-label={translateRaw('X_PRINT')}
         aria-describedby="x_PrintDesc"
         className="btn btn-lg btn-primary btn-block"
-        onClick={print(address, pkey)}
+        onClick={print(address, pkey, network)}
         style={{ margin: '10px auto 0', maxWidth: '260px' }}
       >
         {translate('X_PRINT')}

--- a/common/components/TransactionStatus/TransactionDataTable.tsx
+++ b/common/components/TransactionStatus/TransactionDataTable.tsx
@@ -97,7 +97,7 @@ const TransactionDataTable: React.SFC<Props> = ({ data, receipt, network }) => {
       label: translate('OFFLINE_STEP1_LABEL_1'),
       data: (
         <MaybeLink href={explorer.from}>
-          <Identicon address={data.from} size="26px" />
+          <Identicon address={data.from} size="26px" network={network} />
           <Address address={data.from} />
         </MaybeLink>
       )
@@ -106,7 +106,7 @@ const TransactionDataTable: React.SFC<Props> = ({ data, receipt, network }) => {
       label: translate('OFFLINE_STEP2_LABEL_1'),
       data: (
         <MaybeLink href={explorer.to}>
-          <Identicon address={data.to} size="26px" />
+          <Identicon address={data.to} size="26px" network={network} />
           <Address address={data.to} />
         </MaybeLink>
       )

--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -51,6 +51,8 @@ import { wikiLink as paritySignerHelpLink } from 'libs/wallet/non-deterministic/
 import './WalletDecrypt.scss';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { Errorable } from 'components';
+import { NetworkConfig } from 'types/network';
+import { getNetworkConfig } from 'selectors/config';
 
 interface OwnProps {
   hidden?: boolean;
@@ -72,6 +74,7 @@ interface StateProps {
   computedDisabledWallets: DisabledWallets;
   isWalletPending: AppState['wallet']['isWalletPending'];
   isPasswordPending: AppState['wallet']['isPasswordPending'];
+  network: NetworkConfig;
 }
 
 type Props = OwnProps & StateProps & DispatchProps & RouteComponentProps<{}>;
@@ -92,6 +95,7 @@ interface BaseWalletInfo {
   isReadOnly?: boolean;
   attemptUnlock?: boolean;
   redirect?: string;
+  network?: NetworkConfig;
 }
 
 export interface SecureWalletInfo extends BaseWalletInfo {
@@ -282,6 +286,7 @@ const WalletDecrypt = withRouter<Props>(
                     ? this.props.isPasswordPending
                     : undefined
                 }
+                network={this.props.network}
               />
             </Errorable>
           </section>
@@ -468,7 +473,8 @@ function mapStateToProps(state: AppState, ownProps: Props) {
   return {
     computedDisabledWallets,
     isWalletPending: state.wallet.isWalletPending,
-    isPasswordPending: state.wallet.isPasswordPending
+    isPasswordPending: state.wallet.isPasswordPending,
+    network: getNetworkConfig(state)
   };
 }
 

--- a/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
+++ b/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Select, { Option } from 'react-select';
-import { toChecksumAddress } from 'ethereumjs-util';
 import translate, { translateRaw } from 'translations';
 import {
   DeterministicWalletData,
@@ -19,6 +18,7 @@ import { getTokens } from 'selectors/wallet';
 import { getAddressLabels } from 'selectors/addressBook';
 import { UnitDisplay, Input } from 'components/ui';
 import './DeterministicWalletsModal.scss';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 
 const WALLETS_PER_PAGE = 5;
 
@@ -200,17 +200,17 @@ class DeterministicWalletsModalClass extends React.PureComponent<Props, State> {
   }
 
   private getAddresses(props: Props = this.props) {
-    const { dPath, publicKey, chainCode, seed } = props;
-
+    const { dPath, publicKey, chainCode, seed, network } = props;
     if (dPath && ((publicKey && chainCode) || seed)) {
       if (isValidPath(dPath.value)) {
         this.props.getDeterministicWallets({
           seed,
+          dPath: dPath.value,
           publicKey,
           chainCode,
-          dPath: dPath.value,
           limit: WALLETS_PER_PAGE,
-          offset: WALLETS_PER_PAGE * this.state.page
+          offset: WALLETS_PER_PAGE * this.state.page,
+          chainId: network.chainId
         });
       } else {
         console.error('Invalid dPath provided', dPath);
@@ -280,7 +280,7 @@ class DeterministicWalletsModalClass extends React.PureComponent<Props, State> {
   private renderWalletRow(wallet: DeterministicWalletData) {
     const { desiredToken, network, addressLabels } = this.props;
     const { selectedAddress } = this.state;
-    const label = addressLabels[toChecksumAddress(wallet.address)];
+    const label = addressLabels[toChecksumAddressByChainId(wallet.address, network.chainId)];
     const spanClassName = label ? 'DWModal-addresses-table-address-text' : '';
 
     // Get renderable values, but keep 'em short

--- a/common/components/WalletDecrypt/components/Mnemonic.tsx
+++ b/common/components/WalletDecrypt/components/Mnemonic.tsx
@@ -10,6 +10,8 @@ import { getSingleDPath, getPaths } from 'selectors/config/wallet';
 import { TogglablePassword } from 'components';
 import { Input } from 'components/ui';
 import DeprecationWarning from './DeprecationWarning';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface OwnProps {
   onUnlock(param: any): void;
@@ -18,6 +20,7 @@ interface OwnProps {
 interface StateProps {
   dPath: DPath;
   dPaths: DPath[];
+  network: NetworkConfig;
 }
 
 type Props = OwnProps & StateProps;
@@ -160,7 +163,8 @@ function mapStateToProps(state: AppState): StateProps {
   return {
     // Mnemonic dPath is guaranteed to always be provided
     dPath: getSingleDPath(state, InsecureWalletName.MNEMONIC_PHRASE) as DPath,
-    dPaths: getPaths(state, InsecureWalletName.MNEMONIC_PHRASE)
+    dPaths: getPaths(state, InsecureWalletName.MNEMONIC_PHRASE),
+    network: getNetworkConfig(state)
   };
 }
 

--- a/common/components/WalletDecrypt/components/Trezor.tsx
+++ b/common/components/WalletDecrypt/components/Trezor.tsx
@@ -9,7 +9,9 @@ import { AppState } from 'reducers';
 import { connect } from 'react-redux';
 import { SecureWalletName, trezorReferralURL } from 'config';
 import { getSingleDPath, getPaths } from 'selectors/config/wallet';
+import { NetworkConfig } from 'types/network';
 import './Trezor.scss';
+import { getNetworkConfig } from 'selectors/config';
 
 //todo: conflicts with comment in walletDecrypt -> onUnlock method
 interface OwnProps {
@@ -19,6 +21,7 @@ interface OwnProps {
 interface StateProps {
   dPath: DPath | undefined;
   dPaths: DPath[];
+  network: NetworkConfig;
 }
 
 // todo: nearly duplicates ledger component props
@@ -155,7 +158,8 @@ class TrezorDecryptClass extends PureComponent<Props, State> {
 function mapStateToProps(state: AppState): StateProps {
   return {
     dPath: getSingleDPath(state, SecureWalletName.TREZOR),
-    dPaths: getPaths(state, SecureWalletName.TREZOR)
+    dPaths: getPaths(state, SecureWalletName.TREZOR),
+    network: getNetworkConfig(state)
   };
 }
 

--- a/common/components/WalletDecrypt/components/ViewOnly.tsx
+++ b/common/components/WalletDecrypt/components/ViewOnly.tsx
@@ -2,12 +2,14 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Select, { Option } from 'react-select';
 import translate, { translateRaw } from 'translations';
-import { isValidETHAddress } from 'libs/validators';
+import { isValidAddress } from 'libs/validators';
 import { AddressOnlyWallet } from 'libs/wallet';
 import { getRecentAddresses } from 'selectors/wallet';
 import { AppState } from 'reducers';
 import { Input, Identicon } from 'components/ui';
 import './ViewOnly.scss';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface OwnProps {
   onUnlock(param: any): void;
@@ -15,6 +17,7 @@ interface OwnProps {
 
 interface StateProps {
   recentAddresses: AppState['wallet']['recentAddresses'];
+  network: NetworkConfig;
 }
 
 type Props = OwnProps & StateProps;
@@ -29,14 +32,14 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
   };
 
   public render() {
-    const { recentAddresses } = this.props;
+    const { recentAddresses, network } = this.props;
     const { address } = this.state;
-    const isValid = isValidETHAddress(address);
+    const isValid = isValidAddress(address, network.chainId);
 
     const recentOptions = (recentAddresses.map(addr => ({
       label: (
         <React.Fragment>
-          <Identicon address={addr} />
+          <Identicon address={addr} network={network} />
           {addr}
         </React.Fragment>
       ),
@@ -89,8 +92,9 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
       ev.preventDefault();
     }
 
+    const { network } = this.props;
     const { address } = this.state;
-    if (isValidETHAddress(address)) {
+    if (isValidAddress(address, network.chainId)) {
       const wallet = new AddressOnlyWallet(address);
       this.props.onUnlock(wallet);
     }
@@ -98,5 +102,6 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
 }
 
 export const ViewOnlyDecrypt = connect((state: AppState): StateProps => ({
-  recentAddresses: getRecentAddresses(state)
+  recentAddresses: getRecentAddresses(state),
+  network: getNetworkConfig(state)
 }))(ViewOnlyDecryptClass);

--- a/common/components/ui/Address.tsx
+++ b/common/components/ui/Address.tsx
@@ -1,40 +1,50 @@
 import React from 'react';
-import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 import NewTabLink from './NewTabLink';
 import { IWallet } from 'libs/wallet';
-import { BlockExplorerConfig } from 'types/network';
+import { BlockExplorerConfig, NetworkConfig } from 'types/network';
+import { getNetworkConfig } from 'selectors/config';
+import { AppState } from 'reducers';
+import { connect } from 'react-redux';
 
 interface BaseProps {
   explorer?: BlockExplorerConfig | null;
+  address?: string | null;
+  wallet?: IWallet | null;
 }
 
-interface AddressProps extends BaseProps {
-  address: string;
+interface StateProps {
+  network: NetworkConfig;
 }
 
-interface WalletProps extends BaseProps {
-  wallet: IWallet;
-}
+type Props = BaseProps & StateProps;
 
-type Props = AddressProps | WalletProps;
+// const isAddressProps = (props: Props): props is Props =>
+//   typeof (props as AddressProps).address === 'string';
 
-const isAddressProps = (props: Props): props is AddressProps =>
-  typeof (props as AddressProps).address === 'string';
+export class Address extends React.PureComponent<Props> {
+  public render() {
+    let addr = '';
+    let chainId = 0;
+    if (this.props.address != null) {
+      addr = this.props.address;
+      if (this.props.network) {
+        chainId = this.props.network.chainId;
+      }
+    } else {
+      addr = this.props.wallet != null ? this.props.wallet.getAddressString() : '';
+    }
+    addr = toChecksumAddressByChainId(addr, chainId);
 
-const Address: React.SFC<Props> = props => {
-  let addr = '';
-  if (isAddressProps(props)) {
-    addr = props.address;
-  } else {
-    addr = props.wallet.getAddressString();
+    if (this.props.explorer) {
+      return <NewTabLink href={this.props.explorer.addressUrl(addr)}>{addr}</NewTabLink>;
+    } else {
+      return <React.Fragment>{addr}</React.Fragment>;
+    }
   }
-  addr = toChecksumAddress(addr);
+}
 
-  if (props.explorer) {
-    return <NewTabLink href={props.explorer.addressUrl(addr)}>{addr}</NewTabLink>;
-  } else {
-    return <React.Fragment>{addr}</React.Fragment>;
-  }
-};
-
-export default Address;
+//export default Address;
+export default connect((state: AppState) => ({
+  network: getNetworkConfig(state)
+}))(Address);

--- a/common/components/ui/Identicon.tsx
+++ b/common/components/ui/Identicon.tsx
@@ -1,18 +1,24 @@
-import { isValidETHAddress } from 'libs/validators';
+import { isValidAddress } from 'libs/validators';
 import React from 'react';
 import makeBlockie from 'ethereum-blockies-base64';
+import { NetworkConfig } from 'types/network';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 
 interface Props {
   address: string;
   className?: string;
   size?: string;
+  network: NetworkConfig;
 }
 
 export default function Identicon(props: Props) {
   const size = props.size || '4rem';
-  const { address, className = '' } = props;
+  const { address, className = '', network } = props;
   // FIXME breaks on failed checksums
-  const identiconDataUrl = isValidETHAddress(address) ? makeBlockie(address) : '';
+  const checksummedAddress = toChecksumAddressByChainId(address, network.chainId);
+  const identiconDataUrl = isValidAddress(checksummedAddress, network.chainId)
+    ? makeBlockie(checksummedAddress)
+    : '';
   return (
     // Use inline styles for printable wallets
     <div

--- a/common/config/contracts/rsk.json
+++ b/common/config/contracts/rsk.json
@@ -1,1 +1,7 @@
-[]
+[
+    {
+        "name": "Bridge",
+        "address": "0x0000000000000000000000000000000001000006",
+        "abi": "[{ \"name\": \"getFederationAddress\", \"type\": \"function\", \"constant\": true, \"inputs\": [], \"outputs\": [{ \"name\": \"\", \"type\": \"string\" }] }]"
+    }
+]

--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -78,6 +78,11 @@ export const ETH_SINGULAR: DPath = {
   value: "m/0'/0'/0'"
 };
 
+export const RSK_TESTNET: DPath = {
+  label: 'Testnet (RSK)',
+  value: "m/44'/37310'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -93,7 +98,8 @@ export const DPaths: DPath[] = [
   MUSIC_DEFAULT,
   ETSC_DEFAULT,
   EGEM_DEFAULT,
-  CLO_DEFAULT
+  CLO_DEFAULT,
+  RSK_TESTNET
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/containers/Tabs/CheckTransaction/components/TxHashInput.tsx
+++ b/common/containers/Tabs/CheckTransaction/components/TxHashInput.tsx
@@ -3,11 +3,13 @@ import { connect } from 'react-redux';
 import Select from 'react-select';
 import moment from 'moment';
 import translate from 'translations';
-import { isValidTxHash, isValidETHAddress } from 'libs/validators';
+import { isValidTxHash, isValidAddress } from 'libs/validators';
 import { getRecentNetworkTransactions } from 'selectors/transactions';
 import { AppState } from 'reducers';
 import { Input } from 'components/ui';
 import './TxHashInput.scss';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface OwnProps {
   hash?: string;
@@ -15,6 +17,7 @@ interface OwnProps {
 }
 interface ReduxProps {
   recentTxs: AppState['transactions']['recent'];
+  network: NetworkConfig;
 }
 type Props = OwnProps & ReduxProps;
 
@@ -81,7 +84,7 @@ class TxHashInput extends React.Component<Props, State> {
           onChange={this.handleChange}
         />
 
-        {isValidETHAddress(hash) && (
+        {isValidAddress(hash, this.props.network.chainId) && (
           <p className="TxHashInput-message help-block is-invalid">
             {translate('SELECT_RECENT_TX_BY_TXHASH')}
           </p>
@@ -116,5 +119,6 @@ class TxHashInput extends React.Component<Props, State> {
 }
 
 export default connect((state: AppState): ReduxProps => ({
-  recentTxs: getRecentNetworkTransactions(state)
+  recentTxs: getRecentNetworkTransactions(state),
+  network: getNetworkConfig(state)
 }))(TxHashInput);

--- a/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import translate, { translateRaw } from 'translations';
-import { getNetworkContracts } from 'selectors/config';
+import { getNetworkContracts, getNetworkConfig } from 'selectors/config';
 import { connect } from 'react-redux';
 import { AppState } from 'reducers';
-import { isValidETHAddress, isValidAbiJson } from 'libs/validators';
-import { NetworkContract } from 'types/network';
+import { isValidAddress, isValidAbiJson } from 'libs/validators';
+import { NetworkContract, NetworkConfig } from 'types/network';
 import { donationAddressMap } from 'config';
 import { Input, TextArea, CodeBlock, Dropdown } from 'components/ui';
 import { AddressFieldFactory } from 'components/AddressFieldFactory';
@@ -20,6 +20,7 @@ interface ContractOption {
 interface StateProps {
   currentTo: ReturnType<typeof getCurrentTo>;
   contracts: NetworkContract[];
+  network: NetworkConfig;
 }
 
 interface OwnProps {
@@ -77,8 +78,9 @@ class InteractForm extends Component<Props, State> {
   public render() {
     const { contracts, accessContract, currentTo } = this.props;
     const { abiJson, contract } = this.state;
-    const validEthAddress = isValidETHAddress(
-      currentTo.value ? addHexPrefix(currentTo.value.toString('hex')) : ''
+    const validEthAddress = isValidAddress(
+      currentTo.value ? addHexPrefix(currentTo.value.toString('hex')) : '',
+      this.props.network.chainId
     );
     const validAbiJson = isValidAbiJson(abiJson);
     const showContractAccessButton = validEthAddress && validAbiJson;
@@ -203,7 +205,8 @@ class InteractForm extends Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   contracts: getNetworkContracts(state) || [],
-  currentTo: getCurrentTo(state)
+  currentTo: getCurrentTo(state),
+  network: getNetworkConfig(state)
 });
 
 export default connect(mapStateToProps, { setCurrentTo })(InteractForm);

--- a/common/containers/Tabs/GenerateWallet/components/Keystore/EnterPassword.tsx
+++ b/common/containers/Tabs/GenerateWallet/components/Keystore/EnterPassword.tsx
@@ -6,11 +6,21 @@ import { Spinner } from 'components/ui';
 import Template from '../Template';
 import './EnterPassword.scss';
 import { TogglablePassword } from 'components';
+import { NetworkConfig } from 'types/network';
+import { connect } from 'react-redux';
+import { getNetworkConfig } from 'selectors/config';
+import { AppState } from 'reducers';
 
 interface Props {
   isGenerating: boolean;
-  continue(pw: string): void;
+  continue(pw: string, network: NetworkConfig): void;
 }
+
+interface StateProps {
+  network: NetworkConfig;
+}
+
+type AllProps = Props & StateProps;
 
 interface State {
   password: string;
@@ -18,7 +28,8 @@ interface State {
   passwordValidation: ZXCVBNResult | null;
   feedback: string;
 }
-export default class EnterPassword extends Component<Props, State> {
+
+export default class EnterPassword extends Component<AllProps, State> {
   public state: State = {
     password: '',
     confirmedPassword: '',
@@ -124,7 +135,7 @@ export default class EnterPassword extends Component<Props, State> {
 
   private handleSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
-    this.props.continue(this.state.password);
+    this.props.continue(this.state.password, this.props.network);
   };
 
   private onPasswordChange = (e: React.FormEvent<HTMLInputElement>) => {
@@ -159,3 +170,11 @@ export default class EnterPassword extends Component<Props, State> {
     this.setState({ passwordValidation, feedback });
   };
 }
+
+const mapStateToProps = (state: AppState): StateProps => {
+  return {
+    network: getNetworkConfig(state)
+  };
+};
+
+export const EnterPw = connect(mapStateToProps)(EnterPassword);

--- a/common/containers/Tabs/GenerateWallet/components/Keystore/PaperWallet.tsx
+++ b/common/containers/Tabs/GenerateWallet/components/Keystore/PaperWallet.tsx
@@ -6,10 +6,12 @@ import { stripHexPrefix } from 'libs/values';
 import './PaperWallet.scss';
 import Template from '../Template';
 import { Input } from 'components/ui';
+import { NetworkConfig } from 'types/network';
 
 interface Props {
   keystore: IV3Wallet;
   privateKey: string;
+  network: NetworkConfig;
   continue(): void;
 }
 
@@ -33,7 +35,11 @@ const PaperWallet: React.SFC<Props> = props => (
       {/* Download Paper Wallet */}
       <h2 className="GenPaper-title">{translate('X_PRINT')}</h2>
       <div className="GenPaper-paper">
-        <PrintableWallet address={props.keystore.address} privateKey={props.privateKey} />
+        <PrintableWallet
+          address={props.keystore.address}
+          privateKey={props.privateKey}
+          network={props.network}
+        />
       </div>
 
       {/* Warning */}

--- a/common/containers/Tabs/SendTransaction/components/Fields/Fields.tsx
+++ b/common/containers/Tabs/SendTransaction/components/Fields/Fields.tsx
@@ -21,6 +21,7 @@ import { NonStandardTransaction } from './components';
 import { getOffline, getNetworkConfig } from 'selectors/config';
 import { getCurrentSchedulingToggle, ICurrentSchedulingToggle } from 'selectors/schedule/fields';
 import { getUnit } from 'selectors/transaction';
+import { NetworkConfig } from 'types/network';
 
 const QueryWarning: React.SFC<{}> = () => (
   <WhenQueryExists
@@ -37,11 +38,12 @@ interface StateProps {
   shouldDisplay: boolean;
   offline: boolean;
   useScheduling: ICurrentSchedulingToggle['value'];
+  network: NetworkConfig;
 }
 
 class FieldsClass extends Component<StateProps> {
   public render() {
-    const { shouldDisplay, schedulingAvailable, useScheduling } = this.props;
+    const { shouldDisplay, schedulingAvailable, useScheduling, network } = this.props;
 
     return (
       <OnlyUnlocked
@@ -50,7 +52,7 @@ class FieldsClass extends Component<StateProps> {
             <QueryWarning />
             {shouldDisplay && (
               <div className="Tab-content-pane">
-                <AddressField showLabelMatch={true} />
+                <AddressField showLabelMatch={true} network={network} />
                 <div className="row form-group">
                   <div
                     className={schedulingAvailable ? 'col-sm-9 col-md-10' : 'col-sm-12 col-md-12'}
@@ -107,5 +109,6 @@ export const Fields = connect((state: AppState) => ({
   schedulingAvailable: getNetworkConfig(state).name === 'Kovan' && getUnit(state) === 'ETH',
   shouldDisplay: !isAnyOfflineWithWeb3(state),
   offline: getOffline(state),
-  useScheduling: getCurrentSchedulingToggle(state).value
+  useScheduling: getCurrentSchedulingToggle(state).value,
+  network: getNetworkConfig(state)
 }))(FieldsClass);

--- a/common/containers/Tabs/SendTransaction/components/RecentTransaction.tsx
+++ b/common/containers/Tabs/SendTransaction/components/RecentTransaction.tsx
@@ -19,7 +19,7 @@ export default class RecentTransaction extends React.Component<Props> {
     return (
       <tr className="RecentTx" key={tx.time} onClick={this.handleClick}>
         <td className="RecentTx-to">
-          <Identicon address={tx.to} />
+          <Identicon address={tx.to} network={network} />
           <Address address={tx.to} />
         </td>
         <td className="RecentTx-value">

--- a/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
+++ b/common/containers/Tabs/SendTransaction/components/RequestPayment.tsx
@@ -99,7 +99,7 @@ class RequestPayment extends React.Component<Props, {}> {
     return (
       <div className="RequestPayment">
         <div className="Tab-content-pane">
-          <AddressField isReadOnly={true} isCheckSummed={true} />
+          <AddressField isReadOnly={true} isCheckSummed={true} network={networkConfig} />
 
           <div className="row form-group">
             <div className="col-xs-12">

--- a/common/containers/Tabs/Swap/components/LiteSend/Fields.tsx
+++ b/common/containers/Tabs/Swap/components/LiteSend/Fields.tsx
@@ -11,11 +11,14 @@ import { getCurrentBalance } from 'selectors/wallet';
 import Spinner from 'components/ui/Spinner';
 import { Wei, TokenValue } from 'libs/units';
 import { Input } from 'components/ui';
+import { getNetworkConfig } from 'selectors/config';
+import { NetworkConfig } from 'types/network';
 
 interface StateProps {
   unit: string;
   resetWallet: TResetWallet;
   currentBalance: Wei | TokenValue | null;
+  network: NetworkConfig;
 }
 
 type Props = StateProps;
@@ -103,6 +106,10 @@ class FieldsClass extends Component<Props> {
 }
 
 export const Fields = connect(
-  (state: AppState) => ({ unit: getUnit(state), currentBalance: getCurrentBalance(state) }),
+  (state: AppState) => ({
+    unit: getUnit(state),
+    currentBalance: getCurrentBalance(state),
+    network: getNetworkConfig(state)
+  }),
   { resetWallet }
 )(FieldsClass);

--- a/common/libs/checksum.ts
+++ b/common/libs/checksum.ts
@@ -1,0 +1,10 @@
+import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddress as toChecksumAddressRSK } from 'rskjs-util';
+
+export function toChecksumAddressByChainId(address: string, chainId: number) {
+  if (chainId === 30 || chainId === 31) {
+    //Passing chainId = null solves it using ethereumjs-util, to be considered...
+    return toChecksumAddressRSK(address, chainId);
+  }
+  return toChecksumAddress(address);
+}

--- a/common/libs/contracts/ABIFunction.ts
+++ b/common/libs/contracts/ABIFunction.ts
@@ -1,5 +1,5 @@
 import abi from 'ethereumjs-abi';
-import { toChecksumAddress, addHexPrefix, stripHexPrefix } from 'ethereumjs-util';
+import { addHexPrefix, stripHexPrefix } from 'ethereumjs-util';
 import BN from 'bn.js';
 import {
   FuncParams,
@@ -9,6 +9,7 @@ import {
   ITypeMapping,
   ISuppliedArgs
 } from './types';
+import { toChecksumAddressByChainId } from '../checksum';
 
 export default class AbiFunction {
   public constant: boolean;
@@ -33,7 +34,7 @@ export default class AbiFunction {
     return encodedCall;
   };
 
-  public decodeInput = (argString: string) => {
+  public decodeInput = (argString: string, chainId: number) => {
     // Remove method selector from data, if present
     argString = argString.replace(addHexPrefix(this.methodSelector), '');
     // Convert argdata to a hex buffer for ethereumjs-abi
@@ -46,12 +47,12 @@ export default class AbiFunction {
       const currType = this.inputTypes[index];
       return {
         ...argObj,
-        [currName]: this.parsePostDecodedValue(currType, currArg)
+        [currName]: this.parsePostDecodedValue(currType, currArg, chainId)
       };
     }, {});
   };
 
-  public decodeOutput = (argString: string) => {
+  public decodeOutput = (argString: string, chainId: number) => {
     // Remove method selector from data, if present
     argString = argString.replace(addHexPrefix(this.methodSelector), '');
 
@@ -69,7 +70,7 @@ export default class AbiFunction {
       const currType = this.outputTypes[index];
       return {
         ...argObj,
-        [currName]: this.parsePostDecodedValue(currType, currArg)
+        [currName]: this.parsePostDecodedValue(currType, currArg, chainId)
       };
     }, {});
   };
@@ -85,9 +86,9 @@ export default class AbiFunction {
     this.methodSelector = abi.methodID(this.name, this.inputTypes).toString('hex');
   }
 
-  private parsePostDecodedValue = (type: string, value: any) => {
+  private parsePostDecodedValue = (type: string, value: any, chainId: number) => {
     const valueMapping: ITypeMapping = {
-      address: (val: any) => toChecksumAddress(val.toString(16))
+      address: (val: any) => toChecksumAddressByChainId(val.toString(16), chainId)
     };
 
     const mapppedType = valueMapping[type];

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -104,6 +104,7 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       url: 'https://node.expanse.tech/'
     }
   ],
+
   POA: [
     {
       name: makeNodeName('POA', 'core'),
@@ -164,6 +165,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       type: 'rpc',
       service: '0xinfra.com',
       url: 'https://clo-geth.0xinfra.com/'
+    }
+  ],
+
+  RSK_TESTNET: [
+    {
+      name: makeNodeName('RSK_TESTNET', 'rsk_testnet'),
+      type: 'rpc',
+      service: 'mycrypto.testnet.rsk.co',
+      url: 'https://mycrypto.testnet.rsk.co/'
     }
   ]
 };

--- a/common/libs/transaction/utils/ether.ts
+++ b/common/libs/transaction/utils/ether.ts
@@ -1,7 +1,7 @@
 import Tx from 'ethereumjs-tx';
 import { bufferToHex } from 'ethereumjs-util';
 import { Wei } from 'libs/units';
-import { isValidETHAddress } from 'libs/validators';
+import { isValidAddress } from 'libs/validators';
 import { IFullWallet } from 'libs/wallet';
 import { translateRaw } from 'translations';
 import { ITransaction, IHexStrTransaction } from '../typings';
@@ -68,8 +68,8 @@ const gasParamsInRange = (t: ITransaction) => {
   }
 };
 
-const validAddress = (t: ITransaction) => {
-  if (!isValidETHAddress(bufferToHex(t.to))) {
+const validAddress = (t: ITransaction, chainId: number) => {
+  if (!isValidAddress(bufferToHex(t.to), chainId)) {
     throw Error(translateRaw('ERROR_5'));
   }
 };
@@ -91,7 +91,7 @@ const signTx = async (t: ITransaction, w: IFullWallet) => {
   return signedTx; //instead of returning the rawTx with it, we can derive it from the signedTx anyway
 };
 
-const validateTx = (t: ITransaction, accountBalance: Wei, isOffline: boolean) => {
+const validateTx = (t: ITransaction, accountBalance: Wei, isOffline: boolean, chainId: number) => {
   gasParamsInRange(t);
   if (!isOffline && !validGasLimit(t)) {
     throw Error('Not enough gas supplied');
@@ -99,7 +99,7 @@ const validateTx = (t: ITransaction, accountBalance: Wei, isOffline: boolean) =>
   if (!enoughBalanceViaTx(t, accountBalance)) {
     throw Error(translateRaw('GETH_BALANCE'));
   }
-  validAddress(t);
+  validAddress(t, chainId);
 };
 
 export {

--- a/common/libs/transaction/utils/index.ts
+++ b/common/libs/transaction/utils/index.ts
@@ -7,9 +7,10 @@ export const signTransaction = async (
   t: ITransaction,
   w: IFullWallet,
   accountBalance: Wei,
-  isOffline: boolean
+  isOffline: boolean,
+  chainId: number
 ) => {
-  eth.validateTx(t, accountBalance, isOffline);
+  eth.validateTx(t, accountBalance, isOffline, chainId);
   const signedT = await eth.signTx(t, w);
   return signedT;
 };

--- a/common/libs/wallet/non-deterministic/web3.ts
+++ b/common/libs/wallet/non-deterministic/web3.ts
@@ -1,6 +1,7 @@
 import { getTransactionFields, makeTransaction } from 'libs/transaction';
 import { IFullWallet } from '../IWallet';
-import { bufferToHex, toChecksumAddress } from 'ethereumjs-util';
+import { bufferToHex } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 import { configuredStore } from 'store';
 import { getNodeLib, getNetworkByChainId } from 'selectors/config';
 import Web3Node from 'libs/nodes/web3';
@@ -9,14 +10,16 @@ import { INode } from 'libs/nodes/INode';
 export default class Web3Wallet implements IFullWallet {
   private address: string;
   private network: string;
+  private chainId: number;
 
-  constructor(address: string, network: string) {
+  constructor(address: string, network: string, chainId: number) {
     this.address = address;
     this.network = network;
+    this.chainId = chainId;
   }
 
   public getAddressString(): string {
-    return toChecksumAddress(this.address);
+    return toChecksumAddressByChainId(this.address, this.chainId);
   }
 
   public signRawTransaction(): Promise<Buffer> {

--- a/common/libs/web-workers/generateKeystore.ts
+++ b/common/libs/web-workers/generateKeystore.ts
@@ -1,5 +1,4 @@
 import { IV3Wallet } from 'ethereumjs-wallet';
-import { N_FACTOR } from 'config';
 import Worker from 'worker-loader!./workers/generateKeystore.worker.ts';
 
 interface KeystorePayload {
@@ -8,7 +7,10 @@ interface KeystorePayload {
   privateKey: string;
 }
 
-export default function generateKeystore(password: string): Promise<KeystorePayload> {
+export default function generateKeystore(
+  password: string,
+  N_FACTOR: number
+): Promise<KeystorePayload> {
   return new Promise(resolve => {
     const worker = new Worker();
     worker.postMessage({ password, N_FACTOR });

--- a/common/reducers/addressBook.ts
+++ b/common/reducers/addressBook.ts
@@ -1,4 +1,4 @@
-import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 import { TypeKeys, AddressBookAction, AddressLabelEntry } from 'actions/addressBook';
 
 export interface State {
@@ -23,8 +23,8 @@ export function addressBook(state: State = INITIAL_STATE, action: AddressBookAct
   switch (action.type) {
     case TypeKeys.SET_ADDRESS_LABEL: {
       const { addresses, labels } = state;
-      const { address, label } = action.payload;
-      const checksummedAddress = toChecksumAddress(address);
+      const { address, label, chainId } = action.payload;
+      const checksummedAddress = toChecksumAddressByChainId(address, chainId);
       const updatedAddresses = {
         ...addresses,
         [checksummedAddress]: label
@@ -43,12 +43,12 @@ export function addressBook(state: State = INITIAL_STATE, action: AddressBookAct
 
     case TypeKeys.CLEAR_ADDRESS_LABEL: {
       const { addresses, labels } = state;
-      const address = action.payload;
+      const { address, chainId } = action.payload;
       const label = addresses[address];
       const updatedAddresses = { ...addresses };
       const updatedLabels = { ...labels };
 
-      delete updatedAddresses[toChecksumAddress(address)];
+      delete updatedAddresses[toChecksumAddressByChainId(address, chainId)];
       delete updatedLabels[label];
 
       return {
@@ -59,8 +59,8 @@ export function addressBook(state: State = INITIAL_STATE, action: AddressBookAct
     }
 
     case TypeKeys.SET_ADDRESS_LABEL_ENTRY: {
-      const { id, address } = action.payload;
-      const checksummedAddress = toChecksumAddress(address);
+      const { id, address, chainId } = action.payload;
+      const checksummedAddress = toChecksumAddressByChainId(address, chainId);
       const isNonRowEntry = id === 'ADDRESS_BOOK_TABLE_ID' || id === 'ACCOUNT_ADDRESS_ID';
 
       return {
@@ -79,7 +79,7 @@ export function addressBook(state: State = INITIAL_STATE, action: AddressBookAct
       const id = action.payload;
       const entries = { ...state.entries };
 
-      delete entries[id];
+      delete entries[id.label];
 
       return {
         ...state,

--- a/common/reducers/config/networks/staticNetworks.ts
+++ b/common/reducers/config/networks/staticNetworks.ts
@@ -20,7 +20,8 @@ import {
   MUSIC_DEFAULT,
   ETSC_DEFAULT,
   EGEM_DEFAULT,
-  CLO_DEFAULT
+  CLO_DEFAULT,
+  RSK_TESTNET
 } from 'config/dpaths';
 import { ConfigAction } from 'actions/config';
 import { makeExplorer } from 'utils/helpers';
@@ -363,6 +364,32 @@ export const INITIAL_STATE: State = {
       min: 1,
       max: 60,
       initial: 20
+    }
+  },
+
+  RSK_TESTNET: {
+    id: 'RSK_TESTNET',
+    name: 'RSK',
+    unit: 'SBTC',
+    chainId: 31,
+    color: '#58A052',
+    isCustom: false,
+    blockExplorer: makeExplorer({
+      name: 'RSK Testnet Explorer',
+      origin: 'https://explorer.testnet.rsk.co'
+    }),
+    tokens: require('config/tokens/rsk.json'),
+    contracts: require('config/contracts/rsk.json'),
+    isTestnet: true,
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: RSK_TESTNET,
+      [SecureWalletName.LEDGER_NANO_S]: RSK_TESTNET,
+      [InsecureWalletName.MNEMONIC_PHRASE]: RSK_TESTNET
+    },
+    gasPriceSettings: {
+      min: 0.183,
+      max: 1.5,
+      initial: 0.183
     }
   }
 };

--- a/common/sagas/config/web3.ts
+++ b/common/sagas/config/web3.ts
@@ -93,7 +93,7 @@ export function* unlockWeb3(): SagaIterator {
     if (!address) {
       throw new Error('No accounts found in MetaMask / Mist.');
     }
-    const wallet = new Web3Wallet(address, stripWeb3Network(network));
+    const wallet = new Web3Wallet(address, stripWeb3Network(network), network.chainId);
     yield put(setWallet(wallet));
   } catch (err) {
     console.error(err);

--- a/common/sagas/deterministicWallets.ts
+++ b/common/sagas/deterministicWallets.ts
@@ -5,7 +5,7 @@ import {
   updateDeterministicWallet
 } from 'actions/deterministicWallets';
 import { showNotification } from 'actions/notifications';
-import { publicToAddress, toChecksumAddress } from 'ethereumjs-util';
+import { publicToAddress } from 'ethereumjs-util';
 import HDKey from 'hdkey';
 import { INode } from 'libs/nodes/INode';
 import { SagaIterator } from 'redux-saga';
@@ -16,9 +16,10 @@ import { getTokens } from 'selectors/wallet';
 import translate from 'translations';
 import { TokenValue } from 'libs/units';
 import { Token } from 'types/network';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 
 export function* getDeterministicWallets(action: GetDeterministicWalletsAction): SagaIterator {
-  const { seed, dPath, publicKey, chainCode, limit, offset } = action.payload;
+  const { seed, dPath, publicKey, chainCode, limit, offset, chainId } = action.payload;
   let pathBase;
   let hdk;
 
@@ -43,7 +44,7 @@ export function* getDeterministicWallets(action: GetDeterministicWalletsAction):
     const address = publicToAddress(dkey.publicKey, true).toString('hex');
     wallets.push({
       index,
-      address: toChecksumAddress(address),
+      address: toChecksumAddressByChainId(address, chainId),
       tokenValues: {}
     });
   }

--- a/common/sagas/transaction/current/currentTo.ts
+++ b/common/sagas/transaction/current/currentTo.ts
@@ -5,14 +5,17 @@ import { setTokenTo } from 'actions/transaction/actionCreators/meta';
 import { Address } from 'libs/units';
 import { select, call, put, takeLatest, take } from 'redux-saga/effects';
 import { SagaIterator } from 'redux-saga';
-import { isValidENSAddress, isValidETHAddress } from 'libs/validators';
+import { isValidENSAddress, isValidAddress } from 'libs/validators';
 import { TypeKeys } from 'actions/transaction/constants';
 import { getResolvedAddress } from 'selectors/ens';
 import { resolveDomainRequested, TypeKeys as ENSTypekeys } from 'actions/ens';
 import { SetToFieldAction, SetTokenToMetaAction } from 'actions/transaction';
+import { NetworkConfig } from 'shared/types/network';
+import { getNetworkConfig } from 'selectors/config';
 
 export function* setCurrentTo({ payload: raw }: SetCurrentToAction): SagaIterator {
-  const validAddress: boolean = yield call(isValidETHAddress, raw);
+  const network: NetworkConfig = yield select(getNetworkConfig);
+  const validAddress: boolean = yield call(isValidAddress, raw, network ? network.chainId : 0);
   const validEns: boolean = yield call(isValidENSAddress, raw);
 
   let value: Buffer | null = null;

--- a/common/sagas/transactions.ts
+++ b/common/sagas/transactions.ts
@@ -1,7 +1,6 @@
 import { SagaIterator } from 'redux-saga';
 import { put, select, apply, call, take, takeEvery } from 'redux-saga/effects';
 import EthTx from 'ethereumjs-tx';
-import { toChecksumAddress } from 'ethereumjs-util';
 import {
   setTransactionData,
   FetchTransactionDataAction,
@@ -24,6 +23,7 @@ import { TypeKeys as ConfigTypeKeys } from 'actions/config';
 import { TransactionData, TransactionReceipt, SavedTransaction } from 'types/transactions';
 import { NetworkConfig } from 'types/network';
 import { AppState } from 'reducers';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 
 export function* fetchTxData(action: FetchTransactionDataAction): SagaIterator {
   const txhash = action.payload;
@@ -103,7 +103,7 @@ export function* getSaveableTransaction(tx: EthTx, hash: string): SagaIterator {
     hash,
     from,
     chainId,
-    to: toChecksumAddress(fields.to),
+    to: toChecksumAddressByChainId(fields.to, fields.chainId),
     value: fields.value,
     time: Date.now()
   };

--- a/common/selectors/addressBook.ts
+++ b/common/selectors/addressBook.ts
@@ -1,9 +1,10 @@
-import { toChecksumAddress } from 'ethereumjs-util';
 import { AppState } from 'reducers';
 import { ADDRESS_BOOK_TABLE_ID } from 'components/AddressBookTable';
 import { ACCOUNT_ADDRESS_ID } from 'components/BalanceSidebar/AccountAddress';
 import { AddressLabelEntry } from 'actions/addressBook';
 import { getCurrentTo } from './transaction';
+import { toChecksumAddressByChainId } from 'libs/checksum';
+import { getNetworkConfig } from 'selectors/config';
 
 export function getAddressLabels(state: AppState) {
   return state.addressBook.addresses;
@@ -31,8 +32,10 @@ export function getAccountAddressEntry(state: AppState) {
 
 export function getAddressLabelEntryFromAddress(state: AppState, address: string) {
   const rows = getAddressLabelRows(state);
+  const network = getNetworkConfig(state);
   const entry = rows.find(
-    (iteratedEntry: AddressLabelEntry) => iteratedEntry.address === toChecksumAddress(address)
+    (iteratedEntry: AddressLabelEntry) =>
+      iteratedEntry.address === toChecksumAddressByChainId(address, network.chainId)
   );
 
   return entry;

--- a/common/selectors/transaction/meta.ts
+++ b/common/selectors/transaction/meta.ts
@@ -9,7 +9,7 @@ import { getCustomTokens } from 'selectors/customTokens';
 import { getNetworkConfig } from 'selectors/config';
 import { Token } from '../../../shared/types/network';
 import { stripHexPrefixAndLower } from 'libs/values';
-import { toChecksumAddress } from 'ethereumjs-util';
+import { toChecksumAddressByChainId } from 'libs/checksum';
 
 const getMetaState = (state: AppState) => getTransactionState(state).meta;
 const getFrom = (state: AppState) => {
@@ -20,7 +20,8 @@ const getFrom = (state: AppState) => {
     try {
       const from = transactionInstance.from;
       if (from) {
-        return toChecksumAddress(from.toString('hex'));
+        const networkConfig = getNetworkConfig(state);
+        return toChecksumAddressByChainId(from.toString('hex'), networkConfig.chainId);
       }
     } catch (e) {
       console.warn(e);
@@ -52,7 +53,10 @@ const getUnit = (state: AppState) => {
         networkTokens = networkConfig.tokens;
       }
       const mergedTokens = networkTokens ? [...networkTokens, ...customTokens] : customTokens;
-      const stringTo = toChecksumAddress(stripHexPrefixAndLower(to.toString('hex')));
+      const stringTo = toChecksumAddressByChainId(
+        stripHexPrefixAndLower(to.toString('hex')),
+        networkConfig.chainId
+      );
       const result = mergedTokens.find(t => t.address === stringTo);
       if (result) {
         return result.symbol;

--- a/common/selectors/wallet.ts
+++ b/common/selectors/wallet.ts
@@ -194,6 +194,10 @@ export function getDisabledWallets(state: AppState): DisabledWallets {
     addReason([SecureWalletName.WEB3], 'This wallet is not supported in the MyCrypto app');
   }
 
+  if (network.chainId === 30 || network.chainId === 31) {
+    addReason([SecureWalletName.PARITY_SIGNER], 'This wallet is not supported by RSK yet');
+  }
+
   // Dedupe and sort for consistency
   disabledWallets.wallets = disabledWallets.wallets
     .filter((name, idx) => disabledWallets.wallets.indexOf(name) === idx)

--- a/common/typescript/rskjs-util.d.ts
+++ b/common/typescript/rskjs-util.d.ts
@@ -1,0 +1,19 @@
+declare module 'rskjs-util' {
+  /**
+   *
+   * @description Returns a checksummed address
+   * @export
+   * @param {string} address
+   * @returns {string}
+   */
+  export function toChecksumAddress(address: string, chainId: number): string;
+
+  /**
+   *
+   * @description Checks if the address is a valid checksummed address
+   * @export
+   * @param {string} address
+   * @returns {boolean}
+   */
+  export function isValidChecksumAddress(address: string, chainId: number): boolean;
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "redux": "3.7.2",
     "redux-logger": "3.0.6",
     "redux-saga": "0.16.0",
+    "rskjs-util": "1.0.3",
     "scryptsy": "2.0.0",
     "semver": "5.5.0",
     "uuid": "3.2.1",

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -14,7 +14,8 @@ type StaticNetworkIds =
   | 'MUSIC'
   | 'ETSC'
   | 'EGEM'
-  | 'CLO';
+  | 'CLO'
+  | 'RSK_TESTNET';
 
 export interface BlockExplorerConfig {
   name: string;

--- a/spec/actions/addressBook.spec.ts
+++ b/spec/actions/addressBook.spec.ts
@@ -14,7 +14,8 @@ describe('addressBook: Actions', () => {
     it('should generate the correct action', () => {
       const payload = {
         address: '0x0',
-        label: 'Foo'
+        label: 'Foo',
+        chainId: 1
       };
 
       expect(setAddressLabel(payload)).toEqual({
@@ -25,7 +26,7 @@ describe('addressBook: Actions', () => {
   });
   describe('clearAddressLabel', () => {
     it('should generate the correct action', () => {
-      const payload = '0';
+      const payload = { label: '0', address: '', chainId: 1 };
 
       expect(clearAddressLabel(payload)).toEqual({
         type: TypeKeys.CLEAR_ADDRESS_LABEL,
@@ -40,7 +41,8 @@ describe('addressBook: Actions', () => {
         address: '0x0',
         addressError: 'Derp',
         label: 'Foo',
-        labelError: 'Derp'
+        labelError: 'Derp',
+        chainId: 1
       };
 
       expect(setAddressLabelEntry(payload)).toEqual({
@@ -56,7 +58,8 @@ describe('addressBook: Actions', () => {
         address: '0x0',
         addressError: 'Derp',
         label: 'Foo',
-        labelError: 'Derp'
+        labelError: 'Derp',
+        chainId: 1
       };
 
       expect(changeAddressLabelEntry(payload)).toEqual({
@@ -77,7 +80,7 @@ describe('addressBook: Actions', () => {
   });
   describe('clearAddressLabelEntry', () => {
     it('should generate the correct action', () => {
-      const payload = '0';
+      const payload = { label: '0', address: '', chainId: 1 };
 
       expect(clearAddressLabelEntry(payload)).toEqual({
         type: TypeKeys.CLEAR_ADDRESS_LABEL_ENTRY,

--- a/spec/libs/checksum.spec.ts
+++ b/spec/libs/checksum.spec.ts
@@ -1,0 +1,20 @@
+import { toChecksumAddressByChainId } from '../../common/libs/checksum';
+
+const VALID_NON_CHECKSUMED_ADDRESS = '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed';
+const VALID_ETH_ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+const VALID_RSK_TESTNET_ADDRESS = '0x5aAeb6053F3e94c9b9A09F33669435E7EF1BEaEd';
+const RSK_TESTNET_CHAIN_ID = 31;
+const ETH_CHAIN_ID = 1;
+
+describe('Checksum', () => {
+  it('should validate correct ETH checksumed address as true', () => {
+    expect(toChecksumAddressByChainId(VALID_NON_CHECKSUMED_ADDRESS, ETH_CHAIN_ID)).toEqual(
+      VALID_ETH_ADDRESS
+    );
+  });
+  it('should validate correct RSK checksumed testnet address as true', () => {
+    expect(toChecksumAddressByChainId(VALID_NON_CHECKSUMED_ADDRESS, RSK_TESTNET_CHAIN_ID)).toEqual(
+      VALID_RSK_TESTNET_ADDRESS
+    );
+  });
+});

--- a/spec/reducers/addressBook.spec.ts
+++ b/spec/reducers/addressBook.spec.ts
@@ -8,7 +8,8 @@ describe('addressBook: Reducer', () => {
         undefined,
         addressBookActions.setAddressLabel({
           address: '0x0',
-          label: 'Foo'
+          label: 'Foo',
+          chainId: 1
         })
       )
     ).toEqual({
@@ -26,13 +27,17 @@ describe('addressBook: Reducer', () => {
       undefined,
       addressBookActions.setAddressLabel({
         address: '0x0',
-        label: 'Foo'
+        label: 'Foo',
+        chainId: 1
       })
     );
 
-    expect(addressBook(firstState, addressBookActions.clearAddressLabel('0x0'))).toEqual(
-      INITIAL_STATE
-    );
+    expect(
+      addressBook(
+        firstState,
+        addressBookActions.clearAddressLabel({ address: '0x0', label: '', chainId: 1 })
+      )
+    ).toEqual(INITIAL_STATE);
   });
   it('should set an address label entry', () => {
     expect(
@@ -45,7 +50,8 @@ describe('addressBook: Reducer', () => {
           addressError: 'Derp',
           label: 'Foo',
           temporaryLabel: 'Food',
-          labelError: 'Derp'
+          labelError: 'Derp',
+          chainId: 1
         })
       )
     ).toEqual({
@@ -58,7 +64,8 @@ describe('addressBook: Reducer', () => {
           addressError: 'Derp',
           label: 'Foo',
           temporaryLabel: 'Food',
-          labelError: 'Derp'
+          labelError: 'Derp',
+          chainId: 1
         }
       }
     });
@@ -73,11 +80,15 @@ describe('addressBook: Reducer', () => {
         addressError: 'Derp',
         label: 'Foo',
         temporaryLabel: 'Food',
-        labelError: 'Derp'
+        labelError: 'Derp',
+        chainId: 1
       })
     );
-    expect(addressBook(firstState, addressBookActions.clearAddressLabelEntry('0'))).toEqual(
-      INITIAL_STATE
-    );
+    expect(
+      addressBook(
+        firstState,
+        addressBookActions.clearAddressLabelEntry({ label: '0', address: '', chainId: 1 })
+      )
+    ).toEqual(INITIAL_STATE);
   });
 });

--- a/spec/reducers/config/__snapshots__/config.spec.ts.snap
+++ b/spec/reducers/config/__snapshots__/config.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ELLA",
+      "RSK_TESTNET",
     ],
     "selector": [Function],
   },

--- a/spec/reducers/config/config.spec.ts
+++ b/spec/reducers/config/config.spec.ts
@@ -333,7 +333,8 @@ describe('unsetWeb3NodeOnWalletEvent*', () => {
   it('should return early if wallet type is web3', () => {
     const mockAddress = '0x0';
     const mockNetwork = 'ETH';
-    const mockWeb3Wallet = new Web3Wallet(mockAddress, mockNetwork);
+    const chainId = 1;
+    const mockWeb3Wallet = new Web3Wallet(mockAddress, mockNetwork, chainId);
     const gen2 = unsetWeb3NodeOnWalletEvent({ payload: mockWeb3Wallet } as any);
     gen2.next(); //getNode
     gen2.next('web3'); //getNodeConfig

--- a/spec/sagas/addressBook.spec.ts
+++ b/spec/sagas/addressBook.spec.ts
@@ -13,7 +13,8 @@ import {
   changeAddressLabelEntry,
   saveAddressLabelEntry,
   clearAddressLabelEntry,
-  removeAddressLabelEntry
+  removeAddressLabelEntry,
+  AddressLabel
 } from 'actions/addressBook';
 import { getInitialState } from '../selectors/helpers';
 
@@ -31,13 +32,15 @@ describe('addressBook: Sagas', () => {
   const id = '0';
   const address = '0x081f37708032d0a7b3622591a8959b213fb47d6f';
   const label = 'Foo';
+  const chainId = 1;
 
   describe('handleChangeAddressLabelEntry', () => {
     it('should successfully change an address label entry with no errors', async () => {
       const action = changeAddressLabelEntry({
         id,
         address,
-        label
+        label,
+        chainId
       });
       const dispatched: string[] = [];
 
@@ -58,7 +61,8 @@ describe('addressBook: Sagas', () => {
           addressError: undefined,
           label,
           temporaryLabel: label,
-          labelError: undefined
+          labelError: undefined,
+          chainId
         })
       ]);
     });
@@ -66,7 +70,8 @@ describe('addressBook: Sagas', () => {
       const action = changeAddressLabelEntry({
         id,
         address: '0', // Invalid ETH address
-        label
+        label,
+        chainId
       });
       const dispatched: string[] = [];
 
@@ -87,7 +92,8 @@ describe('addressBook: Sagas', () => {
           addressError: translateRaw('INVALID_ADDRESS'),
           label,
           temporaryLabel: label,
-          labelError: undefined
+          labelError: undefined,
+          chainId
         })
       ]);
     });
@@ -95,7 +101,8 @@ describe('addressBook: Sagas', () => {
       const action = changeAddressLabelEntry({
         id,
         address,
-        label: 'F' // Invalid label length
+        label: 'F', // Invalid label length
+        chainId
       });
       const dispatched: string[] = [];
 
@@ -116,7 +123,8 @@ describe('addressBook: Sagas', () => {
           addressError: undefined,
           label: '',
           temporaryLabel: 'F',
-          labelError: translateRaw('INVALID_LABEL_LENGTH')
+          labelError: translateRaw('INVALID_LABEL_LENGTH'),
+          chainId
         })
       ]);
     });
@@ -183,10 +191,11 @@ describe('addressBook: Sagas', () => {
       );
 
       expect(dispatched).toEqual([
-        clearAddressLabel(address),
+        clearAddressLabel({ address, label, chainId }),
         setAddressLabel({
           address,
-          label
+          label,
+          chainId
         }),
         setAddressLabelEntry({
           id: '1',
@@ -195,7 +204,8 @@ describe('addressBook: Sagas', () => {
           addressError: undefined,
           label,
           temporaryLabel: label,
-          labelError: undefined
+          labelError: undefined,
+          chainId
         }),
         setAddressLabelEntry({
           id: ADDRESS_BOOK_TABLE_ID,
@@ -204,7 +214,8 @@ describe('addressBook: Sagas', () => {
           addressError: undefined,
           label: '',
           temporaryLabel: '',
-          labelError: undefined
+          labelError: undefined,
+          chainId
         })
       ]);
     });
@@ -237,10 +248,11 @@ describe('addressBook: Sagas', () => {
       );
 
       expect(dispatched).toEqual([
-        clearAddressLabel(address),
+        clearAddressLabel({ address, label, chainId }),
         setAddressLabel({
           address,
-          label
+          label,
+          chainId
         }),
         setAddressLabelEntry({
           id,
@@ -249,7 +261,8 @@ describe('addressBook: Sagas', () => {
           addressError: undefined,
           label: 'Foo',
           temporaryLabel: 'Foo',
-          labelError: undefined
+          labelError: undefined,
+          chainId
         })
       ]);
     });
@@ -289,24 +302,28 @@ describe('addressBook: Sagas', () => {
               addressError: undefined,
               label,
               temporaryLabel: label,
-              labelError: undefined
+              labelError: undefined,
+              chainId: 1
             }
           }
         }
       };
       const action = removeAddressLabelEntry(id);
-      const dispatched: string[] = [];
+      const dispatched: AddressLabel[] = [];
 
       await runSaga(
         {
-          dispatch: (dispatching: string) => dispatched.push(dispatching),
+          dispatch: (dispatching: AddressLabel) => dispatched.push(dispatching),
           getState: () => state
         },
         handleRemoveAddressLabelEntry,
         action
       );
 
-      expect(dispatched).toEqual([clearAddressLabel(address), clearAddressLabelEntry(id)]);
+      expect(dispatched).toEqual([
+        clearAddressLabel({ address, label: '0', chainId }),
+        clearAddressLabelEntry({ address, label: id, chainId: 1 })
+      ]);
     });
   });
 });

--- a/spec/sagas/deterministicWallets.spec.ts
+++ b/spec/sagas/deterministicWallets.spec.ts
@@ -49,7 +49,8 @@ describe('getDeterministicWallets*', () => {
     const dWallet = {
       seed:
         '1ba4b713b9cf6f91e8e2eea015fc4e107452fa7d8ade32322207967371e5c0fb93289d4dde94ce13625ecc60279d211b6d677c67f54b9e97c7e68afc9ca1b5ea',
-      dPath: "m/44'/60'/0'/0"
+      dPath: "m/44'/60'/0'/0",
+      chainId: 1
     };
     const action = dWalletActions.getDeterministicWallets(dWallet);
     const gen = getDeterministicWallets(action);
@@ -73,7 +74,8 @@ describe('getDeterministicWallets*', () => {
       publicKey: '02fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f',
       chainCode: '180c998615636cd875aa70c71cfa6b7bf570187a56d8c6d054e60b644d13e9d3',
       limit: 10,
-      offset: 0
+      offset: 0,
+      chainId: 1
     };
 
     const action = dWalletActions.getDeterministicWallets(dWallet);

--- a/spec/sagas/transaction/broadcast/broadcast.spec.ts
+++ b/spec/sagas/transaction/broadcast/broadcast.spec.ts
@@ -40,7 +40,7 @@ describe('broadcastLocalTransactionHandler*', () => {
 
 describe('broadcastWeb3TransactionHandler*', () => {
   const tx = 'tx';
-  const web3Wallet = new Web3Wallet('', '');
+  const web3Wallet = new Web3Wallet('', '', 1);
   const notWeb3Wallet = false;
   const txHash = 'txHash';
 

--- a/spec/sagas/transaction/current/currentTo.spec.ts
+++ b/spec/sagas/transaction/current/currentTo.spec.ts
@@ -1,12 +1,13 @@
 import { getResolvedAddress } from 'selectors/ens';
 import { Address } from 'libs/units';
 import { call, select, put, take } from 'redux-saga/effects';
-import { isValidETHAddress, isValidENSAddress } from 'libs/validators';
+import { isValidAddress, isValidENSAddress } from 'libs/validators';
 import { setCurrentTo, setField } from 'sagas/transaction/current/currentTo';
 import { isEtherTransaction } from 'selectors/transaction';
 import { cloneableGenerator } from 'redux-saga/utils';
 import { setToField, setTokenTo } from 'actions/transaction';
 import { resolveDomainRequested, TypeKeys as ENSTypekeys } from 'actions/ens';
+import { getNetworkConfig } from 'selectors/config';
 
 describe('setCurrentTo*', () => {
   const data = {} as any;
@@ -22,8 +23,12 @@ describe('setCurrentTo*', () => {
     };
 
     data.validEthGen = setCurrentTo(ethAddrAction);
+
+    it('should select getNetworkConfig', () => {
+      expect(data.validEthGen.next().value).toEqual(select(getNetworkConfig));
+    });
     it('should call isValidETHAddress', () => {
-      expect(data.validEthGen.next().value).toEqual(call(isValidETHAddress, raw));
+      expect(data.validEthGen.next().value).toEqual(call(isValidAddress, raw, 0));
     });
 
     it('should call isValidENSAddress', () => {
@@ -48,8 +53,11 @@ describe('setCurrentTo*', () => {
     };
     data.validEnsGen = setCurrentTo(ensAddrAction);
 
+    it('should select getNetworkConfig', () => {
+      expect(data.validEnsGen.next().value).toEqual(select(getNetworkConfig));
+    });
     it('should call isValidETHAddress', () => {
-      expect(data.validEnsGen.next().value).toEqual(call(isValidETHAddress, raw));
+      expect(data.validEnsGen.next().value).toEqual(call(isValidAddress, raw, 0));
     });
 
     it('should call isValidENSAddress', () => {


### PR DESCRIPTION
Closes #626

Description
Integrating RSK testnet network and a different checksum for it. Now, depending on the chainId it applies ethereumjs-utils checksum for every ETH addresses or rskjs-util checksum for RSK addresses.

Changes
New configuration. Instead of calling 'toChecksumAddress" now it calls 'toChecksumAddressByChainId' and instead of calling 'isValidETHAddress' now it calls 'isValidAddress' (with chainId as parameter).

Steps to Test
1) Connect to RSK network.
2) Verify that ETH addresses are rightly checksumed.
3) Verify that RSK addresses are rightly checksumed.
4) Verify that a ETH address doesn't work in RSK and vice versa.