### PR TITLE
Update Musicoin to use the correct registered BIP44 path

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -65,7 +65,7 @@ export const ELLA_DEFAULT: DPath = {
 
 export const MUSIC_DEFAULT: DPath = {
   label: 'Default (MUSIC)',
-  value: "m/44'/60'/0'/0"
+  value: "m/44'/184'/0'/0"
 };
 
 export const ETSC_DEFAULT: DPath = {


### PR DESCRIPTION
Closes #2252

The BIP44 HD derivation path for Musicoin on MyCrypto and MyEtherWallet disagree with each other.

MyEtherWallet uses the correct registered BIP44 path: `"m/44'/184'/0'/0"`
MyCrypto is currently using Ethereum's BIP44 path: `"m/44'/60'/0'/0"`

Update Musicoin to use the correct registered BIP44 path, `"m/44'/184'/0'/0"`, based on:
https://github.com/satoshilabs/slips/blame/71332b0/slip-0044.md#L215