### PR TITLE
Check for `web3` before polling network status for MetaMask

### DIFF
--- a/common/features/store.ts
+++ b/common/features/store.ts
@@ -91,6 +91,9 @@ window.addEventListener('load', () => {
   });
 });
 
-setInterval(handleMetaMaskPolling.bind(null, store), METAMASK_POLLING_INTERVAL);
+/** @desc When MetaMask is loaded as an extension, watch for network changes. */
+if ((window as any).web3) {
+  setInterval(handleMetaMaskPolling.bind(null, store), METAMASK_POLLING_INTERVAL);
+}
 
 export default store;


### PR DESCRIPTION
Closes #2016 

### Description

Browsers without MetaMask were caught in a refresh loop due to the web3 check failing.

### Changes

* The poll doesn't start unless `web3` is detected.

### Steps to Test

1. Load the app in a browser without MetaMask.
2. Use the app as normal without infinite refreshing.