### PR TITLE
Allow usage of ENS domains on ViewWallet

### DIFF
--- a/common/components/AddressField.tsx
+++ b/common/components/AddressField.tsx
@@ -15,6 +15,7 @@ interface OwnProps {
   showLabelMatch?: boolean;
   showIdenticon?: boolean;
   showInputLabel?: boolean;
+  showEnsResolution?: boolean;
   placeholder?: string;
   value?: string;
   dropdownThreshold?: number;
@@ -38,12 +39,14 @@ const AddressField: React.SFC<Props> = ({
   showInputLabel = true,
   onChangeOverride,
   value,
-  dropdownThreshold
+  dropdownThreshold,
+  showEnsResolution = true
 }) => (
   <AddressFieldFactory
     isSelfAddress={isSelfAddress}
     showLabelMatch={showLabelMatch}
     showIdenticon={showIdenticon}
+    showEnsResolution={showEnsResolution}
     onChangeOverride={onChangeOverride}
     value={value}
     dropdownThreshold={dropdownThreshold}

--- a/common/components/AddressFieldFactory/AddressFieldFactory.tsx
+++ b/common/components/AddressFieldFactory/AddressFieldFactory.tsx
@@ -16,6 +16,7 @@ interface OwnProps {
   isSelfAddress?: boolean;
   showLabelMatch?: boolean;
   showIdenticon?: boolean;
+  showEnsResolution?: boolean;
   value?: string;
   dropdownThreshold?: number;
   withProps(props: CallbackProps): React.ReactElement<any> | null;
@@ -67,7 +68,8 @@ class AddressFieldFactoryClass extends React.Component<Props> {
       showIdenticon,
       onChangeOverride,
       value,
-      dropdownThreshold
+      dropdownThreshold,
+      showEnsResolution
     } = this.props;
 
     return (
@@ -77,6 +79,7 @@ class AddressFieldFactoryClass extends React.Component<Props> {
           showLabelMatch={showLabelMatch}
           withProps={withProps}
           showIdenticon={showIdenticon}
+          showEnsResolution={showEnsResolution}
           onChangeOverride={onChangeOverride}
           value={value}
           dropdownThreshold={dropdownThreshold}
@@ -111,6 +114,7 @@ interface DefaultAddressFieldProps {
   isSelfAddress?: boolean;
   showLabelMatch?: boolean;
   showIdenticon?: boolean;
+  showEnsResolution?: boolean;
   value?: string;
   dropdownThreshold?: number;
   withProps(props: CallbackProps): React.ReactElement<any> | null;
@@ -121,6 +125,7 @@ const DefaultAddressField: React.SFC<DefaultAddressFieldProps> = ({
   isSelfAddress,
   showLabelMatch,
   showIdenticon,
+  showEnsResolution,
   value,
   withProps,
   onChangeOverride,
@@ -138,6 +143,7 @@ const DefaultAddressField: React.SFC<DefaultAddressFieldProps> = ({
         onChangeOverride={onChangeOverride}
         value={value}
         dropdownThreshold={dropdownThreshold}
+        showEnsResolution={showEnsResolution}
       />
     )}
   />

--- a/common/components/AddressFieldFactory/AddressInputFactory.tsx
+++ b/common/components/AddressFieldFactory/AddressInputFactory.tsx
@@ -28,6 +28,7 @@ interface OwnProps {
   isSelfAddress?: boolean;
   showLabelMatch?: boolean;
   showIdenticon?: boolean;
+  showEnsResolution?: boolean;
   isFocused?: boolean;
   className?: string;
   value?: string;
@@ -78,7 +79,8 @@ class AddressInputFactoryClass extends Component<Props> {
       showIdenticon = true,
       onChangeOverride,
       value,
-      dropdownThreshold
+      dropdownThreshold,
+      showEnsResolution
     } = this.props;
     const inputClassName = `AddressInput-input ${label ? 'AddressInput-input-with-label' : ''}`;
     const sendingTo = label
@@ -121,7 +123,9 @@ class AddressInputFactoryClass extends Component<Props> {
               })
             }
           />
-          <ENSStatus ensAddress={currentTo.raw} isLoading={isResolving} rawAddress={addr} />
+          {showEnsResolution && (
+            <ENSStatus ensAddress={currentTo.raw} isLoading={isResolving} rawAddress={addr} />
+          )}
           {isFocused &&
             !isENSAddress && (
               <AddressFieldDropdown

--- a/common/components/WalletDecrypt/components/ViewOnly.tsx
+++ b/common/components/WalletDecrypt/components/ViewOnly.tsx
@@ -5,7 +5,7 @@ import translate, { translateRaw } from 'translations';
 import { AddressOnlyWallet } from 'libs/wallet';
 import { AppState } from 'features/reducers';
 import { configSelectors } from 'features/config';
-import { Input } from 'components/ui';
+import { ensSelectors } from 'features/ens';
 import { AddressField } from 'components';
 import './ViewOnly.scss';
 
@@ -15,6 +15,7 @@ interface OwnProps {
 
 interface StateProps {
   isValidAddress: ReturnType<typeof configSelectors.getIsValidAddressFn>;
+  resolvedAddress: ReturnType<typeof ensSelectors.getResolvedAddress>;
 }
 
 type Props = OwnProps & StateProps;
@@ -26,9 +27,17 @@ interface State {
 
 class ViewOnlyDecryptClass extends PureComponent<Props, State> {
   public state = {
-    address: '',
+    address: this.props.resolvedAddress || '',
     addressFromBook: ''
   };
+
+  public componentDidUpdate({ resolvedAddress: prevResolvedAddress }: Props) {
+    const { resolvedAddress } = this.props;
+
+    if (resolvedAddress !== prevResolvedAddress) {
+      this.setState({ address: resolvedAddress || '' });
+    }
+  }
 
   public render() {
     const { isValidAddress } = this.props;
@@ -44,6 +53,7 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
                 value={addressFromBook}
                 showInputLabel={false}
                 showIdenticon={false}
+                showEnsResolution={false}
                 placeholder={translateRaw('SELECT_FROM_ADDRESS_BOOK')}
                 onChangeOverride={this.handleSelectAddressFromBook}
                 dropdownThreshold={0}
@@ -53,11 +63,9 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
               <em>{translate('OR')}</em>
             </section>
             <section className="ViewOnly-fields-field">
-              <Input
-                isValid={isValid}
-                className="ViewOnly-input"
-                value={address}
-                onChange={this.changeAddress}
+              <AddressField
+                showInputLabel={false}
+                showIdenticon={false}
                 placeholder={translateRaw('VIEW_ONLY_ENTER')}
               />
               <button className="ViewOnly-submit btn btn-primary btn-block" disabled={!isValid}>
@@ -69,10 +77,6 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
       </div>
     );
   }
-
-  private changeAddress = (ev: React.FormEvent<HTMLInputElement>) => {
-    this.setState({ address: ev.currentTarget.value });
-  };
 
   private handleSelectAddressFromBook = (ev: React.FormEvent<HTMLInputElement>) => {
     const { currentTarget: { value: addressFromBook } } = ev;
@@ -106,5 +110,6 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
 }
 
 export const ViewOnlyDecrypt = connect((state: AppState): StateProps => ({
-  isValidAddress: configSelectors.getIsValidAddressFn(state)
+  isValidAddress: configSelectors.getIsValidAddressFn(state),
+  resolvedAddress: ensSelectors.getResolvedAddress(state)
 }))(ViewOnlyDecryptClass);

--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -502,7 +502,7 @@
     "CREATE_FINAL_STEP_4_MNEMONIC": "Enter your phrase",
     "CREATE_FINAL_STEP_4_KEYSTORE": "Provide file & password",
     "VIEW_ONLY_RECENT": "Select a recent address",
-    "VIEW_ONLY_ENTER": "Enter an address (e.g. 0x4bbeEB066eD09...)",
+    "VIEW_ONLY_ENTER": "Enter an address (e.g. 0x4bbeEB066eD09...) or an ENS address (example.eth)",
     "GO_TO_ACCOUNT": "Go to Account",
     "INSECURE_WALLET_TYPE_TITLE": "$wallet_type wallets are disabled online",
     "INSECURE_WALLET_TYPE_DESC": "Entering your $wallet_type on any website is dangerous. If MyCrypto.com was compromised, or you accidentally visited a phishing website, you could lose your funds. Because of that, we have disabled the use of $wallet_type wallets through the website. In order to access your account, please download MyCrypto and run it locally.",


### PR DESCRIPTION
This PR enables the user to enter an ENS domain in the ViewAddress tab.

<img width="1307" alt="screen shot 2018-11-19 at 5 51 11 pm" src="https://user-images.githubusercontent.com/10479826/48742246-bf29d380-ec23-11e8-93c3-1b803da96786.png">

