### PR TITLE
Remove blockscale network

### DIFF
--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -24,12 +24,6 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       type: 'infura',
       service: 'Infura',
       url: 'https://mainnet.infura.io/mycrypto'
-    },
-    {
-      name: makeNodeName('ETH', 'blockscale'),
-      type: 'rpc',
-      service: 'Blockscale',
-      url: 'https://api.dev.blockscale.net/dev/parity'
     }
   ],
 


### PR DESCRIPTION
### Description
Removed blockscale eth network at the request of blockscale.

### Changes
Removed blockscale as a network option.

### Steps to Test
Verify blockscale is not one of the available Ethereum network options.

### Screenshots
<img width="649" alt="screen shot 2019-01-12 at 8 34 11 pm" src="https://user-images.githubusercontent.com/14166520/51081647-a381fd00-16a9-11e9-8a31-e8fc5c9db4a8.png">
