### PR TITLE
Fix ENS subdomain resolution

### DIFF
--- a/common/features/transaction/sagas.spec.ts
+++ b/common/features/transaction/sagas.spec.ts
@@ -66,7 +66,6 @@ describe('transaction: Sagas', () => {
       describe('with invalid Ethereum address, valid ENS address', () => {
         const raw = 'testing.eth';
         const resolvedAddress = '0xa';
-        const [domain] = raw.split('.');
         const ensAddrPayload = {
           raw,
           value: null
@@ -96,7 +95,7 @@ describe('transaction: Sagas', () => {
 
         it('should put resolveDomainRequested', () => {
           expect(data.validEnsGen.next().value).toEqual(
-            put(ensActions.resolveDomainRequested(domain))
+            put(ensActions.resolveDomainRequested(raw))
           );
         });
 

--- a/common/features/transaction/sagas.ts
+++ b/common/features/transaction/sagas.ts
@@ -52,8 +52,7 @@ export function* setCurrentToSaga({ payload: raw }: types.SetCurrentToAction): S
   } else if (validEns) {
     yield call(setField, { value, raw });
 
-    const [domain] = raw.split('.');
-    yield put(ensActions.resolveDomainRequested(domain));
+    yield put(ensActions.resolveDomainRequested(raw));
     yield take([
       ensTypes.ENSActions.RESOLVE_DOMAIN_FAILED,
       ensTypes.ENSActions.RESOLVE_DOMAIN_SUCCEEDED,

--- a/common/libs/ens/index.ts
+++ b/common/libs/ens/index.ts
@@ -9,6 +9,17 @@ export function normalise(name: string): string {
   }
 }
 
+export const extractDomain = (fullDomain: string): string => {
+  const labels = fullDomain.split('.');
+  if (labels.length === 0) {
+    return '';
+  } else if (labels.length === 1) {
+    return labels[0];
+  } else {
+    return labels[labels.length - 2];
+  }
+};
+
 export const getNameHash = (name: string = ''): string => {
   if (name === '') {
     throw new Error('Empty string provided');


### PR DESCRIPTION
Closes #1977 

### Description

As of now, the ENS resolution process doesn't work for subdomains (e.g. "wallet.mydomain.eth"). This PR aims to solve this issue.

Additionally, the changes allow new tlds to be added (e.g. [.xyz](https://medium.com/the-ethereum-name-service/announcing-support-for-xyz-on-ens-7f5bc7fe1b24)), since resolution is no longer forced under the `.eth` tld.

### Changes

Don't split the input address into `{name}.{tld}` in `/transaction/sagas.ts` and leave it to `/ens/sagas.ts`. This change also removes the hardcoded `.eth` used for the resolution process.

Add an auxiliary function to extract the domain from the address to perform the auction status check with.

### Steps to Test

1. Go to `account/send`
2. Type `fantastique.eth` (or any other known domain) in the address input. It should resolve to an address.
3. Type `wallet.etherbase.eth` (or any other known subdomain) in the address input. It should resolve to an address.

### Screenshots

![domain_resolution](https://user-images.githubusercontent.com/11276821/46222890-20ba7980-c328-11e8-8476-ad351f3f6a1e.png)

![subdomain_resolution](https://user-images.githubusercontent.com/11276821/46222894-24e69700-c328-11e8-884d-dacb78806bf2.png)
