### PR TITLE
Fix chain nonce bug

### DIFF
--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -28,7 +28,6 @@ import * as types from './types';
 import * as actions from './actions';
 import * as sagas from './sagas';
 import { isSchedulingEnabled } from 'features/schedule/selectors';
-import { conductMaxNonceCheck } from './sagas';
 
 describe('Network Sagas', () => {
   describe('From', () => {
@@ -406,7 +405,6 @@ describe('Network Sagas', () => {
       );
       const transactionCountString = '0x9';
       const transactionCount = 9;
-      const fromAddress = 'fromaddress';
       const transaction: any = {
         hash: '0xecc044b81a794fc567dd389b7709b89a3a0a001dcdd151fc442c57982cfa012b',
         from: 'fromaddress',

--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -28,6 +28,7 @@ import * as types from './types';
 import * as actions from './actions';
 import * as sagas from './sagas';
 import { isSchedulingEnabled } from 'features/schedule/selectors';
+import { conductMaxNonceCheck } from './sagas';
 
 describe('Network Sagas', () => {
   describe('From', () => {
@@ -395,7 +396,7 @@ describe('Network Sagas', () => {
           {
             hash: '0xecc044b81a794fc567dd389b7709b89a3a0a001dcdd151fc442c57982cfa012b',
             from: 'fromaddress',
-            chainId: 1,
+            chainId: 11,
             nonce: 8,
             to: '0x3d1F9d958AFa2e94dab3f3Ce7362b87daEa39017',
             value: '0x0',
@@ -404,6 +405,18 @@ describe('Network Sagas', () => {
         ])
       );
       const transactionCountString = '0x9';
+      const transactionCount = 9;
+      const fromAddress = 'fromaddress';
+      const transaction: any = {
+        hash: '0xecc044b81a794fc567dd389b7709b89a3a0a001dcdd151fc442c57982cfa012b',
+        from: 'fromaddress',
+        chainId: 11,
+        nonce: 8,
+        to: '0x3d1F9d958AFa2e94dab3f3Ce7362b87daEa39017',
+        value: '0x0',
+        time: 1544811728723
+      };
+      const tx = { transaction };
 
       const gens: any = {};
       gens.gen = cloneableGenerator(sagas.handleNonceRequest)();
@@ -460,9 +473,19 @@ describe('Network Sagas', () => {
       });
 
       it('should select transactionSelectors', () => {
-        expect(gens.gen.next(recentTransactions).value).toEqual(
+        expect(gens.gen.next(transactionCount).value).toEqual(
           select(transactionsSelectors.getRecentTransactions)
         );
+      });
+
+      it('should select transactionSelectors', () => {
+        expect(gens.gen.next(recentTransactions).value).toEqual(
+          select(derivedSelectors.getTransaction)
+        );
+      });
+
+      it('should call getTransactionFields', () => {
+        expect(gens.gen.next(tx).value).toEqual(call(getTransactionFields, transaction));
       });
     });
 

--- a/common/features/transaction/network/sagas.spec.ts
+++ b/common/features/transaction/network/sagas.spec.ts
@@ -429,7 +429,7 @@ describe('Network Sagas', () => {
       it('should exit if being called without a wallet inst', () => {
         gens.noWallet = gens.gen.clone();
         gens.noWallet.next(null); // No wallet inst
-        expect(gens.noWallet.next(offline).done).toEqual(true);
+        expect(gens.noWallet.next(offline).done).toEqual(false);
       });
 
       it('should select getOffline', () => {
@@ -438,7 +438,7 @@ describe('Network Sagas', () => {
 
       it('should exit if being called while offline', () => {
         gens.offline = gens.gen.clone();
-        expect(gens.offline.next(true).done).toEqual(true);
+        expect(gens.offline.next(true).done).toEqual(false);
       });
 
       it('should apply walletInst.getAddressString', () => {

--- a/common/features/transaction/network/sagas.ts
+++ b/common/features/transaction/network/sagas.ts
@@ -219,7 +219,11 @@ export function* handleNonceRequest(): SagaIterator {
   const isOffline: boolean = yield select(configMetaSelectors.getOffline);
   try {
     if (isOffline || !walletInst) {
-      throw Error();
+      if (isOffline) {
+        throw Error('offline');
+      } else {
+        throw Error('wallet');
+      }
     }
     const fromAddress: string = yield apply(walletInst, walletInst.getAddressString);
     const transactionCountString: string = yield apply(nodeLib, nodeLib.getTransactionCount, [
@@ -241,10 +245,12 @@ export function* handleNonceRequest(): SagaIterator {
     const base10Nonce = Nonce(retrievedNonce);
     yield put(transactionFieldsActions.inputNonce(base10Nonce.toString()));
     yield put(actions.getNonceSucceeded(retrievedNonce));
-  } catch {
-    yield put(
-      notificationsActions.showNotification('warning', 'Your addresses nonce could not be fetched')
-    );
+  } catch (e) {
+    if (e === 'offline') {
+      yield put(
+        notificationsActions.showNotification('warning', 'Your addresses nonce could not be fetched')
+      );
+    }
     yield put(actions.getNonceFailed());
   }
 }
@@ -255,6 +261,7 @@ export function* conductMaxNonceCheck(
   recentTransactions: AppState['transactions']['recent'],
   chainId: number
 ): SagaIterator {
+  console.log('got hur12')
   // Selects the maximum nonce from the maximum of the recent-transaction nonces with the same `from` address and the transaction count of the address
   const selectedNonce = Math.max(
     transactionCount,
@@ -270,6 +277,7 @@ export function* conductMaxNonceCheck(
       0
     )
   ).toString();
+  console.log('got hur13')
   return selectedNonce;
 }
 

--- a/common/features/transaction/network/sagas.ts
+++ b/common/features/transaction/network/sagas.ts
@@ -219,7 +219,7 @@ export function* handleNonceRequest(): SagaIterator {
   const isOffline: boolean = yield select(configMetaSelectors.getOffline);
   try {
     if (isOffline || !walletInst) {
-      return;
+      throw Error();
     }
     const fromAddress: string = yield apply(walletInst, walletInst.getAddressString);
     const transactionCountString: string = yield apply(nodeLib, nodeLib.getTransactionCount, [

--- a/common/features/transaction/network/sagas.ts
+++ b/common/features/transaction/network/sagas.ts
@@ -261,7 +261,6 @@ export function* conductMaxNonceCheck(
   recentTransactions: AppState['transactions']['recent'],
   chainId: number
 ): SagaIterator {
-  console.log('got hur12')
   // Selects the maximum nonce from the maximum of the recent-transaction nonces with the same `from` address and the transaction count of the address
   const selectedNonce = Math.max(
     transactionCount,
@@ -277,7 +276,6 @@ export function* conductMaxNonceCheck(
       0
     )
   ).toString();
-  console.log('got hur13')
   return selectedNonce;
 }
 

--- a/common/features/transaction/network/sagas.ts
+++ b/common/features/transaction/network/sagas.ts
@@ -248,7 +248,10 @@ export function* handleNonceRequest(): SagaIterator {
   } catch (e) {
     if (e === 'offline') {
       yield put(
-        notificationsActions.showNotification('warning', 'Your addresses nonce could not be fetched')
+        notificationsActions.showNotification(
+          'warning',
+          'Your addresses nonce could not be fetched'
+        )
       );
     }
     yield put(actions.getNonceFailed());


### PR DESCRIPTION
Closes: #2426 
Closes: #2336

### Description

Fixes issue with nonce calculation when using the same public/private keypair across multiple networks. Fixed issue with nonce calculation when offline.

### Changes

* Added a ChainID check to nonce lookup.
* `Throw`s instead of `return`s in try/catch to re-allow nonce cancellation when offline.

### Steps to Test

1. Send a transaction on mainnet using MetaMask.
2. Switch to Ropsten or Rinkeby and login using MetaMask (this will use the same keypair). 
3. Open the Advanced transaction settings section. This will display your nonce. Your nonce will be calculated to be the same as whatever the nonce for the new network is. It won't use the same nonce as the same account on the previous network.
4. Disconnect your computer from the internet. Click the Refresh button in the nonce field and it should fail correctly without blocking out the field (fixes #2336).

