### PR TITLE
Add Ether-1 (ETHO)

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -133,6 +133,11 @@ export const ATH_DEFAULT: DPath = {
   value: "m/44'/1620'/0'/0"
 };
 
+export const ETHO_DEFAULT: DPath = {
+  label: 'Default (ETHO)',
+  value: "m/44'/1313114'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -159,7 +164,8 @@ export const DPaths: DPath[] = [
   AQUA_DEFAULT,
   AKA_DEFAULT,
   PIRL_DEFAULT,
-  ATH_DEFAULT
+  ATH_DEFAULT,
+  ETHO_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ATH",
+      "ETHO",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -31,7 +31,8 @@ import {
   AQUA_DEFAULT,
   AKA_DEFAULT,
   PIRL_DEFAULT,
-  ATH_DEFAULT
+  ATH_DEFAULT,
+  ETHO_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -639,6 +640,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       [SecureWalletName.TREZOR]: ATH_DEFAULT,
       [SecureWalletName.LEDGER_NANO_S]: ATH_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: ATH_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  ETHO: {
+    id: 'ETHO',
+    name: 'Ether-1',
+    unit: 'ETHO',
+    chainId: 1313114,
+    isCustom: false,
+    color: '#7a1336',
+    blockExplorer: makeExplorer({
+      name: 'Ether-1 Explorer',
+      origin: 'https://explorer.ether1.org'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETHO_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: ETHO_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETHO_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -274,6 +274,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'wallet.atheios.com',
       url: 'https://wallet.atheios.com:8797'
     }
+  ],
+
+  ETHO: [
+    {
+      name: makeNodeName('ETHO', 'ether1.org'),
+      type: 'rpc',
+      service: 'ether1.org',
+      url: 'https://rpc.ether1.org'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -24,7 +24,8 @@ type StaticNetworkIds =
   | 'AQUA'
   | 'AKA'
   | 'PIRL'
-  | 'ATH';
+  | 'ATH'
+  | 'ETHO';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
Closes #2189

    homepage : https://ether1.org
    block explorer : https://explorer.ether1.org
    network statistics : https://stats.ether1.org
    slip0044 index : 1313114 - satoshilabs/slips#338 (merged)
    chainId : 1313114

[Ether-1 (ETHO) is supported in Trezor ONE firmware version 1.6.3](https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d)

Ether-1 (ETHO) support has been merged to LedgerHQ's official repository:
LedgerHQ/ledger-app-eth#26 (merged)

Ether-1 (ETHO) is on LedgerHQ's official roadmap:
https://trello.com/c/06fhw7Uc/119-ether-1-support

### Screenshots

![image](https://user-images.githubusercontent.com/1062488/46245075-5443e500-c3b6-11e8-8a1c-a7b5b977ba7b.png)
![image](https://user-images.githubusercontent.com/1062488/46245096-9f5df800-c3b6-11e8-8ee4-21fa229809b2.png)
![image](https://user-images.githubusercontent.com/1062488/46245109-ce746980-c3b6-11e8-88bb-6e017d183bfb.png)
