### PR TITLE
Enable Ledger Nano S support for EtherGem

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -357,6 +357,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: EGEM_DEFAULT,
       [SecureWalletName.SAFE_T]: EGEM_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: EGEM_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: EGEM_DEFAULT
     },
     gasPriceSettings: {


### PR DESCRIPTION
Closes #2172

    homepage : https://egem.io
    block explorer : https://explorer.egem.io
    network statistics : https://network.egem.io
    slip0044 index : 1987
    chainId : 1987

[EtherGem (EGEM) is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

EtherGem (EGEM) support has been merged to LedgerHQ's official repository:
https://github.com/LedgerHQ/ledger-app-eth/pull/28 (merged)

EtherGem (EGEM) is on LedgerHQ's official roadmap:
https://trello.com/c/lGIfDKq1/120-ethergem-support

### Screenshots
![image](https://user-images.githubusercontent.com/1062488/45582196-b5799d80-b879-11e8-9418-20acf7a941bc.png)

cc: @TeamEGEM