### PR TITLE
Update Address Field Placeholder to include ENS name example

### DIFF
--- a/common/components/AddressField.tsx
+++ b/common/components/AddressField.tsx
@@ -35,7 +35,7 @@ const AddressField: React.SFC<Props> = ({
   showLabelMatch,
   toChecksumAddress,
   showIdenticon,
-  placeholder = donationAddressMap.ETH,
+  placeholder = "donate.mycryptoid.eth or 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520",
   showInputLabel = true,
   onChangeOverride,
   value,

--- a/common/components/AddressField.tsx
+++ b/common/components/AddressField.tsx
@@ -35,7 +35,7 @@ const AddressField: React.SFC<Props> = ({
   showLabelMatch,
   toChecksumAddress,
   showIdenticon,
-  placeholder = "donate.mycryptoid.eth or 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520",
+  placeholder = 'donate.mycryptoid.eth or 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520',
   showInputLabel = true,
   onChangeOverride,
   value,

--- a/common/components/AddressField.tsx
+++ b/common/components/AddressField.tsx
@@ -35,7 +35,7 @@ const AddressField: React.SFC<Props> = ({
   showLabelMatch,
   toChecksumAddress,
   showIdenticon,
-  placeholder = 'donate.mycryptoid.eth or 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520',
+  placeholder = `donate.mycryptoid.eth or ${donationAddressMap.ETH}`,
   showInputLabel = true,
   onChangeOverride,
   value,


### PR DESCRIPTION
Makes it more obvious that you can input an ENS name or an Ethereum address in the placeholder field. 

In future, probably only do this on networks that support ENS.