### PR TITLE
Link to the correct block explorer in "Select an Address" "more" link

### DIFF
--- a/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
+++ b/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
@@ -280,6 +280,17 @@ class DeterministicWalletsModalClass extends React.PureComponent<Props, State> {
     const label = addressLabels[wallet.address.toLowerCase()];
     const spanClassName = label ? 'DWModal-addresses-table-address-text' : '';
 
+    let blockExplorer;
+    if (!network.isCustom) {
+      blockExplorer = network.blockExplorer;
+    } else {
+      blockExplorer = {
+        addressUrl: (address: string) => {
+          return `https://ethplorer.io/address/${address}`;
+        }
+      };
+    }
+
     // Get renderable values, but keep 'em short
     const token = desiredToken ? wallet.tokenValues[desiredToken] : null;
 
@@ -327,7 +338,7 @@ class DeterministicWalletsModalClass extends React.PureComponent<Props, State> {
         <td>
           <a
             target="_blank"
-            href={`https://ethplorer.io/address/${wallet.address}`}
+            href={blockExplorer.addressUrl(wallet.address)}
             rel="noopener noreferrer"
           >
             <i className="DWModal-addresses-table-more" />


### PR DESCRIPTION
Closes #2242 

I often use the "select an address" dialog box to take a quick glance across multiple wallets.  I noticed that the "more" link brings us to ethplorer, which isn't helpful for most chains.

### Link to the correct block explorer in "Select an Address" "more" link

The "more" link in "Select an Address" modal always uses ethplorer, rather than the provided block explorer for the given chain

Instead, use the provided block explorer.

Fall back to ethplorer if `network.isCustom`