### PR TITLE
enable hardware wallets for ARTIS_TAU1

### DIFF
--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -817,9 +817,9 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     contracts: [],
     isTestnet: true,
     dPathFormats: {
-      //[SecureWalletName.TREZOR]: ARTIS_TAU1,
-      //[SecureWalletName.SAFE_T]: ARTIS_TAU1,
-      //[SecureWalletName.LEDGER_NANO_S]: ETH_LEDGER,
+      [SecureWalletName.TREZOR]: ARTIS_TAU1,
+      [SecureWalletName.SAFE_T]: ARTIS_TAU1,
+      [SecureWalletName.LEDGER_NANO_S]: ETH_LEDGER,
       [InsecureWalletName.MNEMONIC_PHRASE]: ARTIS_TAU1
     },
     gasPriceSettings: {


### PR DESCRIPTION
Hardware wallets work with ARTIS_TAU1 like ARTIS_SIGMA1 where they are already enabled.

For ARTIS see: https://github.com/MyCryptoHQ/MyCrypto/pull/2358