### PR TITLE
Fix Stuck Node on Metamask Logout

### DIFF
--- a/common/sagas/config/node.ts
+++ b/common/sagas/config/node.ts
@@ -148,6 +148,12 @@ export function* handleChangeNodeRequested({
 
   // Bail out if they're switching to the same node
   if (currentConfig.id === nodeIdToSwitchTo) {
+    yield put(
+      changeNodeSucceeded({
+        nodeId: currentConfig.id,
+        networkId: currentConfig.network
+      })
+    );
     return;
   }
 


### PR DESCRIPTION
Closes #1949

### Description

Adds a `CHANGE_NODE_SUCCEEDED` if the requested node to change to matches our current one. Otherwise it would get stuck in the requested state forever.

### Changes

* High level
* Changes that
* You Made

### Steps to Test

1. Log in with metamask
2. Change tabs (logout)
3. Confirm you're on the node you want to be
