### PR TITLE
Enable Ledger Nano S support for Callisto, Musicoin, EtherGem & GoChain

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -382,6 +382,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: CLO_DEFAULT,
       [SecureWalletName.SAFE_T]: CLO_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: CLO_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: CLO_DEFAULT
     },
     gasPriceSettings: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -307,6 +307,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: MUSIC_DEFAULT,
       [SecureWalletName.SAFE_T]: MUSIC_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: MUSIC_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: MUSIC_DEFAULT
     },
     gasPriceSettings: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -466,6 +466,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: GO_DEFAULT,
       [SecureWalletName.SAFE_T]: GO_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: GO_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: GO_DEFAULT
     },
     gasPriceSettings: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -358,6 +358,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: EGEM_DEFAULT,
       [SecureWalletName.SAFE_T]: EGEM_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: EGEM_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: EGEM_DEFAULT
     },
     gasPriceSettings: {


### PR DESCRIPTION
Closes #2168 
Closes #2170 
Closes #2172 
Closes #2174 

This was originally sent as individual pull requests, but, as requested, I am resending them now all at once.

* Enable Ledger Nano S support for Callisto
* Enable Ledger Nano S support for Musicoin
* Enable Ledger Nano S support for EtherGem
* Enable Ledger Nano S support for GoChain

This pull request supercedes #2169 , #2171 , #2173 and #2175 -- Please refer to those individual pull requests for the corresponding screenshots.

Merging this PR also:
Closes #2169 
Closes #2171 
Closes #2173 
Closes #2175 