### PR TITLE
Add Pirl

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -123,6 +123,11 @@ export const AKA_DEFAULT: DPath = {
   value: "m/44'/200625'/0'/0"
 };
 
+export const PIRL_DEFAULT: DPath = {
+  label: 'Default (PIRL)',
+  value: "m/44'/164'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -147,7 +152,8 @@ export const DPaths: DPath[] = [
   EOSC_DEFAULT,
   ESN_DEFAULT,
   AQUA_DEFAULT,
-  AKA_DEFAULT
+  AKA_DEFAULT,
+  PIRL_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "AKA",
+      "PIRL",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -29,7 +29,8 @@ import {
   EOSC_DEFAULT,
   ESN_DEFAULT,
   AQUA_DEFAULT,
-  AKA_DEFAULT
+  AKA_DEFAULT,
+  PIRL_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -589,6 +590,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       [SecureWalletName.TREZOR]: AKA_DEFAULT,
       [SecureWalletName.LEDGER_NANO_S]: AKA_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: AKA_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  PIRL: {
+    id: 'PIRL',
+    name: 'Pirl',
+    unit: 'PIRL',
+    chainId: 3125659152,
+    isCustom: false,
+    color: '#a2d729',
+    blockExplorer: makeExplorer({
+      name: 'Poseidon Explorer',
+      origin: 'https://poseidon.pirl.io/explorer'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: PIRL_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: PIRL_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: PIRL_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -256,6 +256,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'rpc.akroma.io',
       url: 'https://rpc.akroma.io'
     }
+  ],
+
+  PIRL: [
+    {
+      name: makeNodeName('PIRL', 'wallrpc.pirl.io'),
+      type: 'rpc',
+      service: 'wallrpc.pirl.io',
+      url: 'https://wallrpc.pirl.io'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -22,7 +22,8 @@ type StaticNetworkIds =
   | 'EOSC'
   | 'ESN'
   | 'AQUA'
-  | 'AKA';
+  | 'AKA'
+  | 'PIRL';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
Closes #2164 

### Add support for Pirl

    bitcointalk ANN    : https://bitcointalk.org/index.php?topic=2120193.0
    homepage           : https://pirl.io
    block explorer     : https://explorer.pirl.io
                         https://poseidon.pirl.io/explorer
    network statistics : http://stats.pirl.io
    slip0044 index     : 164
    chainId            : 3125659152

Dependencies needed for full 32bit chain ID support: (already merged - thank you!)
Ledger support: https://github.com/MyCryptoHQ/MyCrypto/pull/2094 (merged)
Trezor support: https://github.com/MyCryptoHQ/MyCrypto/pull/2148 (merged)

The official Ledger Nano S Pirl application was released last week:
[![ledger announcement tweet](https://pbs.twimg.com/media/DmQUzLaW4AAwnI7.jpg:large)](https://twitter.com/LedgerHQ/status/1036976685579685894)

### Screenshots
![screenshot from 2018-09-10 22-04-23-mycrypto-pirl-select-address](https://user-images.githubusercontent.com/1062488/45579437-8b15e900-b855-11e8-83a1-bcdf484e4bd9.png)


![screenshot from 2018-09-10 22-06-43-mycrypto-pirl-tx-broadcast](https://user-images.githubusercontent.com/1062488/45579442-923cf700-b855-11e8-80b4-2b8eed9f684f.png)


