### PR TITLE
Fix input field in ViewOnly

### DIFF
--- a/common/components/WalletDecrypt/components/ViewOnly.tsx
+++ b/common/components/WalletDecrypt/components/ViewOnly.tsx
@@ -86,15 +86,18 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
     const { isValidAddress, currentAddress, resolvedAddress } = this.props;
     const { addressFromBook } = this.state;
 
+    let wallet;
+
     if (isValidAddress(addressFromBook)) {
-      const wallet = new AddressOnlyWallet(addressFromBook);
-      this.props.onUnlock(wallet);
+      wallet = addressFromBook;
     } else if (isValidAddress(currentAddress.raw)) {
-      const wallet = new AddressOnlyWallet(currentAddress.raw);
-      this.props.onUnlock(wallet);
+      wallet = currentAddress.raw;
     } else if (resolvedAddress && isValidAddress(resolvedAddress)) {
-      const wallet = new AddressOnlyWallet(resolvedAddress);
-      this.props.onUnlock(wallet);
+      wallet = resolvedAddress;
+    }
+
+    if (wallet) {
+      this.props.onUnlock(new AddressOnlyWallet(wallet));
     }
   };
 }

--- a/common/components/WalletDecrypt/components/ViewOnly.tsx
+++ b/common/components/WalletDecrypt/components/ViewOnly.tsx
@@ -83,7 +83,7 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
   };
 
   private openWallet = () => {
-    const { isValidAddress, currentAddress, resolvedAddress } = this.props;
+    const { isValidAddress, currentAddress, resolvedAddress, onUnlock } = this.props;
     const { addressFromBook } = this.state;
 
     let wallet;
@@ -97,7 +97,7 @@ class ViewOnlyDecryptClass extends PureComponent<Props, State> {
     }
 
     if (wallet) {
-      this.props.onUnlock(new AddressOnlyWallet(wallet));
+      onUnlock(new AddressOnlyWallet(wallet));
     }
   };
 }


### PR DESCRIPTION
In ViewOnly, the `Enter an address...` input wasn't allowing non-ENS domains -- now it does!