### PR TITLE
Add-account flow default changes

### DIFF
--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -275,30 +275,18 @@ const WalletDecrypt = withRouter<Props>(
       return this.WALLETS[selectedWalletKey];
     }
 
-    public handleCreateAccount = (createAccount: any) => {
+    public handleCreateAccount = (createAccount: ((newAccount: Account) => void)) => {
       const { accountData } = this.state;
       const network: NetworkOptions | undefined = getNetworkByName(accountData.network);
-      if (!network) {
-        const newAccount: Account = {
-          ...accountData,
-          assets: 'DefaultAsset',
-          value: 0,
-          label: 'New Account',
-          localSettings: 'default',
-          transactionHistory: ''
-        };
-        createAccount(newAccount);
-      } else {
-        const newAccount: Account = {
-          ...accountData,
-          assets: network.unit,
-          value: 0,
-          label: 'New Account',
-          localSettings: 'default',
-          transactionHistory: ''
-        };
-        createAccount(newAccount);
-      }
+      const newAccount: Account = {
+        ...accountData,
+        assets: network ? network.unit : 'DefaultAsset',
+        value: 0,
+        label: 'New Account',
+        localSettings: 'default',
+        transactionHistory: ''
+      };
+      createAccount(newAccount);
     };
 
     public handleCompleteFlow() {

--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -275,23 +275,23 @@ const WalletDecrypt = withRouter<Props>(
       return this.WALLETS[selectedWalletKey];
     }
 
-    public handleCreateAccount = async (createAccount: any) => {
+    public handleCreateAccount = (createAccount: any) => {
       const { accountData } = this.state;
-      try {
-        const network: NetworkOptions = await getNetworkByName(accountData.network);
+      const network: NetworkOptions | undefined = getNetworkByName(accountData.network);
+      if (!network) {
         const newAccount: Account = {
           ...accountData,
-          assets: network.unit,
+          assets: 'DefaultAsset',
           value: 0,
           label: 'New Account',
           localSettings: 'default',
           transactionHistory: ''
         };
         createAccount(newAccount);
-      } catch {
+      } else {
         const newAccount: Account = {
           ...accountData,
-          assets: 'DefaultAsset',
+          assets: network.unit,
           value: 0,
           label: 'New Account',
           localSettings: 'default',

--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -52,6 +52,8 @@ import { NetworkOptionsContext, AccountContext } from 'v2/providers';
 import { Link } from 'react-router-dom';
 import { Account } from 'v2/services/Account/types';
 import { Web3Decrypt } from 'components/WalletDecrypt/components/Web3';
+import { getNetworkByName } from 'v2/libs';
+import { NetworkOptions } from 'v2/services/NetworkOptions/types';
 
 interface OwnProps {
   hidden?: boolean;
@@ -273,19 +275,30 @@ const WalletDecrypt = withRouter<Props>(
       return this.WALLETS[selectedWalletKey];
     }
 
-    public handleCreateAccount = (createAccount: any) => {
+    public handleCreateAccount = async (createAccount: any) => {
       const { accountData } = this.state;
-      //const network = accountData.network;
-      //const asset = getBaseAsset(network);
-      const newAccount: Account = {
-        ...accountData,
-        assets: '',
-        value: 0,
-        label: 'New Account',
-        localSettings: '',
-        transactionHistory: ''
-      };
-      createAccount(newAccount);
+      try {
+        const network: NetworkOptions = await getNetworkByName(accountData.network);
+        const newAccount: Account = {
+          ...accountData,
+          assets: network.unit,
+          value: 0,
+          label: 'New Account',
+          localSettings: '',
+          transactionHistory: ''
+        };
+        createAccount(newAccount);
+      } catch {
+        const newAccount: Account = {
+          ...accountData,
+          assets: 'DefaultAsset',
+          value: 0,
+          label: 'New Account',
+          localSettings: '',
+          transactionHistory: ''
+        };
+        createAccount(newAccount);
+      }
     };
 
     public handleCompleteFlow() {
@@ -522,9 +535,9 @@ const WalletDecrypt = withRouter<Props>(
                     className="Panel-dropdown"
                     value={this.state.accountData.network}
                     items={new Set(networkNames.sort())}
-                    onChange={({ target: { value } }) =>
-                      this.setState({ accountData: { ...this.state.accountData, network: value } })
-                    }
+                    onChange={({ target: { value } }) => {
+                      this.setState({ accountData: { ...this.state.accountData, network: value } });
+                    }}
                     placeholder="Ethereum"
                   />
                 );

--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -284,7 +284,7 @@ const WalletDecrypt = withRouter<Props>(
           assets: network.unit,
           value: 0,
           label: 'New Account',
-          localSettings: '',
+          localSettings: 'default',
           transactionHistory: ''
         };
         createAccount(newAccount);
@@ -294,7 +294,7 @@ const WalletDecrypt = withRouter<Props>(
           assets: 'DefaultAsset',
           value: 0,
           label: 'New Account',
-          localSettings: '',
+          localSettings: 'default',
           transactionHistory: ''
         };
         createAccount(newAccount);

--- a/common/v2/features/Wallets/web3/web3.ts
+++ b/common/v2/features/Wallets/web3/web3.ts
@@ -8,7 +8,7 @@ import {
   makeProviderConfig
 } from 'libs/nodes';
 import { CustomNodeConfig, NodeOptions } from 'v2/services/NodeOptions/types';
-import { getNetworkByChainId, NetworkSelect } from 'v2/libs';
+import { getNetworkByChainId } from 'v2/libs';
 import { translateRaw } from 'translations';
 import {
   createNodeOptions,
@@ -16,6 +16,7 @@ import {
   createNodeOptionsWithID
 } from 'v2/services/NodeOptions/NodeOptions';
 import { updateCurrents, readCurrents } from 'v2/services/Currents/Currents';
+import { NetworkOptions } from 'v2/services/NetworkOptions/types';
 
 //#region Web3
 
@@ -23,7 +24,7 @@ let web3Added = true;
 
 export const initWeb3Node = async () => {
   const { chainId, lib } = await setupWeb3Node();
-  const network: NetworkSelect = getNetworkByChainId(chainId);
+  const network: NetworkOptions = await getNetworkByChainId(chainId);
   if (!network) {
     throw new Error(`MyCrypto doesn’t support the network with chain ID '${chainId}'`);
   }

--- a/common/v2/features/Wallets/web3/web3.ts
+++ b/common/v2/features/Wallets/web3/web3.ts
@@ -24,7 +24,7 @@ let web3Added = true;
 
 export const initWeb3Node = async () => {
   const { chainId, lib } = await setupWeb3Node();
-  const network: NetworkOptions = await getNetworkByChainId(chainId);
+  const network: NetworkOptions | undefined = getNetworkByChainId(chainId);
   if (!network) {
     throw new Error(`MyCrypto doesn’t support the network with chain ID '${chainId}'`);
   }

--- a/common/v2/libs/networks/index.ts
+++ b/common/v2/libs/networks/index.ts
@@ -1,2 +1,1 @@
 export * from './networks';
-export * from './types';

--- a/common/v2/libs/networks/networks.ts
+++ b/common/v2/libs/networks/networks.ts
@@ -5,36 +5,12 @@ export const getAllNetworks = () => {
   return Object.values(getCache().networkOptions);
 };
 
-export const getNetworkByChainId = (chainId: string): Promise<NetworkOptions> => {
-  return new Promise((resolve, reject) => {
-    try {
-      const networks = getAllNetworks();
-
-      networks.map((network: NetworkOptions) => {
-        if (network.chainId === parseInt(chainId, 16)) {
-          resolve(network);
-        }
-      });
-      reject();
-    } catch (e) {
-      reject();
-    }
-  });
+export const getNetworkByChainId = (chainId: string): NetworkOptions | undefined => {
+  const networks = getAllNetworks() || [];
+  return networks.find((network: NetworkOptions) => network.chainId === parseInt(chainId, 16));
 };
 
-export const getNetworkByName = async (name: string): Promise<NetworkOptions> => {
-  return new Promise((resolve, reject) => {
-    try {
-      const networks = getAllNetworks();
-
-      networks.map((network: NetworkOptions) => {
-        if (network.name === name) {
-          resolve(network);
-        }
-      });
-      reject();
-    } catch (e) {
-      reject();
-    }
-  });
+export const getNetworkByName = (name: string): NetworkOptions | undefined => {
+  const networks = getAllNetworks() || [];
+  return networks.find((network: NetworkOptions) => network.name === name);
 };

--- a/common/v2/libs/networks/networks.ts
+++ b/common/v2/libs/networks/networks.ts
@@ -1,19 +1,40 @@
-import { NetworkSelect } from './types';
 import { getCache } from 'v2/services/LocalCache';
 import { NetworkOptions } from 'v2/services/NetworkOptions/types';
 
-export const getNetworkByChainId = (chainId: string): NetworkSelect => {
-  const networks = getAllNetworks();
-
-  let networkToSelect = null;
-  networks.map((network: NetworkOptions) => {
-    if (network.chainId === parseInt(chainId, 16)) {
-      networkToSelect = network;
-    }
-  });
-  return networkToSelect === null ? null : networkToSelect;
-};
-
 export const getAllNetworks = () => {
   return Object.values(getCache().networkOptions);
+};
+
+export const getNetworkByChainId = (chainId: string): Promise<NetworkOptions> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const networks = getAllNetworks();
+
+      networks.map((network: NetworkOptions) => {
+        if (network.chainId === parseInt(chainId, 16)) {
+          resolve(network);
+        }
+      });
+      reject();
+    } catch (e) {
+      reject();
+    }
+  });
+};
+
+export const getNetworkByName = async (name: string): Promise<NetworkOptions> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const networks = getAllNetworks();
+
+      networks.map((network: NetworkOptions) => {
+        if (network.name === name) {
+          resolve(network);
+        }
+      });
+      reject();
+    } catch (e) {
+      reject();
+    }
+  });
 };

--- a/common/v2/libs/networks/types.ts
+++ b/common/v2/libs/networks/types.ts
@@ -1,3 +1,0 @@
-import { NetworkOptions } from 'v2/services/NetworkOptions/types';
-
-export type NetworkSelect = NetworkOptions | null;

--- a/common/v2/services/AssetOption/types.ts
+++ b/common/v2/services/AssetOption/types.ts
@@ -2,11 +2,11 @@ export interface AssetOption {
   name: string;
   network: string;
   ticker: string;
-  type: string;
+  type: assetOptionMethod;
   decimal: number;
   contractAddress: null;
 }
-
+export type assetOptionMethod = 'base' | 'call';
 export interface ExtendedAssetOption extends AssetOption {
   uuid: string;
 }

--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -80,7 +80,7 @@ export const initNetworkOptions = () => {
     });
     const newLocalNetwork: types.NetworkOptions = {
       contracts: newContracts,
-      assets: [],
+      assets: [STATIC_NETWORKS_INITIAL_STATE[en].id],
       nodes: [],
       id: STATIC_NETWORKS_INITIAL_STATE[en].id,
       name: STATIC_NETWORKS_INITIAL_STATE[en].name,
@@ -95,7 +95,16 @@ export const initNetworkOptions = () => {
       gasPriceSettings: STATIC_NETWORKS_INITIAL_STATE[en].gasPriceSettings,
       shouldEstimateGasPrice: STATIC_NETWORKS_INITIAL_STATE[en].shouldEstimateGasPrice
     };
+    const newLocalAssetOption: types.AssetOption = {
+      name: STATIC_NETWORKS_INITIAL_STATE[en].name,
+      network: en,
+      ticker: en,
+      type: 'base',
+      decimal: 18,
+      contractAddress: null
+    };
     newStorage.networkOptions[en] = newLocalNetwork;
+    newStorage.assetOptions[STATIC_NETWORKS_INITIAL_STATE[en].id] = newLocalAssetOption;
   });
   setCache(newStorage);
 };

--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -25,6 +25,8 @@ export const initializeCache = () => {
 
     initGlobalSettings();
 
+    initLocalSettings();
+
     initContractOptions();
   }
 };
@@ -38,6 +40,17 @@ export const initGlobalSettings = () => {
   newStorage.globalSettings = {
     fiatCurrency: 'USD',
     darkMode: false
+  };
+  setCache(newStorage);
+};
+
+export const initLocalSettings = () => {
+  const newStorage = getCacheRaw();
+  newStorage.localSettings = {
+    default: {
+      fiatCurrency: 'USD',
+      favorite: false
+    }
   };
   setCache(newStorage);
 };

--- a/common/v2/services/LocalCache/constants.ts
+++ b/common/v2/services/LocalCache/constants.ts
@@ -159,11 +159,11 @@ export const CACHE_INIT_DEV: LocalCache = {
     }
   },
   assetOptions: {
-    Ethereum: {
+    ETH: {
       name: 'Ethereum',
-      network: 'Ethereum',
+      network: 'ETH',
       ticker: 'ETH',
-      type: 'coin',
+      type: 'base',
       decimal: 18,
       contractAddress: null
     }


### PR DESCRIPTION
### Description

Edits the defaults for account object in add-account flow.


TODO: 
- [x] Change accountData information depending on network - @blurpesec - #2528
- - [x] Asset (should be set to base asset of each network)
- - [x] Label (get feedback on this, currently set to "New Account") *Leaving this alone for now - make a task for this in PM tool*
- - [x] LocalSettings (figure out some default value for this and set it)
- - [x] TransactionHistory (leave as empty string until filled in by user..?) *Leaving this alone*