### PR TITLE
support full 32bit chainId for Trezor

### DIFF
--- a/common/libs/wallet/deterministic/trezor.ts
+++ b/common/libs/wallet/deterministic/trezor.ts
@@ -54,6 +54,13 @@ export class TrezorWallet extends HardwareWallet {
             return reject(Error(result.error));
           }
 
+          // check the returned signature_v and recalc signature_v if it needed
+          // see also https://github.com/trezor/trezor-mcu/pull/399
+          if (Number(result.v) <= 1) {
+            //  for larger chainId, only signature_v returned. simply recalc signature_v
+            result.v += 2 * chainId + 35;
+          }
+
           // TODO: Explain what's going on here? Add tests? Adapted from:
           // https://github.com/kvhnuke/etherwallet/blob/v3.10.2.6/app/scripts/uiFuncs.js#L24
           const txToSerialize: TxObj = {


### PR DESCRIPTION
for some larger chainId, Trezor returns signature_v bit only. simply recalc signature_v
