### PR TITLE
Hide equivalent values for RSK network

### DIFF
--- a/common/components/BalanceSidebar/EquivalentValues.tsx
+++ b/common/components/BalanceSidebar/EquivalentValues.tsx
@@ -191,6 +191,10 @@ class EquivalentValues extends React.Component<Props, State> {
           <div className="text-center">
             <h5 style={{ color: 'red' }}>{translate('EQUIV_VALS_TESTNET')}</h5>
           </div>
+        ) : network.hideEquivalentValues ? (
+          <div className="text-center">
+            <h5 style={{ color: 'red' }}>{translate('EQUIV_VALS_UNSUPPORTED_UNIT')}</h5>
+          </div>
         ) : ratesError ? (
           <h5>{ratesError}</h5>
         ) : isFetching ? (

--- a/common/components/TXMetaDataPanel/components/FeeSummary.tsx
+++ b/common/components/TXMetaDataPanel/components/FeeSummary.tsx
@@ -80,15 +80,16 @@ class FeeSummary extends React.Component<Props> {
     const usdBig = network.isTestnet
       ? new BN(0)
       : feeBig && rates[network.unit] && feeBig.muln(rates[network.unit].USD);
-    const usd = isOffline ? null : (
-      <UnitDisplay
-        value={usdBig}
-        unit="ether"
-        displayShortBalance={2}
-        displayTrailingZeroes={true}
-        checkOffline={true}
-      />
-    );
+    const usd =
+      isOffline || network.hideEquivalentValues ? null : (
+        <UnitDisplay
+          value={usdBig}
+          unit="ether"
+          displayShortBalance={2}
+          displayTrailingZeroes={true}
+          checkOffline={true}
+        />
+      );
 
     const feeSummaryClasses = classNames({
       FeeSummary: true,

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -413,7 +413,8 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       max: 1.5,
       initial: 0.06
     },
-    unsupportedTabs: [TAB.ENS]
+    unsupportedTabs: [TAB.ENS],
+    hideEquivalentValues: true
   },
 
   RSK_TESTNET: {

--- a/common/features/selectors.ts
+++ b/common/features/selectors.ts
@@ -173,9 +173,9 @@ export function getShownTokenBalances(
 }
 
 const getUSDConversionRate = (state: AppState, unit: string) => {
-  const { isTestnet } = configSelectors.getNetworkConfig(state);
+  const { isTestnet, hideEquivalentValues } = configSelectors.getNetworkConfig(state);
   const { rates } = ratesSelectors.getRates(state);
-  if (isTestnet) {
+  if (isTestnet || hideEquivalentValues) {
     return null;
   }
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -76,6 +76,7 @@ interface StaticNetworkConfig {
   gasPriceSettings: GasPriceSetting;
   shouldEstimateGasPrice?: boolean;
   unsupportedTabs?: TAB[];
+  hideEquivalentValues?: boolean;
 }
 
 interface CustomNetworkConfig {
@@ -87,6 +88,7 @@ interface CustomNetworkConfig {
   chainId: number;
   dPathFormats: DPathFormats | null;
   unsupportedTabs?: TAB[];
+  hideEquivalentValues?: boolean;
 }
 
 type NetworkConfig = CustomNetworkConfig | StaticNetworkConfig;


### PR DESCRIPTION
Closes #2091

### Description

RSK currency symbol is SBTC "Smart Bitcoin" that crashes to SBTC "Super Bitcoin". This generates mistakes in rate conversions because MyCrypto API returns "Super Bitcoin" rate for SBTC.
### Changes

* Addition of new configuration parameter hideEquivalentValues (optional boolean) that avoids showing rate conversions and, consequently, misunderstandings operating with RSK network.

### Steps to Test

1. Select RSK network
2. Go to "View&Send" / "Contracts" tab and prepare a transaction.
3. Check that no USD values are shown.
4. Check that "Equivalent Values" box shows a message about not showing values for this unit.
