### PR TITLE
UBQ: update node url, update explorer url

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -199,7 +199,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     color: '#b37aff',
     blockExplorer: makeExplorer({
       name: 'Ubiqscan',
-      origin: 'https://ubiqscan.io/en'
+      origin: 'https://ubiqscan.io'
     }),
     tokens: require('config/tokens/ubq.json'),
     contracts: require('config/contracts/ubq.json'),

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -98,7 +98,7 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       name: makeNodeName('UBQ', 'ubiqscan'),
       type: 'rpc',
       service: 'ubiqscan.io',
-      url: 'https://pyrus2.ubiqscan.io'
+      url: 'https://rpc1.ubiqscan.io'
     }
   ],
 


### PR DESCRIPTION
### Description

Some minor updates to the UBQ configurations. 
node url: pyrus2.ubiqscan.io is behind a proxy returning parity like responses, as a result balances are not shown correctly in mycrypto. rpc1.ubiqscan.io is without such proxy and fixes this.

explorer url: remove /en (deprecated), avoids a redirect.

