### PR TITLE
Add RSK gas estimation

### DIFF
--- a/common/api/RSKgas.ts
+++ b/common/api/RSKgas.ts
@@ -1,0 +1,43 @@
+import { GasEstimates } from './gas';
+import { checkHttpStatus, parseJSON } from './utils';
+
+export function fetchRSKEstimates(chainId: number): Promise<GasEstimates> {
+  const url: string =
+    chainId === 30 ? 'https://mycrypto.rsk.co' : 'https://mycrypto.testnet.rsk.co';
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'eth_getBlockByNumber',
+      params: ['latest', false],
+      id: 1
+    }),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  })
+    .then(checkHttpStatus)
+    .then(parseJSON)
+    .then(res => {
+      const minGasPriceWei: number = +res.result.minimumGasPrice / 1000000000;
+      let minGasPrice: number;
+      let min: number;
+      if (chainId === 31 && minGasPriceWei === 0) {
+        minGasPrice = 1;
+        min = 1;
+      } else {
+        minGasPrice = minGasPriceWei;
+        min = minGasPrice * 1.0001;
+      }
+
+      return {
+        chainId,
+        safeLow: min,
+        standard: min,
+        fast: min,
+        fastest: minGasPrice * 10,
+        isDefault: false,
+        time: Date.now()
+      } as GasEstimates;
+    });
+}

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -395,7 +395,8 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       max: 1.5,
       initial: 0.183
     },
-    unsupportedTabs: [TAB.ENS]
+    unsupportedTabs: [TAB.ENS],
+    shouldEstimateGasPrice: true
   },
 
   RSK_TESTNET: {
@@ -422,7 +423,8 @@ export const STATIC_NETWORKS_INITIAL_STATE: StaticNetworksState = {
       max: 1.5,
       initial: 0.183
     },
-    unsupportedTabs: [TAB.ENS]
+    unsupportedTabs: [TAB.ENS],
+    shouldEstimateGasPrice: true
   },
 
   GO: {

--- a/common/features/gas/sagas.ts
+++ b/common/features/gas/sagas.ts
@@ -3,6 +3,7 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { gasPriceDefaults, gasEstimateCacheTime } from 'config';
 import { fetchGasEstimates, GasEstimates } from 'api/gas';
+import { fetchRSKEstimates } from 'api/RSKgas';
 import { NetworkConfig } from 'types/network';
 import { AppState } from 'features/reducers';
 import * as configMetaSelectors from 'features/config/meta/selectors';
@@ -52,6 +53,17 @@ export function* fetchEstimates(): SagaIterator {
     oldEstimates.time + gasEstimateCacheTime > Date.now()
   ) {
     yield put(actions.setGasEstimates(oldEstimates));
+    return;
+  }
+
+  if (network.chainId === 30 || network.chainId === 31) {
+    try {
+      const estimates: GasEstimates = yield call(fetchRSKEstimates, network.chainId);
+      yield put(actions.setGasEstimates(estimates));
+    } catch (err) {
+      console.warn('Failed to fetch RSK gas estimates:', err);
+      yield call(setDefaultEstimates, network);
+    }
     return;
   }
 


### PR DESCRIPTION
Closes #2081 

### Description

RSK fetches and estimates gas price depending on the latest block minimum gas price.

### Changes

* Add RSK minimum gas price network query as an API
* Enable RSK networks to estimate gas
* Call API when gas is calculated

### Steps to Test

1. Select RSK MainNet/TestNet network
2. Open Send tab
3. Gas bar should display actual minimum gas price

> If TestNet minimum gas price is 0, uses default minimum 1