### PR TITLE
Bug/Disable transaction send on wallet load

### DIFF
--- a/common/components/SendButtonFactory/SendButtonFactory.tsx
+++ b/common/components/SendButtonFactory/SendButtonFactory.tsx
@@ -62,7 +62,11 @@ export class SendButtonFactoryClass extends Component<Props> {
           withOnClick={({ openModal, signer }) =>
             this.props.withProps({
               disabled: signing
-                ? networkRequestPending || !validGasPrice || !validGasLimit || balance.isPending
+                ? !isFullTransaction ||
+                  networkRequestPending ||
+                  !validGasPrice ||
+                  !validGasLimit ||
+                  balance.isPending
                 : !!(signing && !serializedTransaction),
               signTx: () => signer(transaction),
               openModal

--- a/common/components/SendButtonFactory/SendButtonFactory.tsx
+++ b/common/components/SendButtonFactory/SendButtonFactory.tsx
@@ -5,6 +5,7 @@ import EthTx from 'ethereumjs-tx';
 import { AppState } from 'features/reducers';
 import * as derivedSelectors from 'features/selectors';
 import { walletSelectors } from 'features/wallet';
+import { Balance } from 'libs/wallet';
 import {
   transactionNetworkSelectors,
   transactionSignSelectors,
@@ -31,6 +32,7 @@ interface StateProps {
 }
 
 interface OwnProps {
+  balance: Balance;
   onlyTransactionParameters?: boolean;
   signing?: boolean;
   Modal: typeof ConfirmationModal;
@@ -49,7 +51,8 @@ export class SendButtonFactoryClass extends Component<Props> {
       serializedTransaction,
       networkRequestPending,
       validGasPrice,
-      validGasLimit
+      validGasLimit,
+      balance
     } = this.props;
 
     // return signing ? true : signedTx ? true : false
@@ -59,7 +62,7 @@ export class SendButtonFactoryClass extends Component<Props> {
           withOnClick={({ openModal, signer }) =>
             this.props.withProps({
               disabled: signing
-                ? !isFullTransaction || networkRequestPending || !validGasPrice || !validGasLimit
+                ? networkRequestPending || !validGasPrice || !validGasLimit || balance.isPending
                 : !!(signing && !serializedTransaction),
               signTx: () => signer(transaction),
               openModal
@@ -74,6 +77,7 @@ export class SendButtonFactoryClass extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => {
   return {
+    balance: state.wallet.balance,
     walletType: walletSelectors.getWalletType(state),
     serializedTransaction: derivedSelectors.getSerializedTransaction(state),
     ...derivedSelectors.getTransaction(state),

--- a/common/containers/Tabs/ScheduleTransaction/components/SendScheduleTransactionButtonFactory.tsx
+++ b/common/containers/Tabs/ScheduleTransaction/components/SendScheduleTransactionButtonFactory.tsx
@@ -12,6 +12,7 @@ import { SendButtonFactoryClass } from 'components/SendButtonFactory';
 
 const mapStateToProps = (state: AppState) => {
   return {
+    balance: state.wallet.balance,
     walletType: walletSelectors.getWalletType(state),
     serializedTransaction: derivedSelectors.getSerializedTransaction(state),
     ...derivedSelectors.getSchedulingTransaction(state),


### PR DESCRIPTION




### Disables the transaction button from sending when a wallet is still loading

When a wallet is still loading, the user should no longer be able to click "Send Transaction".

### Changes

* Added the balance prop to `SendButtonFactory.tsx` so that it can access `balance.isPending`
* Modified the transaction send disable code to include a check to see if the balance is pending
* Added the balance to `SendScheduleTransactionButtonFactoryprops` to fix a TypeScript error that appeared because of the previous changes

### Steps to Test

1. Prepare a transaction and click the wallet refresh button

### Screenshots

![image](https://user-images.githubusercontent.com/434238/45723998-2bd01580-bb82-11e8-8aaa-d8464d96c779.png)

