### PR TITLE
Add support for Atheios

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -128,6 +128,11 @@ export const PIRL_DEFAULT: DPath = {
   value: "m/44'/164'/0'/0"
 };
 
+export const ATH_DEFAULT: DPath = {
+  label: 'Default (ATH)',
+  value: "m/44'/1620'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -153,7 +158,8 @@ export const DPaths: DPath[] = [
   ESN_DEFAULT,
   AQUA_DEFAULT,
   AKA_DEFAULT,
-  PIRL_DEFAULT
+  PIRL_DEFAULT,
+  ATH_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "PIRL",
+      "ATH",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -30,7 +30,8 @@ import {
   ESN_DEFAULT,
   AQUA_DEFAULT,
   AKA_DEFAULT,
-  PIRL_DEFAULT
+  PIRL_DEFAULT,
+  ATH_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -614,6 +615,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       [SecureWalletName.TREZOR]: PIRL_DEFAULT,
       [SecureWalletName.LEDGER_NANO_S]: PIRL_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: PIRL_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  ATH: {
+    id: 'ATH',
+    name: 'Atheios',
+    unit: 'ATH',
+    chainId: 1620,
+    isCustom: false,
+    color: '#0093c5',
+    blockExplorer: makeExplorer({
+      name: 'Atheios Explorer',
+      origin: 'https://explorer.atheios.com'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ATH_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: ATH_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ATH_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -265,6 +265,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'wallrpc.pirl.io',
       url: 'https://wallrpc.pirl.io'
     }
+  ],
+
+  ATH: [
+    {
+      name: makeNodeName('ATH', 'wallet.atheios.com'),
+      type: 'rpc',
+      service: 'wallet.atheios.com',
+      url: 'https://wallet.atheios.com:8797'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -23,7 +23,8 @@ type StaticNetworkIds =
   | 'ESN'
   | 'AQUA'
   | 'AKA'
-  | 'PIRL';
+  | 'PIRL'
+  | 'ATH';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
Closes #2166

    homepage : https://atheios.com
    block explorer : http://explorer.atheios.com | https://scan.atheios.com
    network statistics : http://stats.atheios.com
    slip0044 index : 1620
    chainId : 1620

[Atheios is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

Atheios support has been merged to LedgerHQ's official repository:
https://github.com/LedgerHQ/ledger-app-eth/pull/31 (merged)

Atheios is on LedgerHQ's official roadmap:
https://trello.com/c/bZOQq2ho/121-atheios-support

### Screenshots
![image](https://user-images.githubusercontent.com/1062488/45580425-f31cfd00-b85e-11e8-8fa5-6c18d61c768b.png)

![image](https://user-images.githubusercontent.com/1062488/45580460-35ded500-b85f-11e8-9b72-8173fcacd904.png)

![image](https://user-images.githubusercontent.com/1062488/45580475-60309280-b85f-11e8-9b14-ce85aa12c085.png)

cc: @atheioschain
cc: @atheios-berran
