### PR TITLE
mycryptoapi-gas

### DIFF
--- a/common/api/gas.ts
+++ b/common/api/gas.ts
@@ -33,7 +33,7 @@ interface GasExpressResponse {
 }
 
 export function fetchGasEstimates(): Promise<GasEstimates> {
-  return fetch('https://dev.blockscale.net/api/gasexpress.json', {
+  return fetch('https://gas.mycryptoapi.com', {
     mode: 'cors'
   })
     .then(checkHttpStatus)


### PR DESCRIPTION

### Description

Switch over ETH gas oracle service from Blockscale to MyCrypto.

### Changes

Changed the gas API URL.

### Steps to Test

Check whether gas price estimates returned by `gas.mycryptoapi.com` are appropriate.
 
