### PR TITLE
Add DEXON support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -173,6 +173,11 @@ export const METADIUM_DEFAULT: DPath = {
   value: "m/44'/916'/0'/0"
 };
 
+export const DEXON_DEFAULT: DPath = {
+  label: 'Default (DEXON)',
+  value: "m/44'/237'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -207,7 +212,8 @@ export const DPaths: DPath[] = [
   ARTIS_TAU1,
   THUNDERCORE_DEFAULT,
   WEB_DEFAULT,
-  METADIUM_DEFAULT
+  METADIUM_DEFAULT,
+  DEXON_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "METADIUM",
+      "DEXON",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -39,7 +39,8 @@ import {
   ARTIS_TAU1,
   THUNDERCORE_DEFAULT,
   WEB_DEFAULT,
-  METADIUM_DEFAULT
+  METADIUM_DEFAULT,
+  DEXON_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import { TAB } from 'components/Header/components/constants';
@@ -896,6 +897,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       min: 80,
       max: 80,
       initial: 80
+    }
+  },
+  DEXON: {
+    id: 'DEXON',
+    name: 'DEXON Network',
+    unit: 'DXN',
+    chainId: 237,
+    isCustom: false,
+    color: '#954a97',
+    blockExplorer: makeExplorer({
+      name: 'DEXON Scan',
+      origin: 'https://dexonscan.app',
+      txPath: 'transaction'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.LEDGER_NANO_S]: DEXON_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: DEXON_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 24,
+      max: 100,
+      initial: 24
     }
   }
 };

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -358,6 +358,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'api.metadium.com',
       url: 'https://api.metadium.com/prod'
     }
+  ],
+
+  DEXON: [
+    {
+      name: makeNodeName('DEXON', 'dexon'),
+      type: 'rpc',
+      service: 'dexon.org',
+      url: 'https://mainnet-rpc.dexon.org'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -34,7 +34,8 @@ type StaticNetworkIds =
   | 'ARTIS_TAU1'
   | 'THUNDERCORE'
   | 'WEB'
-  | 'METADIUM';
+  | 'METADIUM'
+  | 'DEXON';
 
 export interface BlockExplorerConfig {
   name: string;


### PR DESCRIPTION
### Description
DEXON is an EVM compatible, low latency, high-throughput blockchain.

Homepage: https://dexon.org
RPC: https://mainnet-rpc.dexon.org
BIP44 237/ ChainId 237 (https://github.com/satoshilabs/slips/pull/478)

### Changes
This PR adds DEXON support
Standard chain support changes