### PR TITLE
Add EtherInc node

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -143,6 +143,11 @@ export const MIX_DEFAULT: DPath = {
   value: "m/44'/76'/0'/0"
 };
 
+export const ETI_DEFAULT: DPath = {
+  label: 'Default (ETI)',
+  value: "m/44'/60'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -171,7 +176,8 @@ export const DPaths: DPath[] = [
   PIRL_DEFAULT,
   ATH_DEFAULT,
   ETHO_DEFAULT,
-  MIX_DEFAULT
+  MIX_DEFAULT,
+  ETI_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -145,7 +145,7 @@ export const MIX_DEFAULT: DPath = {
 
 export const ETI_DEFAULT: DPath = {
   label: 'Default (ETI)',
-  value: "m/44'/60'/0'/0"
+  value: "m/44'/464'/0'/0"
 };
 
 export const DPaths: DPath[] = [

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "MIX",
+      "ETI",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -33,7 +33,8 @@ import {
   PIRL_DEFAULT,
   ATH_DEFAULT,
   ETHO_DEFAULT,
-  MIX_DEFAULT
+  MIX_DEFAULT,
+  ETI_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -696,6 +697,58 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     gasPriceSettings: {
       min: 1,
       max: 60,
+      initial: 20
+    }
+  },
+
+  ETI: {
+    id: 'ETI',
+    name: 'ETI',
+    unit: 'ETI',
+    chainId: 101,
+    isCustom: false,
+    color: '#3560bf',
+    blockExplorer: makeExplorer({
+      name: 'EtherInc Explorer',
+      origin: 'https://explorer.einc.io'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETI_DEFAULT,
+      [SecureWalletName.SAFE_T]: ETI_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: ETI_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETI_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 80,
+      initial: 20
+    }
+  },
+
+  ETI_TESTNET: {
+    id: 'ETI_TESTNET',
+    name: 'ETI',
+    unit: 'ETI',
+    chainId: 103,
+    isCustom: false,
+    color: '#3560bf',
+    blockExplorer: makeExplorer({
+      name: 'EtherInc Ropsten Explorer',
+      origin: 'https://ropstenexplorer.einc.io'
+    }),
+    tokens: [],
+    contracts: [],
+    isTestnet: true,
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETI_DEFAULT,
+      [SecureWalletName.SAFE_T]: ETI_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETI_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 80,
       initial: 20
     }
   }

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -292,6 +292,24 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'rpc2.mix-blockchain.org',
       url: 'https://rpc2.mix-blockchain.org:8647'
     }
+  ],
+
+  ETI: [
+    {
+      name: makeNodeName('ETI', 'eti'),
+      type: 'rpc',
+      service: 'api.einc.io',
+      url: 'https://api.einc.io/jsonrpc/mainnet/'
+    }
+  ],
+
+  ETI_TESTNET: [
+    {
+      name: makeNodeName('ETI_TESTNET', 'eti_testnet'),
+      type: 'rpc',
+      service: 'api.einc.io',
+      url: 'https://api.einc.io/jsonrpc/ropsten/'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -26,7 +26,9 @@ type StaticNetworkIds =
   | 'PIRL'
   | 'ATH'
   | 'ETHO'
-  | 'MIX';
+  | 'MIX'
+  | 'ETI'
+  | 'ETI_TESTNET';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
# Description
EtherInc is a fork of Ethereum to power the future of blockchain based organizations.

* Homepage: https://einc.io/
* Node: https://api.einc.io/jsonrpc/mainnet
* Explorer: https://explorer.einc.io/
* BIP44 / Chainid 101 ( satoshilabs/slips#438 )

# Changes
This PR adds EtherInc node support