### PR TITLE
Enable Ledger Nano S support for GoChain

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -463,6 +463,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: GO_DEFAULT,
       [SecureWalletName.SAFE_T]: GO_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: GO_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: GO_DEFAULT
     },
     gasPriceSettings: {


### PR DESCRIPTION
Closes #2170

    homepage: https://gochain.io
    block explorer: https://explorer.gochain.io
    network statistics : https://stats.gochain.io
    slip0044 index : 6060
    chain ID: 60

[GoChain is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

GoChain support has been merged to LedgerHQ's official repository:
https://github.com/LedgerHQ/ledger-app-eth/pull/35 (merged)

GoChain is on LedgerHQ's official roadmap:
https://trello.com/c/HsdFkh52/123-gochain-support

### Screenshots
![image](https://user-images.githubusercontent.com/1062488/45582036-0936b780-b877-11e8-8d50-3bc5234d7002.png)

cc: @gochain-io