### PR TITLE
Update Akroma (AKA) explorer link

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -588,7 +588,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     color: '#aa0087',
     blockExplorer: makeExplorer({
       name: 'Akroma Explorer',
-      origin: 'https://akroma.io/explorer'
+      origin: 'https://explorer.akroma.io'
     }),
     tokens: [],
     contracts: [],


### PR DESCRIPTION
Akroma has moved it's explorer from akroma.io/explorer to explorer.akroma.io

This updates the web wallet link accordingly

cc: @detroitpro
cc: @akroma-project