### PR TITLE
Enable ShapeShift swapping on Desktop

### DIFF
--- a/electron-app/main/index.ts
+++ b/electron-app/main/index.ts
@@ -1,5 +1,5 @@
 import 'babel-polyfill';
-import { app } from 'electron';
+import { app, ipcMain, BrowserWindow } from 'electron';
 import { registerServer } from 'shared/enclave/server';
 import getWindow from './window';
 
@@ -21,6 +21,28 @@ app.on('activate', () => {
 // Create main BrowserWindow when electron is ready
 app.on('ready', () => {
   getWindow();
+
+  ipcMain.on('shapeshift-authorize', (_: any, url: string) => {
+    const window = new BrowserWindow({
+      backgroundColor: '#fbfbfb',
+      width: 1220,
+      height: process.platform === 'darwin' ? 680 : 720,
+      minWidth: 480,
+      minHeight: 400,
+      titleBarStyle: 'hidden',
+      webPreferences: {
+        devTools: true,
+        nodeIntegration: true,
+        contextIsolation: false
+      }
+    });
+
+    window.loadURL(url);
+  });
+
+  ipcMain.on('shapeshift-token-retrieved', (_: any, token: string) =>
+    getWindow().webContents.send('shapeshift-set-token', token)
+  );
 });
 
 // Register enclave protocol

--- a/electron-app/main/window.ts
+++ b/electron-app/main/window.ts
@@ -26,7 +26,7 @@ export default function getWindow() {
     webPreferences: {
       devTools: true,
       nodeIntegration: false,
-      contextIsolation: true,
+      contextIsolation: false,
       preload: path.join(__dirname, 'preload.js')
     }
   });
@@ -54,11 +54,6 @@ export default function getWindow() {
   window.webContents.on('context-menu', (_, props) => {
     popupContextMenu(window!, isDevelopment, props);
   });
-
-  // TODO: Figure out updater release process
-  // window.webContents.on('did-finish-load', () => {
-  //   updater(window!);
-  // });
 
   window.webContents.on('devtools-opened', () => {
     window!.focus();

--- a/electron-app/main/window.ts
+++ b/electron-app/main/window.ts
@@ -25,7 +25,7 @@ export default function getWindow() {
     titleBarStyle: 'hidden',
     webPreferences: {
       devTools: true,
-      nodeIntegration: false,
+      nodeIntegration: true,
       contextIsolation: false,
       preload: path.join(__dirname, 'preload.js')
     }


### PR DESCRIPTION
This PR adds logic to `ipcMain` and `ipcRenderer` to handle the 0Auth process for ShapeShift when in an `Electron` context.