### PR TITLE
Add MIX Blockchain

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -138,6 +138,11 @@ export const ETHO_DEFAULT: DPath = {
   value: "m/44'/1313114'/0'/0"
 };
 
+export const MIX_DEFAULT: DPath = {
+  label: 'Default (MIX)',
+  value: "m/44'/76'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -165,7 +170,8 @@ export const DPaths: DPath[] = [
   AKA_DEFAULT,
   PIRL_DEFAULT,
   ATH_DEFAULT,
-  ETHO_DEFAULT
+  ETHO_DEFAULT,
+  MIX_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ETHO",
+      "MIX",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -32,7 +32,8 @@ import {
   AKA_DEFAULT,
   PIRL_DEFAULT,
   ATH_DEFAULT,
-  ETHO_DEFAULT
+  ETHO_DEFAULT,
+  MIX_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -668,6 +669,29 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       [SecureWalletName.TREZOR]: ETHO_DEFAULT,
       [SecureWalletName.LEDGER_NANO_S]: ETHO_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: ETHO_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
+      initial: 20
+    }
+  },
+  MIX: {
+    id: 'MIX',
+    name: 'Mix',
+    unit: 'MIX',
+    chainId: 76,
+    isCustom: false,
+    color: '#e59b2b',
+    blockExplorer: makeExplorer({
+      name: 'MIX Blockchain Explorer',
+      origin: 'https://blocks.mix-blockchain.org'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.LEDGER_NANO_S]: MIX_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: MIX_DEFAULT
     },
     gasPriceSettings: {
       min: 1,

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -283,6 +283,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'ether1.org',
       url: 'https://rpc.ether1.org'
     }
+  ],
+
+  MIX: [
+    {
+      name: makeNodeName('MIX', 'mix-blockchain.org'),
+      type: 'rpc',
+      service: 'rpc2.mix-blockchain.org',
+      url: 'https://rpc2.mix-blockchain.org:8647'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -25,7 +25,8 @@ type StaticNetworkIds =
   | 'AKA'
   | 'PIRL'
   | 'ATH'
-  | 'ETHO';
+  | 'ETHO'
+  | 'MIX';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
Closes #2208

Add support for MIX Blockchain (MIX)

    homepage:           https://www.mix-blockchain.org
    block explorer:     https://blocks.mix-blockchain.org
    network statistics: https://stats.mix-blockchain.org
    slip0044 index:     76
    chain ID:           76

Ledger Nano S MIX app: (merged)
https://github.com/LedgerHQ/ledger-app-eth/pull/38

MIX Blockchain (MIX) is now on LedgerHQ's official roadmap:
https://trello.com/c/pDKJ5jZ9/127-mix-support

cc: @ethernomad
cc: @mix-blockchain