### PR TITLE
Make selecting navigation dropdown items easier

### DIFF
--- a/common/components/Header/NewHeader/components/DesktopHeader.scss
+++ b/common/components/Header/NewHeader/components/DesktopHeader.scss
@@ -107,7 +107,7 @@ $dropdown-background-color: #0f253f;
         top: 100%;
         width: 200px;
         margin: 0;
-        padding: 8px 16px;
+        padding: 0;
         background: $dropdown-background-color;
         border: 1px solid #3e546d;
         text-transform: initial;
@@ -115,12 +115,18 @@ $dropdown-background-color: #0f253f;
         cursor: initial;
 
         li {
+          margin: 0;
           font-size: 12px;
-          padding: 8px 0;
 
           a {
+            display: block;
             color: #fff;
             font-weight: normal;
+            padding: 12px 8px;
+
+            &:hover {
+              background: #293f59;
+            }
           }
         }
       }

--- a/common/components/Header/NewHeader/components/DesktopHeader.scss
+++ b/common/components/Header/NewHeader/components/DesktopHeader.scss
@@ -34,7 +34,6 @@ $dropdown-background-color: #0f253f;
         display: inline;
         font-weight: bold;
         letter-spacing: 1px;
-        cursor: pointer;
 
         a {
           color: #fff;
@@ -87,7 +86,6 @@ $dropdown-background-color: #0f253f;
         justify-content: center;
         padding: 0 22px;
         height: 58px;
-        cursor: pointer;
 
         a {
           color: #fff;

--- a/common/components/Header/NewHeader/components/MobileHeader.scss
+++ b/common/components/Header/NewHeader/components/MobileHeader.scss
@@ -89,11 +89,19 @@ $dropdown-background-color: #0f253f;
     &-subitems {
       margin: 15px 0;
       padding: 0;
-      padding-left: 10px;
       text-transform: initial;
 
       li {
-        margin-bottom: 10px !important;
+        margin-bottom: 0 !important;
+
+        a {
+          display: block;
+          padding: 10px;
+
+          &:hover {
+            background: #293f59;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
A complaint was made that the navigation dropdown items were hard to select. This change expands their hitbox and changes the background color when hovered.

<img width="674" alt="screen shot 2018-11-20 at 12 15 22 pm" src="https://user-images.githubusercontent.com/10479826/48793908-0c5a8380-ecbe-11e8-831e-0efe59e7bd15.png">
