### PR TITLE
[EOSC] Add EOS Classic node support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -88,6 +88,11 @@ export const GO_DEFAULT: DPath = {
   value: "m/44'/6060'/0'/0"
 };
 
+export const EOSC_DEFAULT: DPath = {
+  label: 'Default (EOSC)',
+  value: "m/44'/2018'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -105,7 +110,8 @@ export const DPaths: DPath[] = [
   EGEM_DEFAULT,
   CLO_DEFAULT,
   RSK_TESTNET,
-  GO_DEFAULT
+  GO_DEFAULT,
+  EOSC_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "GO",
+      "EOSC",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -22,7 +22,8 @@ import {
   EGEM_DEFAULT,
   CLO_DEFAULT,
   RSK_TESTNET,
-  GO_DEFAULT
+  GO_DEFAULT,
+  EOSC_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { StaticNetworksState } from './types';
@@ -414,6 +415,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       min: 2,
       max: 60,
       initial: 2
+    }
+  },
+
+  EOSC: {
+    id: 'EOSC',
+    name: 'EOS Classic',
+    unit: 'EOSC',
+    chainId: 20,
+    isCustom: false,
+    color: '#926565',
+    blockExplorer: makeExplorer({
+      name: 'EOSC Explorer',
+      origin: 'https://explorer.eos-classic.io'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: EOSC_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: EOSC_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
     }
   }
 };

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -184,6 +184,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'gochain.io',
       url: 'https://rpc.gochain.io/'
     }
+  ],
+
+  EOSC: [
+    {
+      name: makeNodeName('EOSC', 'eosc'),
+      type: 'rpc',
+      service: 'eos-classic.io',
+      url: 'https://node.eos-classic.io/'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -14,7 +14,8 @@ type StaticNetworkIds =
   | 'EGEM'
   | 'CLO'
   | 'RSK_TESTNET'
-  | 'GO';
+  | 'GO'
+  | 'EOSC';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
### Description

EOS Classic is a combination of EOS & ETH protocol

+ Homepage: https://eos-classic.io
+ Node: https://node.eos-classic.io
+ BIP44 2018 / Chainid 20 ( https://github.com/satoshilabs/slips/pull/279 )
+ Already merged on MyEtherWallet ( https://github.com/kvhnuke/etherwallet/pull/1903 )

### Changes

* This PR adds EOS Classic node support
* Fixed chain id from the old pr
* Fixed snapshot

### Screenshots

![1](https://user-images.githubusercontent.com/39383087/41536825-a47b1a40-7341-11e8-880e-52af873fc3c1.PNG)


