### PR TITLE
Tighten web3 network change refresh validation

### DIFF
--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -12,7 +12,9 @@ Object {
 }
 `;
 
-exports[`handleChangeNodeRequested* should select getCustomNodeConfig and match race snapshot 1`] = `
+exports[
+  `handleChangeNodeRequested* should select getCustomNodeConfig and match race snapshot 1`
+] = `
 Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {

--- a/common/features/deterministicWallets/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/deterministicWallets/__snapshots__/sagas.spec.ts.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getDeterministicWallets* starting from publicKey & chainCode should match put snapshot 1`] = `
+exports[
+  `getDeterministicWallets* starting from publicKey & chainCode should match put snapshot 1`
+] = `
 Object {
   "@@redux-saga/IO": true,
   "PUT": Object {

--- a/common/features/handleMetaMaskPolling.ts
+++ b/common/features/handleMetaMaskPolling.ts
@@ -37,7 +37,12 @@ export default async function handleMetaMaskPolling(store: Store<AppState>): Pro
     const actualChainId = await getActualChainId();
     const actualNetwork = configNetworksSelectors.getNetworkByChainId(state, actualChainId);
 
-    if (web3Wallet && actualNetwork && (web3Wallet as Web3Wallet).network !== actualNetwork.id) {
+    if (
+      web3Wallet &&
+      (web3Wallet as Web3Wallet).network &&
+      actualNetwork &&
+      (web3Wallet as Web3Wallet).network !== actualNetwork.id
+    ) {
       window.location.reload();
 
       return true;


### PR DESCRIPTION
Closes #2013

### Description

A mistake in the MetaMask refresh implementation caused the plage to refresh when the `web3Wallet` instance had no `network` property.

### Changes

* Unnecessary refresh is avoided by checking for existence of network in the refresh check.

### Steps to Test

1. Access any wallet besides MetaMask.
2. The wallet should not boot you out after unlocking.