### PR TITLE
Remove read-only attribute from symbol and decimal input

### DIFF
--- a/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm/DecimalField.tsx
+++ b/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm/DecimalField.tsx
@@ -17,7 +17,7 @@ export class DecimalField extends React.Component<OwnProps> {
       <FieldInput
         fieldName={translateRaw('TOKEN_DEC')}
         fieldToFetch={'decimals'}
-        shouldEnableAutoField={req => !(req.toVal().res === '0')}
+        shouldEnableAutoField={() => false}
         address={this.props.address}
         isOffline={this.props.isOffline}
         userInputValidator={this.isValidUserInput}

--- a/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm/SymbolField.tsx
+++ b/common/components/BalanceSidebar/TokenBalances/AddCustomTokenForm/SymbolField.tsx
@@ -18,7 +18,7 @@ export class SymbolField extends React.Component<OwnProps> {
       <FieldInput
         fieldName={translateRaw('TOKEN_SYMBOL')}
         fieldToFetch={'symbol'}
-        shouldEnableAutoField={req => !req.err()}
+        shouldEnableAutoField={() => false}
         address={this.props.address}
         userInputValidator={this.isValidUserInput}
         fetchedFieldValidator={field =>


### PR DESCRIPTION
### Description

This removes the read-only attribute from the symbol and decimal inputs in the token form. This allows the user to change these values after they have been fetched. This can be used when the user wants to add a token with a symbol that already exists (with a different address).

### Changes

* Removed read-only attribute from symbol and decimal input for the custom tokens form.

### Screenshots

![](https://i.imgur.com/ohbl3c2.png)
