### PR TITLE
Reroute back button to beginning of add-account flow

### DIFF
--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -322,7 +322,7 @@ const WalletDecrypt = withRouter<Props>(
           <div className="WalletDecrypt-decrypt">
             <InsecureWalletWarning
               walletType={translateRaw(selectedWallet.lid)}
-              onCancel={this.clearWalletChoice}
+              onCancel={this.returnToSender}
             />
             {process.env.NODE_ENV !== 'production' && (
               <button
@@ -339,7 +339,7 @@ const WalletDecrypt = withRouter<Props>(
       return (
         <div className="Panel">
           <div className="Panel-top">
-            <Button basic={true} onClick={this.clearWalletChoice}>
+            <Button basic={true} onClick={this.returnToSender}>
               <Typography>
                 {' '}
                 <img src={backArrow} />
@@ -359,7 +359,7 @@ const WalletDecrypt = withRouter<Props>(
                 errorMessage={`Oops, looks like ${translateRaw(
                   selectedWallet.lid
                 )} is not supported by your browser`}
-                onError={this.clearWalletChoice}
+                onError={this.returnToSender}
                 shouldCatch={selectedWallet.lid === this.WALLETS.paritySigner.lid}
               >
                 <selectedWallet.component
@@ -470,7 +470,7 @@ const WalletDecrypt = withRouter<Props>(
       return (
         <div className="Panel">
           <div className="SelectNetworkPanel-top">
-            <Button basic={true} onClick={this.clearWalletChoice}>
+            <Button basic={true} onClick={this.returnToSender}>
               <Typography>
                 {' '}
                 <img src={backArrow} />
@@ -553,6 +553,23 @@ const WalletDecrypt = withRouter<Props>(
       }, timeout);
     };
 
+    public returnToSender = () => {
+      this.setState({
+        selectedWalletKey: null,
+        isInsecureOverridden: false,
+        value: null,
+        hasSelectedNetwork: false,
+        hasSelectedAddress: false,
+        accountData: {
+          address: '',
+          network: 'Ethereum',
+          label: 'New Account',
+          accountType: MiscWalletName.VIEW_ONLY,
+          derivationPath: ''
+        }
+      });
+    }
+    /*
     public clearWalletChoice = () => {
       this.setState({
         selectedWalletKey: null,
@@ -574,7 +591,7 @@ const WalletDecrypt = withRouter<Props>(
           derivationPath: ''
         }
       });
-    };
+    };*/
 
     public render() {
       const { hidden } = this.props;
@@ -702,7 +719,7 @@ export default connect(mapStateToProps, {
   unlockKeystore: WalletActions.unlockKeystore,
   unlockMnemonic: WalletActions.unlockMnemonic,
   unlockPrivateKey: WalletActions.unlockPrivateKey,
-  unlockWeb3: WalletActions.unlockWeb3,
+  unlockWeb3: walletActions.unlockWeb3,
   setWallet: walletActions.setWallet,
   resetTransactionRequested: transactionFieldsActions.resetTransactionRequested,
   showNotification: notificationsActions.showNotification

--- a/common/v2/features/Wallets/web3/web3.ts
+++ b/common/v2/features/Wallets/web3/web3.ts
@@ -8,13 +8,12 @@ import {
   makeProviderConfig
 } from 'libs/nodes';
 import { configNodesSelectedActions, configNodesStaticActions } from 'features/config';
-import { StaticNodeConfig } from 'v2/services/NodeOptions/types';
+import { StaticNodeConfig, CustomNodeConfig } from 'v2/services/NodeOptions/types';
 import { getNetworkByChainId, NetworkSelect } from 'v2/libs';
 import { translateRaw } from 'translations';
 import { LocalCache } from 'v2/services/LocalCache/constants';
-import NodeOptionsServiceBase from 'v2/services/NodeOptions/NodeOptions';
+import { createNodeOptions }  from 'v2/services/NodeOptions/NodeOptions';
 
-const NodeOptions = new NodeOptionsServiceBase();
 
 //#region Web3
 
@@ -104,6 +103,6 @@ export const getNodes = async () => {};
 
 export const getCurrentNode = async () => {};
 
-export const createNewWeb3Node = async (id: string, newNode: StaticNodeConfig) => {
-  NodeOptions.createNodeOptions({ ...newNode, name: id, type: 'web3' });
+export const createNewWeb3Node = async (id: string, newNode: CustomNodeConfig) => {
+  createNodeOptions({ ...newNode, name: id, type: 'web3' });
 };


### PR DESCRIPTION
### Changes

* Changed back button in add-existing-account flow to reroute to beginning of flow by resetting local flow state.
* Fixed a quick issue not allowing pageload


### Steps to Test

1. Navigate to https://localhost/add-account
2. Go through flow for mnemonic option until you get to select address view.
3. Hit the back button. Should reroute you to https://localhost/add-account again at the wallet select view