### PR TITLE
Create gas notches on gas slider

### DIFF
--- a/common/components/TXMetaDataPanel/components/SimpleGas.scss
+++ b/common/components/TXMetaDataPanel/components/SimpleGas.scss
@@ -9,6 +9,11 @@
     > .SimpleGas-slider {
       flex-grow: 1;
       margin-right: $space;
+
+      > .rc-slider > .rc-slider-step > .rc-slider-dot {
+        height: 18px;
+        bottom: -8px
+      }
     }
 
     > .FeeSummary {

--- a/common/components/TXMetaDataPanel/components/SimpleGas.tsx
+++ b/common/components/TXMetaDataPanel/components/SimpleGas.tsx
@@ -76,6 +76,21 @@ class SimpleGas extends React.Component<Props> {
       min: gasEstimates ? gasEstimates.safeLow : gasPriceDefaults.min
     };
 
+    const gasNotches: any = {};
+
+    if (gasEstimates) {
+      const gasRecommendations: any = {
+        fast: gasEstimates.fast,
+        fastest: gasEstimates.fastest,
+        safeLow: gasEstimates.safeLow,
+        standard: gasEstimates.standard
+      };
+
+      for (let notch in gasRecommendations) {
+        gasNotches[gasRecommendations[notch]] = '';
+      }
+    }
+
     /**
      * @desc On retrieval of gas estimates,
      *  the current gas price may be lower than the lowest recommended price.
@@ -112,6 +127,8 @@ class SimpleGas extends React.Component<Props> {
               onChange={this.handleSlider}
               min={bounds.min}
               max={bounds.max}
+              marks={gasNotches}
+              included={false}
               step={bounds.min < 1 ? 0.1 : 1}
               value={actualGasPrice}
               tipFormatter={this.formatTooltip}
@@ -147,8 +164,30 @@ class SimpleGas extends React.Component<Props> {
   private formatTooltip = (gas: number) => {
     const { gasEstimates } = this.props;
     let recommended = '';
-    if (gasEstimates && !gasEstimates.isDefault && gas === gasEstimates.fast) {
-      recommended = '(Recommended)';
+
+    if (gasEstimates && !gasEstimates.isDefault) {
+      switch (gas) {
+        case gasEstimates.fast: {
+          recommended = '(fast)';
+          break;
+        }
+        case gasEstimates.fastest: {
+          recommended = '(fastest)';
+          break;
+        }
+        case gasEstimates.safeLow: {
+          recommended = '(Safe Low)';
+          break;
+        }
+        case gasEstimates.standard: {
+          recommended = '(Standard)';
+          break;
+        }
+        default: {
+          recommended = '';
+          break;
+        }
+      }
     }
 
     return `${gas} Gwei ${recommended}`;

--- a/common/components/TXMetaDataPanel/components/SimpleGas.tsx
+++ b/common/components/TXMetaDataPanel/components/SimpleGas.tsx
@@ -86,8 +86,10 @@ class SimpleGas extends React.Component<Props> {
         standard: gasEstimates.standard
       };
 
-      for (let notch in gasRecommendations) {
-        gasNotches[gasRecommendations[notch]] = '';
+      for (const notch in gasRecommendations) {
+        if (gasRecommendations.hasOwnProperty(notch)) {
+          gasNotches[gasRecommendations[notch]] = '';
+        }
       }
     }
 


### PR DESCRIPTION

Closes #1891 

### Description

Add gas slider notches for Safe Low, Standard, Fast, and Fastest gas values

### Changes

* Add marks to gas price slider that represent gas values returned from 
* Increase notch height to make notches more visible

### Steps to Test

1. Open a wallet and go to the "Send Ether & Tokens" tab to see if gas notches are properly displaying

### Screenshots

![image](https://user-images.githubusercontent.com/434238/45155693-d96a1e80-b1a9-11e8-8054-aef4ff96c507.png)

