### PR TITLE
Bug Fix for #1813

### DIFF
--- a/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
+++ b/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
@@ -60,7 +60,7 @@ interface State {
 
 class TXMetaDataPanel extends React.Component<Props, State> {
   public static defaultProps: DefaultProps = {
-    initialState: 'simple'
+    initialState: 'advanced'
   };
 
   public state: State = {
@@ -68,9 +68,14 @@ class TXMetaDataPanel extends React.Component<Props, State> {
     sliderState: (this.props as DefaultProps).initialState
   };
 
-  public componentDidMount() {
+  public componentWillMount() {
     if (!this.props.offline) {
       this.props.resetTransactionRequested();
+    }
+  }
+
+  public componentDidMount() {
+    if (!this.props.offline) {
       this.props.fetchCCRates([this.props.network.unit]);
       this.props.getNonceRequested();
     }

--- a/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
+++ b/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
@@ -60,7 +60,7 @@ interface State {
 
 class TXMetaDataPanel extends React.Component<Props, State> {
   public static defaultProps: DefaultProps = {
-    initialState: 'advanced'
+    initialState: 'simple'
   };
 
   public state: State = {


### PR DESCRIPTION
Moves `resetTransactionRequested()` call from `componentDidMount` to `componentWillMount` in `TXMetaDataPanel.tsx`. Closes #1813.

Query params are parsed and set inside components, so resetting transaction state _after_ render was wiping it out.