### PR TITLE
Release/1.2.3.3

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -109,7 +109,7 @@ class RootClass extends Component<Props, State> {
         <Provider store={store}>
           <Router>
             <React.Fragment>
-              {!process.env.BUILD_DOWNLOADABLE && onboardingActive && <OnboardingModal />}
+              {onboardingActive && <OnboardingModal />}
               {routes}
               <LegacyRoutes />
               <LogOutPrompt />

--- a/common/containers/OnboardingModal/OnboardingModal.scss
+++ b/common/containers/OnboardingModal/OnboardingModal.scss
@@ -1,3 +1,4 @@
+@import 'common/sass/variables/colors.scss';
 @import 'common/sass/mixins.scss';
 
 .OnboardingModal {
@@ -6,12 +7,13 @@
   width: 90vw;
   height: 90vh;
   min-height: 300px;
-  background: #fff;
+  background: color(pane-bg);
   border-radius: 6px;
   box-shadow: 0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
 
   h1 {
     @include onboarding-modal-slide-heading;
+    color: color(text-color);
   }
   p,
   li {


### PR DESCRIPTION
Onboarding modal could theoretically load in dark theme if a previous user switched to dark theme and then upgraded their app. Also show the onboarding modal on desktop.