### PR TITLE
Add EtherInc (ETI) Support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -163,6 +163,11 @@ export const THUNDERCORE_DEFAULT: DPath = {
   value: "m/44'/1001'/0'/0"
 };
 
+export const ETI_DEFAULT: DPath = {
+  label: 'Default (ETI)',
+  value: "m/44'/464'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -195,7 +200,8 @@ export const DPaths: DPath[] = [
   REOSC_DEFAULT,
   ARTIS_SIGMA1,
   ARTIS_TAU1,
-  THUNDERCORE_DEFAULT
+  THUNDERCORE_DEFAULT,
+  ETI_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "THUNDERCORE",
+      "ETI",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -870,7 +870,6 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     dPathFormats: {
       [SecureWalletName.TREZOR]: ETI_DEFAULT,
       [SecureWalletName.SAFE_T]: ETI_DEFAULT,
-      [SecureWalletName.LEDGER_NANO_S]: ETI_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: ETI_DEFAULT
     },
     gasPriceSettings: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -37,7 +37,8 @@ import {
   REOSC_DEFAULT,
   ARTIS_SIGMA1,
   ARTIS_TAU1,
-  THUNDERCORE_DEFAULT
+  THUNDERCORE_DEFAULT,
+  ETI_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -851,7 +852,33 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       initial: 1
     }
   }
-};
+},
+
+  ETI: {
+    id: 'ETI',
+    name: 'Etherinc',
+    unit: 'ETI',
+    chainId: 101,
+    isCustom: false,
+    color: '#3560bf',
+    blockExplorer: makeExplorer({
+      name: 'Etherinc Explorer',
+      origin: 'https://explorer.einc.io'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ETI_DEFAULT,
+      [SecureWalletName.SAFE_T]: ETI_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: ETI_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETI_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 2,
+      max: 60,
+      initial: 2
+    }
+  };
 
 export function staticNetworksReducer(
   state: types.ConfigStaticNetworksState = STATIC_NETWORKS_INITIAL_STATE,

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -334,6 +334,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'thundercore.com',
       url: 'https://mainnet-rpc.thundercore.com'
     }
+  ],
+
+  ETI: [
+    {
+      name: makeNodeName('ETI', 'eti'),
+      type: 'rpc',
+      service: 'api.einc.io',
+      url: 'https://api.einc.io/jsonrpc/mainnet/'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -32,7 +32,8 @@ type StaticNetworkIds =
   | 'REOSC'
   | 'ARTIS_SIGMA1'
   | 'ARTIS_TAU1'
-  | 'THUNDERCORE';
+  | 'THUNDERCORE'
+  | 'ETI';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
# Description
EtherInc is a fork of Ethereum to power the future of blockchain based organizations.

* Homepage: https://einc.io/
* Node: https://api.einc.io/jsonrpc/mainnet
* Explorer: https://explorer.einc.io/
* BIP44 / Chainid 101 ( [satoshilabs/slips#438](https://github.com/satoshilabs/slips/pull/438) )

# Changes
This PR adds EtherInc node support