### PR TITLE
Change EOSC Chainid

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -508,7 +508,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     id: 'EOSC',
     name: 'EOS Classic',
     unit: 'EOSC',
-    chainId: 20,
+    chainId: 2018,
     isCustom: false,
     color: '#926565',
     blockExplorer: makeExplorer({


### PR DESCRIPTION
EOS Classic is going to swtich the mainnet according to this announcement

https://medium.com/@eoscio/closing-pre-mainnet-and-mainnet-upgrade-announcement-3c0b9ac8912a

Chainid value will be changed to 2018

Other value will remain the same