### PR TITLE
Reverted PR #2305 to fix gas price issue

### DIFF
--- a/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
+++ b/common/components/TXMetaDataPanel/TXMetaDataPanel.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import BN from 'bn.js';
 
 import { translateRaw } from 'translations';
-import { NetworkConfig, StaticNetworkConfig } from 'types/network';
+import { NetworkConfig } from 'types/network';
 import { Units } from 'libs/units';
 import { AppState } from 'features/reducers';
 import { configSelectors, configMetaSelectors } from 'features/config';
@@ -142,14 +142,8 @@ class TXMetaDataPanel extends React.Component<Props, State> {
 }
 
 function mapStateToProps(state: AppState): StateProps {
-  const networkConfig = configSelectors.getNetworkConfig(state) as StaticNetworkConfig;
   return {
-    gasPrice: networkConfig.isCustom
-      ? transactionFieldsSelectors.getGasPrice(state)
-      : {
-          raw: networkConfig.gasPriceSettings.initial.toString(),
-          value: new BN(networkConfig.gasPriceSettings.initial)
-        },
+    gasPrice: transactionFieldsSelectors.getGasPrice(state),
     offline: configMetaSelectors.getOffline(state),
     network: configSelectors.getNetworkConfig(state)
   };


### PR DESCRIPTION
Closes #2351

### Description

This reverts a gas price change that breaks the gas price slider for users on the web app and the desktop app.

### Changes

* Reverted commits 9925fb1e239c042c8d75a5591ed3ab1607f4c866 and 4c9368635bc6ce3fd1ef58ddd45e7a5951020b90

### Steps to Test

1. Access wallet.
2. Notice the slider is set all the way to the left side of the scale. Note that you can't move it.

Notes. This only affects people who have a local node configured that is off. The issue is that the check will bypass shepherd, and always use the "off" locally-configured node 
