### PR TITLE
Add new fiat equivalent values and fix missing symbols

### DIFF
--- a/common/api/rates.ts
+++ b/common/api/rates.ts
@@ -23,6 +23,8 @@ interface ISymbol {
   ETH: number;
   RUB: number;
   JPY: number;
+  KRW: number;
+  INR: number;
 }
 interface IFiatSymbols {
   USD: number;
@@ -31,13 +33,15 @@ interface IFiatSymbols {
   CHF: number;
   RUB: number;
   JPY: number;
+  KRW: number;
+  INR: number;
 }
 interface ICoinAndTokenSymbols {
   BTC: number;
   ETH: number;
 }
 
-const fiat: TFiatSymbols = ['USD', 'EUR', 'GBP', 'CHF', 'RUB', 'JPY'];
+const fiat: TFiatSymbols = ['USD', 'EUR', 'GBP', 'CHF', 'RUB', 'JPY', 'KRW', 'INR'];
 const coinAndToken: TCoinAndTokenSymbols = ['BTC', 'ETH'];
 export const rateSymbols: IRateSymbols = {
   symbols: {
@@ -113,6 +117,8 @@ export const fetchRates = (symbols: string[] = []): Promise<CCResponse> =>
             CHF: rates.CHF,
             RUB: rates.RUB,
             JPY: rates.JPY,
+            KRW: rates.KRW,
+            INR: rates.INR,
             BTC: rates.BTC,
             ETH: 1
           }

--- a/common/api/rates.ts
+++ b/common/api/rates.ts
@@ -21,19 +21,23 @@ interface ISymbol {
   CHF: number;
   BTC: number;
   ETH: number;
+  RUB: number;
+  JPY: number;
 }
 interface IFiatSymbols {
   USD: number;
   EUR: number;
   GBP: number;
   CHF: number;
+  RUB: number;
+  JPY: number;
 }
 interface ICoinAndTokenSymbols {
   BTC: number;
   ETH: number;
 }
 
-const fiat: TFiatSymbols = ['USD', 'EUR', 'GBP', 'CHF'];
+const fiat: TFiatSymbols = ['USD', 'EUR', 'GBP', 'CHF', 'RUB', 'JPY'];
 const coinAndToken: TCoinAndTokenSymbols = ['BTC', 'ETH'];
 export const rateSymbols: IRateSymbols = {
   symbols: {
@@ -107,6 +111,8 @@ export const fetchRates = (symbols: string[] = []): Promise<CCResponse> =>
             EUR: rates.EUR,
             GBP: rates.GBP,
             CHF: rates.CHF,
+            RUB: rates.RUB,
+            JPY: rates.JPY,
             BTC: rates.BTC,
             ETH: 1
           }

--- a/common/components/BalanceSidebar/EquivalentValues.tsx
+++ b/common/components/BalanceSidebar/EquivalentValues.tsx
@@ -135,7 +135,9 @@ class EquivalentValues extends React.Component<Props, State> {
       GBP: '£',
       CHF: '₣',
       RUB: '₽',
-      JPY: '¥'
+      JPY: '¥',
+      KRW: '₩',
+      INR: '₹'
     };
     const coinAndTokenSymbols: any = {
       BTC: btcIco,

--- a/common/components/BalanceSidebar/EquivalentValues.tsx
+++ b/common/components/BalanceSidebar/EquivalentValues.tsx
@@ -133,7 +133,9 @@ class EquivalentValues extends React.Component<Props, State> {
       USD: '$',
       EUR: '€',
       GBP: '£',
-      CHF: ' '
+      CHF: '₣',
+      RUB: '₽',
+      JPY: '¥'
     };
     const coinAndTokenSymbols: any = {
       BTC: btcIco,

--- a/common/features/rates/reducer.spec.ts
+++ b/common/features/rates/reducer.spec.ts
@@ -11,7 +11,9 @@ describe('rates reducer', () => {
         EUR: 2,
         GBP: 3,
         CHF: 4,
-        ETH: 5
+        ETH: 5,
+        RUB: 6,
+        JPY: 7
       }
     };
 

--- a/common/features/rates/reducer.spec.ts
+++ b/common/features/rates/reducer.spec.ts
@@ -13,7 +13,9 @@ describe('rates reducer', () => {
         CHF: 4,
         ETH: 5,
         RUB: 6,
-        JPY: 7
+        JPY: 7,
+        KRW: 8,
+        INR: 9
       }
     };
 


### PR DESCRIPTION

### Description

Add new fiat equivalent values (RUB, JPY) and fix missing symbols


### Steps to Test

Check equivalent values in wallet holding page.

### Screenshots

<img width="452" alt="Screen Shot 2019-04-03 at 7 49 53 PM" src="https://user-images.githubusercontent.com/14166520/55526380-bf15f780-5649-11e9-80c2-835640354919.png">
