### PR TITLE
RSK ticker: renaming SBTC with RBTC

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -400,7 +400,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
   RSK: {
     id: 'RSK',
     name: 'RSK',
-    unit: 'SBTC',
+    unit: 'RBTC',
     chainId: 30,
     color: '#58A052',
     isCustom: false,
@@ -428,7 +428,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
   RSK_TESTNET: {
     id: 'RSK_TESTNET',
     name: 'RSK',
-    unit: 'SBTC',
+    unit: 'RBTC',
     chainId: 31,
     color: '#58A052',
     isCustom: false,


### PR DESCRIPTION
### Description
It's a network configuration change.
RSK's ticker changed, the Smart BTC is known as RBTC.

### Changes
Replace SBTC with RBTC 