### PR TITLE
Added CARD token address

### DIFF
--- a/common/config/tokens/eth.json
+++ b/common/config/tokens/eth.json
@@ -135,6 +135,11 @@
     "decimal": 18
   },
   {
+    "address": "0x954b890704693af242613edef1b603825afcd708",
+    "symbol": "CARD",
+    "decimal": 18
+  },
+  {
     "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
     "symbol": "PLU",
     "decimal": 18


### PR DESCRIPTION
Adding CARD token.

Website: https://cardstack.com
ENS: `cardstack.eth`
Medium: https://medium.com/cardstack
Telegram: http://t.me/cardstack
Twitter: https://twitter.com/cardstack
GitHub: https://github.com/cardstack
Blog post discussing our recent token upgrade: https://cardstack.com/zos-upgrade

Thanks!