### PR TITLE
Update node-hid to 0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "mini-css-extract-plugin": "0.4.0",
     "minimist": "1.2.0",
     "mycrypto-nano-result": "0.0.1",
-    "node-hid": "0.7.7",
     "node-sass": "4.8.3",
     "nodemon": "1.17.3",
     "null-loader": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "mini-css-extract-plugin": "0.4.0",
     "minimist": "1.2.0",
     "mycrypto-nano-result": "0.0.1",
-    "node-hid": "0.7.2",
+    "node-hid": "0.7.7",
     "node-sass": "4.8.3",
     "nodemon": "1.17.3",
     "null-loader": "0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,7 +8147,7 @@ node-gyp@^3.6.0:
     tar "^2.0.0"
     which "1"
 
-node-hid@0.7.7, node-hid@^0.7.7:
+node-hid@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.7.tgz#3341630231b534226b86d6758caba48a646799ed"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,7 +1603,7 @@ binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
-bindings@^1.2.1, bindings@^1.3.0:
+bindings@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
 
@@ -4311,10 +4311,6 @@ expand-range@^1.8.1:
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
-
-expand-template@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.0.tgz#e09efba977bf98f9ee0ed25abd0c692e02aec3fc"
 
 expand-template@^2.0.3:
   version "2.0.3"
@@ -8021,7 +8017,7 @@ mycrypto-shepherd@1.4.0:
     remote-redux-devtools "^0.5.12"
     url-search-params "^0.10.0"
 
-nan@^2.0.5, nan@^2.0.8, nan@^2.10.0, nan@^2.2.1, nan@^2.3.0, nan@^2.6.2:
+nan@^2.0.5, nan@^2.0.8, nan@^2.10.0, nan@^2.2.1, nan@^2.3.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -8099,12 +8095,6 @@ node-abi@^2.0.0:
   dependencies:
     semver "^5.4.1"
 
-node-abi@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.3.0.tgz#f3d554d6ac72a9ee16f0f4dc9548db7c08de4986"
-  dependencies:
-    semver "^5.4.1"
-
 node-abi@^2.7.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.7.1.tgz#a8997ae91176a5fbaa455b194976e32683cda643"
@@ -8157,15 +8147,7 @@ node-gyp@^3.6.0:
     tar "^2.0.0"
     which "1"
 
-node-hid@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.2.tgz#15025cdea2e9756aca2de7266529996d40e52c56"
-  dependencies:
-    bindings "^1.3.0"
-    nan "^2.6.2"
-    prebuild-install "^2.2.2"
-
-node-hid@^0.7.7:
+node-hid@0.7.7, node-hid@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/node-hid/-/node-hid-0.7.7.tgz#3341630231b534226b86d6758caba48a646799ed"
   dependencies:
@@ -9345,26 +9327,6 @@ postcss@^6.0.1:
     chalk "^2.3.2"
     source-map "^0.6.1"
     supports-color "^5.3.0"
-
-prebuild-install@^2.2.2:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.3.tgz#9f65f242782d370296353710e9bc843490c19f69"
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^1.0.2"
-    github-from-package "0.0.0"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    node-abi "^2.2.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
-    os-homedir "^1.0.1"
-    pump "^2.0.1"
-    rc "^1.1.6"
-    simple-get "^2.7.0"
-    tar-fs "^1.13.0"
-    tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
 
 prebuild-install@^5.2.4:
   version "5.2.5"


### PR DESCRIPTION
Closes #2462 

### Description

Updates `node-hid` to 0.7.7 to match the version used by `@ledgerhq/hw-transport-node-hid`, to fix an error with the desktop application.

### Changes

* See title

### Steps to Test

1. Run the desktop app
