### PR TITLE
Remove 'Confirm Address' View

### DIFF
--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, { Component } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
-import { withRouter, RouteComponentProps } from 'react-router';
+import { withRouter, RouteComponentProps, Redirect, Route } from 'react-router';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 
@@ -49,7 +49,6 @@ import backArrow from 'common/assets/images/icn-back-arrow.svg';
 import * as WalletActions from 'v2/features/Wallets';
 
 import { NetworkOptionsContext, AccountContext } from 'v2/providers';
-import { Link } from 'react-router-dom';
 import { Account } from 'v2/services/Account/types';
 import { Web3Decrypt } from 'components/WalletDecrypt/components/Web3';
 import { getNetworkByName } from 'v2/libs';
@@ -290,22 +289,16 @@ const WalletDecrypt = withRouter<Props>(
     };
 
     public handleCompleteFlow() {
-      const { accountData } = this.state;
       return (
         <AccountContext.Consumer>
-          {({ createAccount }) => (
-            <div>
-              {`You're trying to add an ${accountData.network} address ${
-                accountData.address
-              } to your
-                dashboard.`}
-              <Link to="/dashboard" color="white">
-                <Button onClick={() => this.handleCreateAccount(createAccount)}>
-                  {'Confirm address'}
-                </Button>
-              </Link>
-            </div>
-          )}
+          {({ createAccount }) => {
+            this.handleCreateAccount(createAccount);
+            return (
+              <Route>
+                <Redirect to="/dashboard" />
+              </Route>
+            );
+          }}
         </AccountContext.Consumer>
       );
     }

--- a/common/v2/features/DevTools/DevTools.tsx
+++ b/common/v2/features/DevTools/DevTools.tsx
@@ -39,7 +39,8 @@ const DevTools = () => {
                 accountType: SecureWalletName.WEB3,
                 value: 0,
                 transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',
-                uuid: '61d84f5e-0efa-46b9-915c-aed6ebe5a4dc'
+                uuid: '61d84f5e-0efa-46b9-915c-aed6ebe5a4dc',
+                derivationPath: `m/44'/60'/0'/0/0`
               }}
               onSubmit={(values: ExtendedAccount, { setSubmitting }) => {
                 createAccount(values);

--- a/common/v2/providers/AccountProvider/AccountProvider.tsx
+++ b/common/v2/providers/AccountProvider/AccountProvider.tsx
@@ -1,10 +1,10 @@
 import React, { Component, createContext } from 'react';
 import * as service from 'v2/services/Account/Account';
-import { ExtendedAccount } from 'v2/services/Account';
+import { Account, ExtendedAccount } from 'v2/services/Account';
 
 export interface ProviderState {
   accounts: ExtendedAccount[];
-  createAccount(accountData: ExtendedAccount): void;
+  createAccount(accountData: Account): void;
   deleteAccount(uuid: string): void;
   updateAccount(uuid: string, accountData: ExtendedAccount): void;
 }
@@ -14,7 +14,7 @@ export const AccountContext = createContext({} as ProviderState);
 export class AccountProvider extends Component {
   public readonly state: ProviderState = {
     accounts: service.readAccounts() || [],
-    createAccount: (accountData: ExtendedAccount) => {
+    createAccount: (accountData: Account) => {
       service.createAccount(accountData);
       this.getAccounts();
     },

--- a/common/v2/services/Account/types.ts
+++ b/common/v2/services/Account/types.ts
@@ -9,6 +9,7 @@ export interface Account {
   accountType: WalletName;
   value: number;
   transactionHistory: string;
+  derivationPath: string;
 }
 
 export interface ExtendedAccount extends Account {

--- a/common/v2/services/LocalCache/constants.ts
+++ b/common/v2/services/LocalCache/constants.ts
@@ -45,7 +45,8 @@ export const CACHE_INIT_DEV: LocalCache = {
       assets: '12d3cbf2-de3a-4050-a0c6-521592e4b85a',
       accountType: SecureWalletName.WEB3,
       value: 1e18,
-      transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882'
+      transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',
+      derivationPath: `m/44'/60'/0'/0/0`
     }
   },
   transactionHistories: {


### PR DESCRIPTION
### Description

Finishes up handling of data in Add Existing Account flow.


### Changes

* Removed 'Confirm Address' View.
* Added derivation path to Account objects (added in type and initialization files).
* Redirect automatically to Dashboard (endpoint: `/dashboard`).

###### Todo
- [x] Fix routing to dashboard at end of flow to occur *AFTER* account is added to localCache - @blurpesec
- [x] Get rid of "Confirm Address" page as it's not in designs, automatically route to dashboard. - @blurpesec