### PR TITLE
Remove non-exact dependency on electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "2.5.5",
     "coveralls": "3.0.0",
     "css-loader": "0.28.11",
-    "electron": "~>2.0.8",
+    "electron": "2.0.8",
     "electron-builder": "20.13.4",
     "electron-rebuild": "1.7.3",
     "empty": "0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,7 +3685,7 @@ electron-updater@2.21.10:
     semver "^5.5.0"
     source-map-support "^0.5.5"
 
-electron@~>2.0.8:
+electron@2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:


### PR DESCRIPTION
Whoops! It looks like we have tests that prevent unsure versioning. It makes sense from a security standpoint.