### PR TITLE
Adjust translation algorithm

### DIFF
--- a/common/translations/index.tsx
+++ b/common/translations/index.tsx
@@ -67,13 +67,21 @@ export function translateRaw(key: string, variables?: { [name: string]: string }
   const translatedString =
     (repository[language] && repository[language][key]) || repository[fallbackLanguage][key] || key;
 
-  if (!!variables) {
-    // Find each variable and replace it in the translated string
-    let str = translatedString;
-    Object.keys(variables).forEach(v => {
-      const re = new RegExp(v.replace('$', '\\$'), 'g');
-      str = str.replace(re, variables[v]);
+  /** @desc In RegExp, $foo is two "words", but __foo is only one "word."
+   *  Replace all occurences of '$' with '__' in the entire string and each variable,
+   *  then iterate over each variable, replacing the '__variable' in the
+   *  translation key with the variable's value.
+   */
+  if (variables) {
+    let str = translatedString.replace(/\$/g, '__');
+
+    Object.keys(variables).forEach(variable => {
+      const singleWordVariable = variable.replace(/\$/g, '__');
+      const re = new RegExp(`\\b${singleWordVariable}\\b`, 'g');
+
+      str = str.replace(re, variables[variable]);
     });
+
     return str;
   }
 


### PR DESCRIPTION
Closes #(none, reported in dream-team by @Azarielle)

### Description

Translation algorithm was changed to avoid the issue of overwriting other variables.

### Changes

* `translateRaw` now replaces all `$` with `__` prior to replacing variables.

### Steps to Test

1. Open the TXStatus tab.
2. Ensure the blockchain links are accurate.

### Screenshots

<img width="1114" alt="screen shot 2018-07-06 at 6 25 11 pm" src="https://user-images.githubusercontent.com/10479826/42403849-f33a0e00-8149-11e8-99e1-32b61c325ba2.png">


