### PR TITLE
Prevent flooding of sign message button

### DIFF
--- a/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/SignButton.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/SignButton.tsx
@@ -6,12 +6,18 @@ import { messageActions } from 'features/message';
 interface Props {
   message: string;
   signMessageRequested: messageActions.TSignMessageRequested;
+  signing: boolean;
 }
 
 export default class SignMessageButton extends React.Component<Props, {}> {
   public render() {
+    const { signing } = this.props;
     return (
-      <button className="SignMessage-sign btn btn-primary btn-lg" onClick={this.handleSignMessage}>
+      <button
+        className="SignMessage-sign btn btn-primary btn-lg"
+        onClick={this.handleSignMessage}
+        disabled={signing}
+      >
         {translate('NAV_SIGNMSG')}
       </button>
     );

--- a/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/index.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/index.tsx
@@ -17,6 +17,7 @@ interface Props {
   unlocked: boolean;
   signMessageRequested: messageActions.TSignMessageRequested;
   signedMessage: ISignedMessage | null;
+  signing: boolean;
   resetWallet: walletActions.TResetWallet;
   resetMessage: messageActions.TResetMessage;
 }
@@ -72,6 +73,7 @@ export class SignMessage extends Component<Props, State> {
             <SignButton
               message={this.state.message}
               signMessageRequested={this.props.signMessageRequested}
+              signing={this.props.signing}
             />
 
             {signedMessage && (
@@ -106,6 +108,7 @@ export class SignMessage extends Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   signedMessage: state.message.signed,
+  signing: state.message.signing,
   unlocked: walletSelectors.isWalletFullyUnlocked(state)
 });
 

--- a/common/features/message/reducer.ts
+++ b/common/features/message/reducer.ts
@@ -1,8 +1,16 @@
 import * as types from './types';
 
 export const INITIAL_STATE: types.MessageState = {
-  signed: null
+  signed: null,
+  signing: false
 };
+
+function signMessageRequested(state: types.MessageState): types.MessageState {
+  return {
+    ...state,
+    signing: true
+  };
+}
 
 function signLocalMessageSucceeded(
   state: types.MessageState,
@@ -10,14 +18,16 @@ function signLocalMessageSucceeded(
 ): types.MessageState {
   return {
     ...state,
-    signed: action.payload
+    signed: action.payload,
+    signing: false
   };
 }
 
 function signMessageFailed(state: types.MessageState): types.MessageState {
   return {
     ...state,
-    signed: null
+    signed: null,
+    signing: false
   };
 }
 
@@ -32,6 +42,8 @@ export function messageReducer(
   action: types.MessageAction
 ): types.MessageState {
   switch (action.type) {
+    case types.MessageActions.SIGN_REQUESTED:
+      return signMessageRequested(state);
     case types.MessageActions.SIGN_LOCAL_SUCCEEDED:
       return signLocalMessageSucceeded(state, action);
     case types.MessageActions.SIGN_FAILED:

--- a/common/features/message/types.ts
+++ b/common/features/message/types.ts
@@ -9,6 +9,7 @@ export enum MessageActions {
 
 export interface MessageState {
   signed?: ISignedMessage | null;
+  signing: boolean;
 }
 
 export interface SignMessageRequestedAction {


### PR DESCRIPTION
Closes CORE-47

### Prevent flood signing a message

You can flood click “sign message” and each click will commence a verification to accept on Ledger. This should not be allowed.

All the “clicks” that weren’t verified then get spammed as error.

### Changes

* Added a `signing` property to the application state to detect when a message is currently in the process of being signed
* Disabled the sing button when `signing` is `true`

### Steps to Test

1. Sign a message
2. Attempt to sign another message while a signing is in progress

### Screenshots
**Before Signing** button is active
![image](https://user-images.githubusercontent.com/434238/47035192-69a36800-d147-11e8-82ab-f21b40853e10.png)
**During Signing** button is disabled while wallet attempts to sign
![image](https://user-images.githubusercontent.com/434238/47035279-98b9d980-d147-11e8-9276-49147bf3b26a.png)



