### PR TITLE
[THUNDERCORE] Add ThunderCore support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -158,6 +158,11 @@ export const ARTIS_TAU1: DPath = {
   value: "m/44'/60'/0'/0"
 };
 
+export const THUNDERCORE_DEFAULT: DPath = {
+  label: 'Default (THUNDERCORE)',
+  value: "m/44'/1001'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -189,7 +194,8 @@ export const DPaths: DPath[] = [
   MIX_DEFAULT,
   REOSC_DEFAULT,
   ARTIS_SIGMA1,
-  ARTIS_TAU1
+  ARTIS_TAU1,
+  THUNDERCORE_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "ARTIS_TAU1",
+      "THUNDERCORE",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -834,7 +834,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     unit: 'TT',
     chainId: 108,
     isCustom: false,
-    color: '#ffe81c',
+    color: '#ffc000',
     blockExplorer: makeExplorer({
       name: 'ThunderScan',
       origin: 'https://scan.thundercore.com'

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -36,7 +36,8 @@ import {
   MIX_DEFAULT,
   REOSC_DEFAULT,
   ARTIS_SIGMA1,
-  ARTIS_TAU1
+  ARTIS_TAU1,
+  THUNDERCORE_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -824,6 +825,29 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     gasPriceSettings: {
       min: 1,
       max: 1,
+      initial: 1
+    }
+  },
+  THUNDERCORE: {
+    id: 'THUNDERCORE',
+    name: 'ThunderCore',
+    unit: 'TT',
+    chainId: 108,
+    isCustom: false,
+    color: '#ffe81c',
+    blockExplorer: makeExplorer({
+      name: 'ThunderScan',
+      origin: 'https://scan.thundercore.com'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.LEDGER_NANO_S]: THUNDERCORE_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: THUNDERCORE_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 1,
+      max: 60,
       initial: 1
     }
   }

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -325,6 +325,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'rpc.tau1.artis.network',
       url: 'https://rpc.tau1.artis.network'
     }
+  ],
+
+  THUNDERCORE: [
+    {
+      name: makeNodeName('THUNDERCORE', 'thundercore'),
+      type: 'rpc',
+      service: 'thundercore.com',
+      url: 'https://mainnet-rpc.thundercore.com'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -31,7 +31,8 @@ type StaticNetworkIds =
   | 'MIX'
   | 'REOSC'
   | 'ARTIS_SIGMA1'
-  | 'ARTIS_TAU1';
+  | 'ARTIS_TAU1'
+  | 'THUNDERCORE';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
### Description

ThunderCore is an EVM compatible, high-throughput blockchain

* Homepage: https://www.thundercore.com
* RPC: https://mainnet-rpc.thundercore.com
* BIP44 1001/ ChainId 108 (https://github.com/satoshilabs/slips/pull/371)


### Changes

* This PR adds ThunderCore support
* Standard chain support changes
