### PR TITLE
Change dangerous electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "2.5.5",
     "coveralls": "3.0.0",
     "css-loader": "0.28.11",
-    "electron": "2.0.1",
+    "electron": "~>2.0.8",
     "electron-builder": "20.13.4",
     "electron-rebuild": "1.7.3",
     "empty": "0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,9 +3685,9 @@ electron-updater@2.21.10:
     semver "^5.5.0"
     source-map-support "^0.5.5"
 
-electron@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.1.tgz#d9defcc187862143b9027378be78490eddbfabf4"
+electron@~>2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
There was an issue with our version of `electron`.

![screen shot 2018-08-31 at 12 58 56 pm](https://user-images.githubusercontent.com/10479826/44929129-7bf44e80-ad1f-11e8-95d7-882155da30e7.png)
