### PR TITLE
Add support for Akroma

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -118,6 +118,11 @@ export const AQUA_DEFAULT: DPath = {
   value: "m/44'/60'/0'/0"
 };
 
+export const AKA_DEFAULT: DPath = {
+  label: 'Default (AKA)',
+  value: "m/44'/200625'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -141,7 +146,8 @@ export const DPaths: DPath[] = [
   GO_DEFAULT,
   EOSC_DEFAULT,
   ESN_DEFAULT,
-  AQUA_DEFAULT
+  AQUA_DEFAULT,
+  AKA_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "AQUA",
+      "AKA",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -28,7 +28,8 @@ import {
   GO_DEFAULT,
   EOSC_DEFAULT,
   ESN_DEFAULT,
-  AQUA_DEFAULT
+  AQUA_DEFAULT,
+  AKA_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -569,6 +570,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       min: 0.1,
       max: 10,
       initial: 0.1
+    }
+  },
+  AKA: {
+    id: 'AKA',
+    name: 'Akroma',
+    unit: 'AKA',
+    chainId: 200625,
+    isCustom: false,
+    color: '#aa0087',
+    blockExplorer: makeExplorer({
+      name: 'Akroma Explorer',
+      origin: 'https://akroma.io/explorer'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: AKA_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: AKA_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: AKA_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
     }
   }
 };

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -241,6 +241,21 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'uncan.onical.org',
       url: 'https://c.onical.org'
     }
+  ],
+
+  AKA: [
+    {
+      name: makeNodeName('AKA', 'remote.akroma.io'),
+      type: 'rpc',
+      service: 'remote.akroma.io',
+      url: 'https://remote.akroma.io'
+    },
+    {
+      name: makeNodeName('AKA', 'rpc.akroma.io'),
+      type: 'rpc',
+      service: 'rpc.akroma.io',
+      url: 'https://rpc.akroma.io'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -21,7 +21,8 @@ type StaticNetworkIds =
   | 'GO_TESTNET'
   | 'EOSC'
   | 'ESN'
-  | 'AQUA';
+  | 'AQUA'
+  | 'AKA';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
Closes #2157

### Add support for the Akroma Network

    bitcointalk ANN    : https://bitcointalk.org/index.php?topic=2844280.0
    homepage           : https://akroma.io
    block explorer     : https://akroma.io/explorer
    network statistics : http://stats.akroma.io
    slip0044 index     : 200625
    chainId            : 200625

[Akroma (AKA) is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

The official Ledger Nano S Akroma application was released last week:
[![ledger announcement tweet](https://pbs.twimg.com/media/DmQUzLaW4AAwnI7.jpg:large)](https://twitter.com/LedgerHQ/status/1036976685579685894)

### Screenshots

![screenshot from 2018-09-10 21-20-15-mycrypto-aka-select-address](https://user-images.githubusercontent.com/1062488/45332742-66adca00-b540-11e8-9c31-a3d6c6fae551.png)

cc: @detroitpro
cc: @akroma-project