### PR TITLE
Enable Ledger Nano S support for Callisto

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -382,6 +382,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: CLO_DEFAULT,
       [SecureWalletName.SAFE_T]: CLO_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: CLO_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: CLO_DEFAULT
     },
     gasPriceSettings: {


### PR DESCRIPTION
Closes #2168

    homepage           : https://callisto.network
    block explorer     : https://explorer.callisto.network
    network statistics : https://stats.callisto.network
    slip0044 index     : 820
    chainId            : 820

[Callisto is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

Callisto support has been merged to LedgerHQ's official repository:
https://github.com/LedgerHQ/ledger-app-eth/pull/22 (merged)

Callisto is on LedgerHQ's official roadmap:
https://trello.com/c/AawiAoSM/116-callisto-support

### Screenshots
![image](https://user-images.githubusercontent.com/1062488/45581890-7c8afa00-b874-11e8-9b75-3c8c49b7f3f3.png)

cc: @yograterol