### PR TITLE
Update POA Core explorer to BlockScout

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -221,10 +221,10 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     isCustom: false,
     color: '#6d2eae',
     blockExplorer: makeExplorer({
-      name: 'POA Explorer',
-      origin: 'https://poaexplorer.com',
-      addressPath: 'address/search',
-      blockPath: 'blocks/block'
+      name: 'BlockScout',
+      origin: 'https://blockscout.com/poa/core',
+      addressPath: 'address',
+      blockPath: 'blocks'
     }),
     tokens: [],
     contracts: [],


### PR DESCRIPTION
Closes #2223

### Description
POA Network has been developing an open source EVM explorer called BlockScout. Many networks are currently available on BlockScout including POA, ETH, ETC, and many testnets. This PR replaces poaexplorer.com with blockscout.com

### Changes

* The name of the POA explorer to `BlockScout`
* The url to `https://blockscout.com/poa/core`
* The `addressPath` to `address`
* The `blockPath` to `blocks`

### Steps to Test

1. View the homepage of BlockScout `https://blockscout.com/poa/core`
2. View the address page: https://blockscout.com/poa/core/address/0xa0821a7dba468d3ab3200f49a94fda7351dd31cb
3. View the blocks page: https://blockscout.com/poa/core/blocks/5289096

