### PR TITLE
Clean up input validation logic & classes

### DIFF
--- a/common/components/NonceField.tsx
+++ b/common/components/NonceField.tsx
@@ -50,6 +50,7 @@ class NonceField extends React.Component<Props> {
                   readOnly={readOnly}
                   onChange={onChange}
                   disabled={noncePending}
+                  showInvalidWithoutValue={true}
                 />
                 {noncePending ? (
                   <div className="Nonce-spinner">

--- a/common/components/ui/Input.scss
+++ b/common/components/ui/Input.scss
@@ -81,11 +81,11 @@
       color: $input-color-placeholder;
     }
     &:not([disabled]):not([readonly]) {
-      &.invalid.has-blurred {
+      &.invalid {
         border-color: $brand-danger;
         box-shadow: inset 0px 0px 0px 1px $brand-danger;
       }
-      &.valid.has-value {
+      &.valid {
         border-color: #8dd17b;
         box-shadow: inset 0px 0px 0px 1px #8dd17b;
       }

--- a/common/components/ui/Input.tsx
+++ b/common/components/ui/Input.tsx
@@ -3,7 +3,10 @@ import classnames from 'classnames';
 import './Input.scss';
 
 interface OwnProps extends HTMLProps<HTMLInputElement> {
+  isValid?: boolean;
   showInvalidBeforeBlur?: boolean;
+  showInvalidWithoutValue?: boolean;
+  showValidAsPlain?: boolean;
   setInnerRef?(ref: HTMLInputElement | null): void;
 }
 
@@ -16,12 +19,9 @@ interface State {
   isStateless: boolean;
 }
 
-interface OwnProps extends HTMLProps<HTMLInputElement> {
-  isValid: boolean;
-  showValidAsPlain?: boolean;
-}
+type Props = OwnProps & HTMLProps<HTMLInputElement>;
 
-class Input extends React.Component<OwnProps, State> {
+class Input extends React.Component<Props, State> {
   public state: State = {
     hasBlurred: false,
     isStateless: true
@@ -31,18 +31,26 @@ class Input extends React.Component<OwnProps, State> {
     const {
       setInnerRef,
       showInvalidBeforeBlur,
+      showInvalidWithoutValue,
       showValidAsPlain,
       isValid,
       ...htmlProps
     } = this.props;
+    const { hasBlurred, isStateless } = this.state;
     const hasValue = !!this.props.value && this.props.value.toString().length > 0;
-    const classname = classnames(
-      this.props.className,
-      'input-group-input',
-      this.state.isStateless ? '' : isValid ? (showValidAsPlain ? '' : '') : `invalid`,
-      (showInvalidBeforeBlur || this.state.hasBlurred) && 'has-blurred',
-      hasValue && 'has-value'
-    );
+
+    // Currently we don't ever highlight valid, so go empty string instead
+    let validClass = isValid ? '' : 'invalid';
+    if (isStateless) {
+      validClass = '';
+    }
+    if (!hasValue && !showInvalidWithoutValue) {
+      validClass = '';
+    } else if (!hasBlurred && !showInvalidBeforeBlur) {
+      validClass = '';
+    }
+
+    const classname = classnames('input-group-input', this.props.className, validClass);
 
     return (
       <input

--- a/common/sass/styles/overrides/react-select.scss
+++ b/common/sass/styles/overrides/react-select.scss
@@ -65,10 +65,11 @@
   &-menu {
     max-height: 10.0625rem;
   }
-  &.invalid.has-blurred {
-    border-color: $brand-danger;
-    box-shadow: inset 0px 0px 0px 1px $brand-danger;
-  }
+  // Selects should never have invalid input
+  // &.invalid {
+  //   border-color: $brand-danger;
+  //   box-shadow: inset 0px 0px 0px 1px $brand-danger;
+  // }
   &.is-focused {
     border-color: #4295bc;
     box-shadow: inset 0px 0px 0px 1px #4295bc;


### PR DESCRIPTION
Resolves https://github.com/MyCryptoHQ/MyCrypto/pull/1917#discussion_r194201214

### Description

Cleans up the way inputs show valid and invalid to be a little bit less class-soupy, and provide more control from props.

### Changes

* Adds a `showInvalidWithoutValue` prop to inputs to do just that.
* Removes the `has-blurred` and `has-value` classes in favor of only adding `invalid` if those cases are satisfied.
    * This should reduce style complexity and not lead to "untrue" classes, e.g. not having the `has-blurred` class even if you have blurred.
* Minor type cleanups and comments for clarity.
    * Select `invalid` would never occur with the old classes, and input `valid` was removed, but no comments indicated these two cases.

### Steps to Test

1. Erase nonce and blur the input

### Screenshots

<img width="271" alt="screen shot 2018-06-11 at 3 34 30 pm" src="https://user-images.githubusercontent.com/649992/41253499-888c672a-6d8e-11e8-8856-fbc335f6fea0.png">

