### PR TITLE
Changes RSK testnet network name

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -427,7 +427,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
 
   RSK_TESTNET: {
     id: 'RSK_TESTNET',
-    name: 'RSK',
+    name: 'RSK Testnet',
     unit: 'SBTC',
     chainId: 31,
     color: '#58A052',


### PR DESCRIPTION
Closes #2230

### Description

Just changes RSK testnet name to avoid confusions.

### Changes

* Field `name` in `RSK_TESTNET` configuration

### Steps to Test

1. Expand Network & Node selection and validate that is listed `RSK` for mainnet and `RSK Testnet` for testnet.