### PR TITLE
Fix owner vs deedOwner bug

### DIFF
--- a/common/containers/Tabs/ENS/components/NameResolve/components/NameOwned.tsx
+++ b/common/containers/Tabs/ENS/components/NameResolve/components/NameOwned.tsx
@@ -15,6 +15,7 @@ export const NameOwned: React.SFC<IOwnedDomainRequest> = ({
   nameHash,
   resolvedAddress,
   ownerAddress,
+  deedOwnerAddress,
   name
 }) => (
   <section>
@@ -42,6 +43,12 @@ export const NameOwned: React.SFC<IOwnedDomainRequest> = ({
             <td>{translate('NAME_OWNED_OWNER')}:</td>
             <MonoTd>
               <Address address={ownerAddress} />
+            </MonoTd>
+          </tr>
+          <tr>
+            <td>{translate('NAME_OWNED_DEEDOWNER')}:</td>
+            <MonoTd>
+              <Address address={deedOwnerAddress} />
             </MonoTd>
           </tr>
           <tr>

--- a/common/features/ens/helpers.ts
+++ b/common/features/ens/helpers.ts
@@ -27,7 +27,6 @@ export function* makeEthCallAndDecode({ to, data, decoder }: Params): SagaIterat
 function* nameStateOwned({ deedAddress }: IDomainData<NameState.Owned>, nameHash: string) {
   const ensAddresses = yield select(getENSAddresses);
 
-
   // Return the owner's address, and the resolved address if it exists
   // NOTE: THE DEED OWNER IS NOT THE OWNER
   // CHECK LEGACY.MYCRYPTO.COM FOR THE DIFFERENCE BETWEEN DEED OWNER AND OWNER

--- a/common/features/ens/helpers.ts
+++ b/common/features/ens/helpers.ts
@@ -27,11 +27,19 @@ export function* makeEthCallAndDecode({ to, data, decoder }: Params): SagaIterat
 function* nameStateOwned({ deedAddress }: IDomainData<NameState.Owned>, nameHash: string) {
   const ensAddresses = yield select(getENSAddresses);
 
-  // Return the owner's address, and the resolved address if it exists
-  const { ownerAddress }: typeof ENS.deed.owner.outputType = yield call(makeEthCallAndDecode, {
+  // Return the deed owner's address, and the resolved address if it exists
+  const { deedOwnerAddress }: typeof ENS.deed.owner.outputType = yield call(makeEthCallAndDecode, {
     to: deedAddress,
     data: ENS.deed.owner.encodeInput(),
     decoder: ENS.deed.owner.decodeOutput
+  });
+
+  const { ownerAddress }: typeof ENS.registry.owner.outputType = yield call(makeEthCallAndDecode, {
+    to: ensAddresses.registry,
+    data: ENS.registry.resolver.encodeInput({
+      node: nameHash
+    }),
+    decoder: ENS.registry.owner.decodeOutput
   });
 
   const { resolverAddress }: typeof ENS.registry.resolver.outputType = yield call(
@@ -57,16 +65,16 @@ function* nameStateOwned({ deedAddress }: IDomainData<NameState.Owned>, nameHash
     resolvedAddress = result.ret;
   }
 
-  return { ownerAddress, resolvedAddress };
+  return { ownerAddress, deedOwnerAddress, resolvedAddress };
 }
 
 function* nameStateReveal({ deedAddress }: IDomainData<NameState.Reveal>): SagaIterator {
-  const { ownerAddress }: typeof ENS.deed.owner.outputType = yield call(makeEthCallAndDecode, {
+  const { deedOwnerAddress }: typeof ENS.deed.owner.outputType = yield call(makeEthCallAndDecode, {
     to: deedAddress,
     data: ENS.deed.owner.encodeInput(),
     decoder: ENS.deed.owner.decodeOutput
   });
-  return { ownerAddress };
+  return { deedOwnerAddress };
 }
 
 interface IModeMap {
@@ -76,7 +84,7 @@ interface IModeMap {
     hash?: Buffer
   ) =>
     | {}
-    | { ownerAddress: string; resolvedAddress: string }
+    | { deedOwnerAddress: string; resolvedAddress: string }
     | { auctionCloseTime: string; revealBidTime: string };
 }
 

--- a/common/libs/ens/contracts/deed/deed.d.ts
+++ b/common/libs/ens/contracts/deed/deed.d.ts
@@ -5,7 +5,7 @@ export interface IDeed {
   destroyDeed: ABIFuncParamless;
   setOwner: ABIFunc<{ newOwner: address }>;
   registrar: ABIFuncParamless<{ registrarAddress: address }>;
-  owner: ABIFuncParamless<{ ownerAddress: address }>;
+  owner: ABIFuncParamless<{ deedOwnerAddress: address }>;
   closeDeed: ABIFunc<{ refundRatio: uint256 }>;
   setRegistrar: ABIFunc<{ newRegistrar: address }>;
   setBalance: ABIFunc<{ newValue: uint256 }>;

--- a/common/libs/ens/contracts/deed/outputMappings.ts
+++ b/common/libs/ens/contracts/deed/outputMappings.ts
@@ -1,5 +1,5 @@
 export default {
   creationDate: ['creationDate'],
   registrar: ['registrarAddress'],
-  owner: ['ownerAddress']
+  owner: ['deedOwnerAddress']
 };

--- a/common/libs/ens/index.ts
+++ b/common/libs/ens/index.ts
@@ -39,6 +39,7 @@ export interface IBaseDomainRequest {
 
 export interface IOwnedDomainRequest extends IBaseDomainRequest {
   ownerAddress: string;
+  deedOwnerAddress: string;
   resolvedAddress: string;
 }
 

--- a/common/libs/ens/index.ts
+++ b/common/libs/ens/index.ts
@@ -43,7 +43,7 @@ export interface IOwnedDomainRequest extends IBaseDomainRequest {
 }
 
 export interface IRevealDomainRequest extends IBaseDomainRequest {
-  ownerAddress: string;
+  deedOwnerAddress: string;
 }
 
 export type DomainRequest = IOwnedDomainRequest | IRevealDomainRequest | IBaseDomainRequest;

--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -602,6 +602,7 @@
     "NAME_OWNED_LABELHASH": "Labelhash $name",
     "NAME_OWNED_NAMEHASH": "Namehash $name.eth",
     "NAME_OWNED_OWNER": "Owner",
+    "NAME_OWNED_DEEDOWNER": "Deed Owner",
     "NAME_OWNED_HIGHEST_BIDDER": "Highest Bidder",
     "NAME_OWNED_HIGHEST_BID": "Highest Bid",
     "NAME_OWNED_RESOLVED_ADDR": "Resolved Address",

--- a/common/translations/lang/fr.json
+++ b/common/translations/lang/fr.json
@@ -601,6 +601,7 @@
     "NAME_OWNED_LABELHASH": "Labelhash $name",
     "NAME_OWNED_NAMEHASH": "Namehash $name.eth",
     "NAME_OWNED_OWNER": "Propriétaire",
+    "NAME_OWNED_DEEDOWNER": "Propriétaire de l'acte",
     "NAME_OWNED_HIGHEST_BIDDER": "Meilleur enchérisseur",
     "NAME_OWNED_HIGHEST_BID": "Meilleure enchère",
     "NAME_OWNED_RESOLVED_ADDR": "Adresse résolue",

--- a/common/translations/lang/ja.json
+++ b/common/translations/lang/ja.json
@@ -533,6 +533,7 @@
     "NAME_OWNED_LABELHASH": "ラベルハッシュ $name",
     "NAME_OWNED_NAMEHASH": "名前ハッシュ $name.eth",
     "NAME_OWNED_OWNER": "所有者",
+    "NAME_OWNED_DEEDOWNER": "行為の所有者",
     "NAME_OWNED_HIGHEST_BIDDER": "最高額入札者",
     "NAME_OWNED_RESOLVED_ADDR": "解決されたアドレス",
     "LINK": "[$name]($link)",

--- a/common/translations/lang/ko.json
+++ b/common/translations/lang/ko.json
@@ -604,6 +604,7 @@
     "NAME_OWNED_LABELHASH": "라벨해시 $name",
     "NAME_OWNED_NAMEHASH": "이름해시 $name.eth",
     "NAME_OWNED_OWNER": "소유자",
+    "NAME_OWNED_DEEDOWNER": "증서 주인",
     "NAME_OWNED_HIGHEST_BIDDER": "최고가 입찰자",
     "NAME_OWNED_HIGHEST_BID": "최고가 입찰",
     "NAME_OWNED_RESOLVED_ADDR": "분석된 주소",


### PR DESCRIPTION
### Description

Fixes issue where ens lookup resulted in ens owner displaying as the deedowner instead of the Registry owner.

### Changes

* Replace `owner` with `deedOwner`.
* Added actual owner lookup.
* Added a new field for *Deed Owner*.


### Steps to Test

1. Lookup `mycrypto.eth` in mycrypto.com/ens. It should have no owner.
2. Lookup `michaelhahn.eth` in mycrypto.com/ens. It should have owner `0x5FfC014343cd971B7eb70732021E26C35B744cc4`


### Screenshots

![image](https://user-images.githubusercontent.com/29407814/56100099-138b6380-5ee3-11e9-93bc-8c2686fd1212.png)
