### PR TITLE
Show invalid for Nonce Field when empty

### DIFF
--- a/common/components/ui/Input.tsx
+++ b/common/components/ui/Input.tsx
@@ -49,6 +49,9 @@ class Input extends React.Component<Props, State> {
     } else if (!hasBlurred && !showInvalidBeforeBlur) {
       validClass = '';
     }
+    if (!hasValue && showInvalidWithoutValue) {
+      validClass = 'invalid';
+    }
 
     const classname = classnames('input-group-input', this.props.className, validClass);
 


### PR DESCRIPTION
Shows red border highlight around the Nonce field when empty. Primarily used to help users who are used to the flow with a working internet connection be alerted that they need to enter an addition field (nonce) while offline.