### PR TITLE
Support undefined input names

### DIFF
--- a/common/containers/Tabs/Contracts/components/Interact/components/InteractExplorer/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Interact/components/InteractExplorer/index.tsx
@@ -124,13 +124,20 @@ class InteractExplorerClass extends Component<Props, State> {
         {selectedFunction && (
           <div key={selectedFunction.name} className="InteractExplorer-func">
             {/* TODO: Use reusable components with validation */}
-            {selectedFunction.contract.inputs.map(input => {
+            {selectedFunction.contract.inputs.map((input, index) => {
               const { type, name } = input;
-              const inputState = this.state.inputs[name];
+              // if name is not supplied to arg, use the index instead
+              // since that's what the contract ABI function factory subsitutes for the name
+              // if it is undefined
+              const parsedName = name === '' ? index : name;
+
+              const inputState = this.state.inputs[parsedName];
               return (
-                <div key={name} className="input-group-wrapper InteractExplorer-func-in">
+                <div key={parsedName} className="input-group-wrapper InteractExplorer-func-in">
                   <label className="input-group">
-                    <div className="input-group-header">{name + ' ' + type}</div>
+                    <div className="input-group-header">
+                      {(parsedName === index ? `Input#${parsedName}` : parsedName) + ' ' + type}
+                    </div>
                     {type === 'bool' ? (
                       <Dropdown
                         options={[{ value: false, label: 'false' }, { value: true, label: 'true' }]}
@@ -144,15 +151,15 @@ class InteractExplorerClass extends Component<Props, State> {
                         }
                         clearable={false}
                         onChange={({ value }: { value: boolean }) => {
-                          this.handleBooleanDropdownChange({ value, name });
+                          this.handleBooleanDropdownChange({ value, name: parsedName });
                         }}
                       />
                     ) : (
                       <Input
                         className="InteractExplorer-func-in-input"
-                        isValid={!!(inputs[name] && inputs[name].rawData)}
-                        name={name}
-                        value={(inputs[name] && inputs[name].rawData) || ''}
+                        isValid={!!(inputs[parsedName] && inputs[parsedName].rawData)}
+                        name={parsedName}
+                        value={(inputs[parsedName] && inputs[parsedName].rawData) || ''}
                         onChange={this.handleInputChange}
                       />
                     )}

--- a/common/libs/contracts/ABIFunction.ts
+++ b/common/libs/contracts/ABIFunction.ts
@@ -77,12 +77,12 @@ export default class AbiFunction {
   };
 
   private init(outputMappings: FunctionOutputMappings = []) {
-    this.funcParams = this.makeFuncParams();
     //TODO: do this in O(n)
     this.inputTypes = this.inputs.map(({ type }) => type);
     this.outputTypes = this.outputs.map(({ type }) => type);
-    this.inputNames = this.inputs.map(({ name }) => name);
+    this.inputNames = this.inputs.map(({ name }, i) => name || `${i}`);
     this.outputNames = this.outputs.map(({ name }, i) => outputMappings[i] || name || `${i}`);
+    this.funcParams = this.makeFuncParams();
 
     this.methodSelector = abi.methodID(this.name, this.inputTypes).toString('hex');
   }
@@ -105,8 +105,11 @@ export default class AbiFunction {
   };
 
   private makeFuncParams = () =>
-    this.inputs.reduce((accumulator, currInput) => {
-      const { name, type } = currInput;
+    this.inputs.reduce((accumulator, _, idx) => {
+      // use our properties over this.inputs since the names can be modified
+      // if the input names are undefined
+      const name = this.inputNames[idx];
+      const type = this.inputTypes[idx];
       const inputHandler = (inputToParse: any) =>
         //TODO: introduce typechecking and typecasting mapping for inputs
         ({ name, type, value: this.parsePreEncodedValue(type, inputToParse) });


### PR DESCRIPTION
Closes #1872

### Description

Adds support for multiple undefined input names by substituting their names for an index. This guarantees that each input name will still be unique. Before, this substitution did not happen, so if there was >1 undefined input name for a function, then they would have their states bound together since they would be under the same key in a map.

### Changes

* Use index for unique name during ABI function instantiation 
* Change contract interaction to generate its mappings the same way so function calls get properly encoded

### Steps to Test

1. Go to contract -> interact tab
2. Use the following ABI 
```json
[ 
   {
      "constant": true,
      "inputs": [{ "name": "", "type": "uint256" }, { "name": "", "type": "address" }],
      "name": "whitelist",
      "outputs": [{ "name": "", "type": "bool" }],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
   }
]
```
3. Use address `0xB8BF791166eed1A94B3a19bEE0d7dbb2A98b504E`
4. Fill in each field under the `whitelist` function
5. Make sure you're able to fill each field seperately

