### PR TITLE
Re-Enable Default_ETH dpath by removing Default_AQUA

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -113,11 +113,6 @@ export const ESN_DEFAULT: DPath = {
   value: "m/44'/31102'/0'/0"
 };
 
-export const AQUA_DEFAULT: DPath = {
-  label: 'Default (AQUA)',
-  value: "m/44'/60'/0'/0"
-};
-
 export const AKA_DEFAULT: DPath = {
   label: 'Default (AKA)',
   value: "m/44'/200625'/0'/0"
@@ -196,7 +191,6 @@ export const DPaths: DPath[] = [
   GO_DEFAULT,
   EOSC_DEFAULT,
   ESN_DEFAULT,
-  AQUA_DEFAULT,
   AKA_DEFAULT,
   PIRL_DEFAULT,
   ATH_DEFAULT,

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -28,7 +28,6 @@ import {
   GO_DEFAULT,
   EOSC_DEFAULT,
   ESN_DEFAULT,
-  AQUA_DEFAULT,
   AKA_DEFAULT,
   PIRL_DEFAULT,
   ATH_DEFAULT,
@@ -620,9 +619,9 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     tokens: [],
     contracts: [],
     dPathFormats: {
-      [SecureWalletName.TREZOR]: AQUA_DEFAULT,
-      [SecureWalletName.LEDGER_NANO_S]: AQUA_DEFAULT,
-      [InsecureWalletName.MNEMONIC_PHRASE]: AQUA_DEFAULT
+      [SecureWalletName.TREZOR]: ETH_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: ETH_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ETH_DEFAULT
     },
     gasPriceSettings: {
       min: 0.1,


### PR DESCRIPTION
*To help us understand & test your amazing contribution, please include the below information with your PR. 🙏 Thanks!*

### Description

Removed the Default_Aqua dpath as it was frontrunning the Default_ETH dpath, causing it to display incorrectly.

### Steps to Test

1. Access account, in select address modal, note that Default_ETH dpath exists again at `ETH_DEFAULT`
