### PR TITLE
Provide ERC-20 token information to Ledger wallets

### DIFF
--- a/common/libs/wallet/deterministic/ledger.ts
+++ b/common/libs/wallet/deterministic/ledger.ts
@@ -6,6 +6,7 @@ import LedgerEth from '@ledgerhq/hw-app-eth';
 import { translateRaw } from 'translations';
 import { getTransactionFields } from 'libs/transaction';
 import { HardwareWallet, ChainCodeResponse } from './hardware';
+import { byContractAddress } from '@ledgerhq/hw-app-eth/erc20';
 
 // Ledger throws a few types of errors
 interface U2FError {
@@ -51,6 +52,14 @@ export class LedgerWallet extends HardwareWallet {
 
     try {
       const ethApp = await makeApp();
+
+      if (t.getChainId() === 1) {
+        const tokenInfo = byContractAddress(t.to.toString('hex'));
+        if (tokenInfo) {
+          await ethApp.provideERC20TokenInformation(tokenInfo);
+        }
+      }
+
       const result = await ethApp.signTransaction(this.getPath(), t.serialize().toString('hex'));
 
       let v = result.v;

--- a/common/typescript/ledger/hw-app-eth.d.ts
+++ b/common/typescript/ledger/hw-app-eth.d.ts
@@ -1,5 +1,6 @@
 declare module '@ledgerhq/hw-app-eth' {
   import LedgerTransport from '@ledgerhq/hw-transport';
+  import { TokenInfo } from '@ledgerhq/hw-app-eth/erc20';
 
   export default class Eth<T extends LedgerTransport<any>> {
     constructor(transport: T);
@@ -56,5 +57,31 @@ declare module '@ledgerhq/hw-app-eth' {
       path: string,
       messageHex: string
     ): Promise<{ v: number; s: string; r: string }>;
+
+    /**
+     * @description provides a trusted description of an ERC-20 token
+     * @param {TokenInfo} tokenInfo
+     * @returns {Promise<boolean>}
+     * @memberOf Eth
+     */
+    public provideERC20TokenInformation(tokenInfo: TokenInfo): Promise<boolean>;
   }
+}
+
+declare module '@ledgerhq/hw-app-eth/erc20' {
+  interface TokenInfo {
+    contractAddress: string;
+    ticker: string;
+    decimals: number;
+    chainId: number;
+    signature: Buffer;
+    data: Buffer;
+  }
+
+  /**
+   * @description retrieve the token information by a given contract address if any
+   * @param {string} address
+   * @returns {TokenInfo | undefined}
+   */
+  export function byContractAddress(address: string): TokenInfo | undefined;
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "npm": ">= 5.0.0"
   },
   "dependencies": {
-    "@ledgerhq/hw-app-eth": "4.46.1",
+    "@ledgerhq/hw-app-eth": "4.48.0",
     "@ledgerhq/hw-transport-node-hid": "4.46.0",
     "@ledgerhq/hw-transport-u2f": "4.46.0",
     "@parity/qr-signer": "0.3.1",
@@ -22,8 +22,7 @@
     "classnames": "2.2.5",
     "electron-updater": "2.21.10",
     "ethereum-blockies-base64": "1.0.2",
-    "ethereumjs-abi":
-      "git://github.com/ethereumjs/ethereumjs-abi.git#09c3c48fd3bed143df7fa8f36f6f164205e23796",
+    "ethereumjs-abi": "git://github.com/ethereumjs/ethereumjs-abi.git#09c3c48fd3bed143df7fa8f36f6f164205e23796",
     "ethereumjs-tx": "1.3.4",
     "ethereumjs-util": "5.1.5",
     "ethereumjs-wallet": "0.6.0",
@@ -175,19 +174,13 @@
     "prebuild": "check-node-version --package",
     "build:downloadable": "webpack --mode=production --config webpack_config/webpack.html.js",
     "prebuild:downloadable": "check-node-version --package",
-    "build:electron":
-      "webpack --config webpack_config/webpack.electron-prod.js && node webpack_config/buildElectron.js",
-    "build:electron:osx":
-      "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=osx node webpack_config/buildElectron.js",
-    "build:electron:windows":
-      "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=windows node webpack_config/buildElectron.js",
-    "build:electron:linux":
-      "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=linux node webpack_config/buildElectron.js",
+    "build:electron": "webpack --config webpack_config/webpack.electron-prod.js && node webpack_config/buildElectron.js",
+    "build:electron:osx": "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=osx node webpack_config/buildElectron.js",
+    "build:electron:windows": "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=windows node webpack_config/buildElectron.js",
+    "build:electron:linux": "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=linux node webpack_config/buildElectron.js",
     "prebuild:electron": "check-node-version --package",
-    "jenkins:build:linux":
-      "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=JENKINS_LINUX node webpack_config/buildElectron.js",
-    "jenkins:build:mac":
-      "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=JENKINS_MAC node webpack_config/buildElectron.js",
+    "jenkins:build:linux": "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=JENKINS_LINUX node webpack_config/buildElectron.js",
+    "jenkins:build:mac": "webpack --config webpack_config/webpack.electron-prod.js && cross-env ELECTRON_OS=JENKINS_MAC node webpack_config/buildElectron.js",
     "jenkins:upload": "node jenkins/upload",
     "test:coverage": "jest --config=jest_config/jest.config.json --coverage",
     "test": "jest --config=jest_config/jest.config.json",
@@ -200,16 +193,13 @@
     "predev": "check-node-version --package",
     "dev:https": "cross-env HTTPS=true node webpack_config/devServer.js",
     "predev:https": "check-node-version --package",
-    "dev:electron":
-      "concurrently --kill-others --names \"webpack,electron\" \"cross-env BUILD_ELECTRON=true node webpack_config/devServer.js\" \"webpack --config webpack_config/webpack.electron-dev.js && electron dist/electron-js/main.js\"",
+    "dev:electron": "concurrently --kill-others --names \"webpack,electron\" \"cross-env BUILD_ELECTRON=true node webpack_config/devServer.js\" \"webpack --config webpack_config/webpack.electron-dev.js && electron dist/electron-js/main.js\"",
     "tslint": "tslint --project . --exclude common/vendor/**/*",
     "tscheck": "tsc --noEmit",
     "start": "npm run dev",
     "precommit": "lint-staged",
-    "formatAll":
-      "find ./common/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
-    "prettier:diff":
-      "prettier --write --config ./.prettierrc --list-different \"common/**/*.ts\" \"common/**/*.tsx\"",
+    "formatAll": "find ./common/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
+    "prettier:diff": "prettier --write --config ./.prettierrc --list-different \"common/**/*.ts\" \"common/**/*.tsx\"",
     "update:tokens": "ts-node scripts/update-tokens",
     "postinstall": "electron-rebuild --force"
   },

--- a/shared/enclave/server/wallets/ledger.ts
+++ b/shared/enclave/server/wallets/ledger.ts
@@ -5,6 +5,7 @@ import TransportNodeHid from '@ledgerhq/hw-transport-node-hid';
 import LedgerEth from '@ledgerhq/hw-app-eth';
 
 import { WalletLib } from 'shared/enclave/types';
+import { byContractAddress } from '@ledgerhq/hw-app-eth/erc20';
 
 let transport: LedgerTransport<string> | null;
 
@@ -49,6 +50,13 @@ const Ledger: WalletLib = {
       r: toBuffer(0),
       s: toBuffer(0)
     });
+
+    if (ethTx.getChainId() === 1) {
+      const tokenInfo = byContractAddress(ethTx.to.toString('hex'));
+      if (tokenInfo) {
+        await app.provideERC20TokenInformation(tokenInfo);
+      }
+    }
 
     const rsv = await app.signTransaction(path, ethTx.serialize().toString('hex'));
     const signedTx = new EthTx({

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,15 +65,28 @@
   dependencies:
     "@ledgerhq/errors" "^4.46.0"
 
+"@ledgerhq/devices@^4.48.0":
+  version "4.48.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.48.0.tgz#b62cce08dd49a8bd4cbf0eda0e09bf8610e42b56"
+  integrity sha512-Rs0zhkjzJTps1hoHlwGLhPM8Poo8EzE55QGLWk4Q6oXoO/Nk6MRUrFaz2UuCBVQU5RaI2JPhDbwO9bPd9cVH1Q==
+  dependencies:
+    "@ledgerhq/errors" "^4.48.0"
+
 "@ledgerhq/errors@^4.46.0":
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.46.0.tgz#534dd376b9de0e5fe07fcf6b35f5731f6c03e725"
 
-"@ledgerhq/hw-app-eth@4.46.1":
-  version "4.46.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.46.1.tgz#cc298cfb23dd9e27a3c795f8a80ace43fd36f89c"
+"@ledgerhq/errors@^4.48.0":
+  version "4.48.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.48.0.tgz#3a2a65862de72641095db8ef72739d105524a68f"
+  integrity sha512-MM5Tvo+KBr+dQyc6F2d93eyepZdHCmrR9KjwuB2W8pjPBG9jYmtPM/+I72k9o22YXQ9FIyd1WJJaARJoOzWXOA==
+
+"@ledgerhq/hw-app-eth@4.48.0":
+  version "4.48.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.48.0.tgz#230f67c2c06ba6bd4176b7b2b1ad46e5efdde505"
+  integrity sha512-lNdQOFDeAda8f/X6qP27FCtfhUX5eMuaL23aqfqu5Pfp92/FiHTkE2SOTcO0bjQK3/KsIF/ZSDzxtWvv8vkgkA==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.46.0"
+    "@ledgerhq/hw-transport" "^4.48.0"
 
 "@ledgerhq/hw-transport-node-hid@4.46.0":
   version "4.46.0"
@@ -100,6 +113,15 @@
   dependencies:
     "@ledgerhq/devices" "^4.46.0"
     "@ledgerhq/errors" "^4.46.0"
+    events "^3.0.0"
+
+"@ledgerhq/hw-transport@^4.48.0":
+  version "4.48.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.48.0.tgz#8fa09e46d9d9aab35db5679e0970e7fed2ee73bf"
+  integrity sha512-dZH/3dTXlhe3IFl+MRFePcC0TnSeQcaBuiq5t3yDA68qw7WZCbON9GKSO5Rex4yNx5v6BCHyzz1myBFJ7895iw==
+  dependencies:
+    "@ledgerhq/devices" "^4.48.0"
+    "@ledgerhq/errors" "^4.48.0"
     events "^3.0.0"
 
 "@parity/erc681@0.1.1":


### PR DESCRIPTION
### Description

Ledger removed the hardcoded ERC-20 token info from the Ethereum app to reduce the size. This update implements the `provideERC20TokenInformation` function to replace this. More info on this change [here](https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_eth_app.md).

### Changes

* Updated `@ledgerhq/hw-app-eth` to `4.48.0`
* Added TypeScript types for the new functions
* Implemented the `provideERC20TokenInformation` function

### Steps to Test

1. Update the Ethereum app to at least v1.2.2. This update is currently available in Ledger Live only when launching with `FORCE_PROVIDER=4`, but should be available without pretty soon.
2. Generate a token transaction in MyCrypto.
3. Check if the token symbol, amount and destination address are shown on the Ledger device.
