### PR TITLE
Remove typescript unknown property error in common/spec/integration/d…

### DIFF
--- a/spec/integration/data.int.ts
+++ b/spec/integration/data.int.ts
@@ -61,9 +61,9 @@ function testRpcRequests(node: INode, service: string) {
 }
 
 const mapNodeEndpoints = (nodes: { [key: string]: StaticNodeConfig }) => {
-  const { INodes } = INodeTestConfig;
+  const { RpcNodes } = INodeTestConfig;
 
-  INodes.forEach((n: string) => {
+  RpcNodes.forEach((n: string) => {
     shepherd.manual(n, true);
     testRpcRequests(shepherdProvider, `${nodes[n].service} ${nodes[n].network}`);
   });


### PR DESCRIPTION
…ata.int.ts

LIne 64 and 66 Were referring to an incorrectly named object property from ./RpcNodeTestConfig.
INodes instead of the exported RpcNodes. I'm assuming that javascript was inferring that you meant RpcNodes but Typescript doesn't like that.

If you're contributing translations, please follow the contributor guidelines
at https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines#providing-translations

---

If you're contributing code, please link to the issue it resolves and follows the
contributor guidelines at https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributor-Guidelines#contributing-code and fill out the following template:

Closes #(issue number goes here)

### Description
(Description goes here)
I made my first commit to MyCrypto by fixing a typescript error that was not being found.
### Changes
See First Lines ^


### Steps to Test
npm run test
?

### Screenshots

(Only if applicable)
