### PR TITLE
Enable Ledger Nano S support for Musicoin

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -307,6 +307,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: MUSIC_DEFAULT,
       [SecureWalletName.SAFE_T]: MUSIC_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: MUSIC_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: MUSIC_DEFAULT
     },
     gasPriceSettings: {


### PR DESCRIPTION
Closes #2174

    homepage           : https://musicoin.org
    block explorer     : https://explorer.musicoin.org
    slip0044 index     : 184
    chainId            : 7762959

[Musicoin is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

Musicoin support has been merged to LedgerHQ's official repository:
https://github.com/LedgerHQ/ledger-app-eth/pull/20 (merged)

Musicoin is on LedgerHQ's official roadmap:
https://trello.com/c/a3YFOxx1/114-musicoin-support

### Screenshots
![image](https://user-images.githubusercontent.com/1062488/45582371-81ec4280-b87c-11e8-9d03-f66886825142.png)
