### PR TITLE
Remove (X) button when changing wallets

### DIFF
--- a/common/components/ui/UnlockHeader.scss
+++ b/common/components/ui/UnlockHeader.scss
@@ -14,26 +14,4 @@
       padding-right: 8px;
     }
   }
-
-  &-close {
-    @include reset-button;
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    margin: 0.5rem 1rem;
-    z-index: 1;
-    line-height: 24px;
-    font-size: 24px;
-    transition: opacity 120ms;
-    opacity: 0.3;
-
-    > img {
-      height: 26px;
-      width: 26px;
-    }
-
-    &:hover {
-      opacity: 0.87;
-    }
-  }
 }

--- a/common/components/ui/UnlockHeader.tsx
+++ b/common/components/ui/UnlockHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import translate from 'translations';
 import { IWallet } from 'libs/wallet/IWallet';
@@ -7,7 +8,7 @@ import { AppState } from 'features/reducers';
 import WalletDecrypt, { DisabledWallets } from 'components/WalletDecrypt';
 import './UnlockHeader.scss';
 
-interface Props {
+interface OwnProps {
   title?: string;
   wallet: IWallet;
   disabledWallets?: DisabledWallets;
@@ -18,6 +19,7 @@ interface State {
   isExpanded: boolean;
 }
 
+type Props = OwnProps & RouteComponentProps<{}>;
 export class UnlockHeader extends React.PureComponent<Props, State> {
   public state = {
     isExpanded: !this.props.wallet
@@ -30,7 +32,7 @@ export class UnlockHeader extends React.PureComponent<Props, State> {
   }
 
   public render() {
-    const { title, wallet, disabledWallets, showGenerateLink } = this.props;
+    const { title, wallet, disabledWallets, showGenerateLink, history } = this.props;
     const { isExpanded } = this.state;
 
     return (
@@ -40,7 +42,7 @@ export class UnlockHeader extends React.PureComponent<Props, State> {
           !isExpanded && (
             <button
               className="UnlockHeader-open btn btn-default btn-smr"
-              onClick={this.toggleisExpanded}
+              onClick={() => history.push('/')}
             >
               <span>
                 <span className="hidden-xs UnlockHeader-open-text">
@@ -58,12 +60,6 @@ export class UnlockHeader extends React.PureComponent<Props, State> {
       </article>
     );
   }
-
-  public toggleisExpanded = (_: React.FormEvent<HTMLButtonElement>) => {
-    this.setState(state => {
-      return { isExpanded: !state.isExpanded };
-    });
-  };
 }
 
 function mapStateToProps(state: AppState) {
@@ -72,4 +68,4 @@ function mapStateToProps(state: AppState) {
   };
 }
 
-export default connect(mapStateToProps)(UnlockHeader);
+export default withRouter(connect(mapStateToProps)(UnlockHeader));

--- a/common/components/ui/UnlockHeader.tsx
+++ b/common/components/ui/UnlockHeader.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import translate from 'translations';
 import { IWallet } from 'libs/wallet/IWallet';
 import { AppState } from 'features/reducers';
-import closeIcon from 'assets/images/close.svg';
 import WalletDecrypt, { DisabledWallets } from 'components/WalletDecrypt';
 import './UnlockHeader.scss';
 
@@ -49,12 +48,6 @@ export class UnlockHeader extends React.PureComponent<Props, State> {
                 </span>
                 <i className="fa fa-refresh" />
               </span>
-            </button>
-          )}
-        {wallet &&
-          isExpanded && (
-            <button className="UnlockHeader-close" onClick={this.toggleisExpanded}>
-              <img src={closeIcon} alt="close" />
             </button>
           )}
         <WalletDecrypt


### PR DESCRIPTION
### Description

Removes unnecessary (X) button on the wallet selection screen after a user clicks "Change Wallet". Users should not be able to log back in without first going through the proper method.

### Changes

* Removed the (X) button from UnlockHeader.tsx
* Removed styles for the (X) button since they aren't being used anywhere else

### Steps to Test

1. Login with the wallet of your choice
2. Click change wallet
3. The (X) button should be gone

### Screenshots

*Before*
![image](https://user-images.githubusercontent.com/434238/45447869-e3ef5100-b69e-11e8-8ce1-b259572a6339.png)

*After*
![image](https://user-images.githubusercontent.com/434238/45447910-fe292f00-b69e-11e8-9414-5ac8191679c7.png)
