### PR TITLE
Hide unsupported tabs by RSK

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -29,6 +29,7 @@ import {
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { StaticNetworksState } from './types';
+import { TAB } from 'components/Header/components/constants';
 
 const testnetDefaultGasPrice = {
   min: 0.1,
@@ -393,7 +394,8 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       min: 0.183,
       max: 1.5,
       initial: 0.183
-    }
+    },
+    unsupportedTabs: [TAB.SWAP, TAB.ENS]
   },
 
   RSK_TESTNET: {
@@ -419,7 +421,8 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       min: 0.183,
       max: 1.5,
       initial: 0.183
-    }
+    },
+    unsupportedTabs: [TAB.SWAP, TAB.ENS]
   },
 
   GO: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -395,7 +395,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       max: 1.5,
       initial: 0.183
     },
-    unsupportedTabs: [TAB.SWAP, TAB.ENS]
+    unsupportedTabs: [TAB.ENS]
   },
 
   RSK_TESTNET: {
@@ -422,7 +422,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       max: 1.5,
       initial: 0.183
     },
-    unsupportedTabs: [TAB.SWAP, TAB.ENS]
+    unsupportedTabs: [TAB.ENS]
   },
 
   GO: {


### PR DESCRIPTION
Closes #2010

### Description

This change hides tabs not supported (up to now) by both RSK testnet and mainnet. It avoids errors and misundertstandings.

### Changes

* Adds `TAB.ENS` and `TAB.SWAP` to `unsuppportedTabs` field in `StaticNetworksState`

### Steps to Test

1. Select RSK network and check that ENS and Swap tabs are not visible.
2. Change to other network and check that ENS and Swap tabs do are visible.