### PR TITLE
Remove empty check

### DIFF
--- a/shared/enclave/server/views/passphrase.html
+++ b/shared/enclave/server/views/passphrase.html
@@ -35,7 +35,6 @@
         var passphrase = "";
 
         function unlockWithPassphrase() {
-            if (!passphrase.length) return;
             ipcRenderer.send('$EVENT', passphrase);
         }
 


### PR DESCRIPTION
Closes #2073

### Description
Empty passphrase was not allowed for Trezor.

### Changes

* Empty passphrase is now allowed for Trezor.

### Steps to Test

1. Attempt to authenticate via a Trezor with passphrase enabled.
2. When the passphrase prompt appears, press "Enter"
3. You should still be allowed in.
