### PR TITLE
Fix paper wallet address & icon

### DIFF
--- a/common/components/PaperWallet/index.tsx
+++ b/common/components/PaperWallet/index.tsx
@@ -1,5 +1,6 @@
 import { Identicon, QRCode } from 'components/ui';
 import React from 'react';
+import { addHexPrefix, toChecksumAddress } from 'ethereumjs-util';
 
 import ethLogo from 'assets/images/logo-ethereum-1.png';
 import notesBg from 'assets/images/notes-bg.png';
@@ -96,7 +97,8 @@ interface Props {
 
 export default class PaperWallet extends React.Component<Props, {}> {
   public render() {
-    const { privateKey, address } = this.props;
+    const { privateKey } = this.props;
+    const address = toChecksumAddress(addHexPrefix(this.props.address));
 
     return (
       <div style={styles.container}>

--- a/common/components/ui/Identicon.tsx
+++ b/common/components/ui/Identicon.tsx
@@ -11,7 +11,6 @@ interface Props {
 export default function Identicon(props: Props) {
   const size = props.size || '4rem';
   const { address, className = '' } = props;
-  // FIXME breaks on failed checksums
   const identiconDataUrl = isValidETHAddress(address) ? makeBlockie(address) : '';
   return (
     // Use inline styles for printable wallets


### PR DESCRIPTION
Closes #1824

### Description

Fixes the paper wallet by hex prefixing and checksumming the address

### Steps to Test

1. Generate keystore file wallet
2. Proceed to print wallet phase
3. Confirm address is hex prefixed, checksummed, and has an identicon