### PR TITLE
Correct GBX decimals (should be 8; not 18)

### DIFF
--- a/common/config/tokens/eth.json
+++ b/common/config/tokens/eth.json
@@ -2462,7 +2462,7 @@
   {
     "address": "0x12fCd6463E66974cF7bBC24FFC4d40d6bE458283",
     "symbol": "GBX",
-    "decimal": 18
+    "decimal": 8
   },
   {
     "address": "0x7728dFEF5aBd468669EB7f9b48A7f70a501eD29D",


### PR DESCRIPTION
Source for number of decimals: https://etherscan.io/address/0x12fcd6463e66974cf7bbc24ffc4d40d6be458283#readContract

(received an email from someone who noticed the interface showed an incorrect balance for GBX)