### PR TITLE
Handle back-to-back similar transactions

### DIFF
--- a/common/components/ConfirmationModal/components/Body/Body.tsx
+++ b/common/components/ConfirmationModal/components/Body/Body.tsx
@@ -29,20 +29,6 @@ class BodyClass extends React.Component<StateProps, State> {
     });
   };
 
-  public componentDidCatch(error: Error) {
-    if (error.message === 'Serialized transaction not found') {
-      /**
-       * @desc Occasionally, when a new signed transaction matches a previous transaction,
-       * the transaction state is cleared and a warning notification alerts the user. Once the
-       * transaction state is cleared, however, the <Amounts /> component's attempts at selecting
-       * the transaction causes the 'Serialized transaction not found' error.
-       * A longer term fix will involve finding a better way to calculate nonces to avoid
-       * nonce duplication on serial transactions.
-       */
-      // Pass
-    }
-  }
-
   public render() {
     const { showDetails } = this.state;
 

--- a/common/components/ConfirmationModal/components/Body/Body.tsx
+++ b/common/components/ConfirmationModal/components/Body/Body.tsx
@@ -29,6 +29,20 @@ class BodyClass extends React.Component<StateProps, State> {
     });
   };
 
+  public componentDidCatch(error: Error) {
+    if (error.message === 'Serialized transaction not found') {
+      /**
+       * @desc Occasionally, when a new signed transaction matches a previous transaction,
+       * the transaction state is cleared and a warning notification alerts the user. Once the
+       * transaction state is cleared, however, the <Amounts /> component's attempts at selecting
+       * the transaction causes the 'Serialized transaction not found' error.
+       * A longer term fix will involve finding a better way to calculate nonces to avoid
+       * nonce duplication on serial transactions.
+       */
+      // Pass
+    }
+  }
+
   public render() {
     const { showDetails } = this.state;
 

--- a/common/containers/Tabs/SendTransaction/components/Fields/Fields.tsx
+++ b/common/containers/Tabs/SendTransaction/components/Fields/Fields.tsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import translate from 'translations';
+import translate, { translateRaw } from 'translations';
 import { AppState } from 'features/reducers';
 import * as selectors from 'features/selectors';
 import { getOffline, getNetworkConfig } from 'features/config';
 import { scheduleSelectors } from 'features/schedule';
+import { notificationsActions } from 'features/notifications';
 import {
   AddressField,
   AmountField,
@@ -38,7 +39,26 @@ interface StateProps {
   useScheduling: scheduleSelectors.ICurrentSchedulingToggle['value'];
 }
 
-class FieldsClass extends Component<StateProps> {
+interface DispatchProps {
+  showNotification: notificationsActions.TShowNotification;
+}
+
+class FieldsClass extends Component<StateProps & DispatchProps> {
+  public componentDidCatch(error: Error) {
+    if (error.message === 'Serialized transaction not found') {
+      /**
+       * @desc Occasionally, when a new signed transaction matches a previous transaction,
+       * the nonce does not update, since the transaction has not yet been confirmed. This triggers
+       * the <Amounts /> component inside the <ConfirmationModal /> of <TXMetaDataPanel /> to throw
+       * an error when selecting the current transaction's serialized parameters.
+       * A longer term fix will involve finding a better way to calculate nonces to avoid
+       * nonce duplication on serial transactions.
+       */
+      this.props.showNotification('danger', translateRaw('SIMILAR_TRANSACTION_ERROR'));
+      this.forceUpdate();
+    }
+  }
+
   public render() {
     const { shouldDisplay, schedulingAvailable, useScheduling } = this.props;
 
@@ -106,10 +126,15 @@ class FieldsClass extends Component<StateProps> {
   }
 }
 
-export const Fields = connect((state: AppState) => ({
-  schedulingAvailable:
-    getNetworkConfig(state).name === 'Kovan' && selectors.getUnit(state) === 'ETH',
-  shouldDisplay: !selectors.isAnyOfflineWithWeb3(state),
-  offline: getOffline(state),
-  useScheduling: scheduleSelectors.getCurrentSchedulingToggle(state).value
-}))(FieldsClass);
+export const Fields = connect(
+  (state: AppState) => ({
+    schedulingAvailable:
+      getNetworkConfig(state).name === 'Kovan' && selectors.getUnit(state) === 'ETH',
+    shouldDisplay: !selectors.isAnyOfflineWithWeb3(state),
+    offline: getOffline(state),
+    useScheduling: scheduleSelectors.getCurrentSchedulingToggle(state).value
+  }),
+  {
+    showNotification: notificationsActions.showNotification
+  }
+)(FieldsClass);

--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -664,6 +664,7 @@
     "PAYMENT_ID_WARNING": "Don't forget to send your XMR with the payment ID [[?]](https://getmonero.org/resources/moneropedia/paymentid.html) above, or you WILL lose your funds.",
     "WHAT_IS_PAYMENT_ID": "what's a payment ID?",
     "ANNOUNCEMENT_MESSAGE": "MyCrypto.com no longer allows the use of private keys, mnemonics, or keystore files in the browser. To continue using them, please download the [MyCrypto Desktop App](https://download.mycrypto.com).",
-    "U2F_NOT_SUPPORTED": "The U2F standard that hardware wallets use does not seem to be supported by your browser. Please try again using Google Chrome."
+    "U2F_NOT_SUPPORTED": "The U2F standard that hardware wallets use does not seem to be supported by your browser. Please try again using Google Chrome.",
+    "SIMILAR_TRANSACTION_ERROR": "This transaction is very similar to a recent transaction. Please wait a few moments and try again, or click 'Advanced' and manually set the nonce to a new value."
   }
 }


### PR DESCRIPTION
Closes #1992

### Description

Attempting to send two back-to-back transactions to an address triggered a Red Screen of Death because of an uncaught error in a selector.

### Changes

* When the `getSerializedParams` selector fails because the nonce value did not change, the `<Fields />` component now handles that error by showing a notification to the user and updating to clear the confirmation modal.

### Steps to Test

1. Log in to a wallet that is not Web3 (e.g. via keyfile)
2. Make a small transaction to an address.
3. Switch to the `Request Payment` tab, then switch back.
4. Re-enter the same address and value as before.
5. Press the 'Send' button, then press 'Send' in the confirmation modal.
6. The confirmation modal should disappear, the `<Fields />` component should be clear, and a notification should alert the user about the situation.
7. Changing the nonce manually or waiting for the transaction to confirm should allow the transaction to proceed as normal.

### Screenshots
<img width="1440" alt="screen shot 2018-07-09 at 3 56 19 pm" src="https://user-images.githubusercontent.com/10479826/42475770-4063b4a8-8391-11e8-9a39-e27798167fd0.png">

