### PR TITLE
Fix incorrect URL for non-auctioned ENS domains

### DIFF
--- a/common/containers/Tabs/ENS/components/NameResolve/components/NameAuction.tsx
+++ b/common/containers/Tabs/ENS/components/NameResolve/components/NameAuction.tsx
@@ -34,7 +34,7 @@ export const NameAuction: React.SFC<IBaseDomainRequest> = props => {
           </section>
         </div>
 
-        <h1>{translate('NAME_AUCTION_PROMPT_BID')}</h1>
+        <h1>{translate('NAME_AUCTION_PROMPT_BID', { $name: name })}</h1>
         <h3>
           <NewTabLink className="text-center" href={ensV3Url(name + '.eth')}>
             {translate('ENS_SEND_TO_MANAGER', { $name: name + '.eth' })}

--- a/common/containers/Tabs/ENS/components/NameResolve/components/NameForbidden.tsx
+++ b/common/containers/Tabs/ENS/components/NameResolve/components/NameForbidden.tsx
@@ -11,7 +11,7 @@ export const NameForbidden: React.SFC<IBaseDomainRequest> = props => (
       <div className="ens-title">
         <h1>{translate('ENS_DOMAIN_FORBIDDEN', { $name: props.name + '.eth' })}</h1>
         <h3>
-          <NewTabLink className="text-center" href={ensV3Url(props.name)}>
+          <NewTabLink className="text-center" href={ensV3Url(props.name + '.eth')}>
             {translate('ENS_SEND_TO_MANAGER', { $name: props.name + '.eth' })}
           </NewTabLink>
         </h3>

--- a/common/containers/Tabs/ENS/components/NameResolve/components/NameNotYetAvailable.tsx
+++ b/common/containers/Tabs/ENS/components/NameResolve/components/NameNotYetAvailable.tsx
@@ -14,7 +14,7 @@ export const NameNotYetAvailable: React.SFC<IBaseDomainRequest> = props => (
           {translate('ENS_INVALID_INPUT')}.
         </h1>
         <h3>
-          <NewTabLink className="text-center" href={ensV3Url(props.name)}>
+          <NewTabLink className="text-center" href={ensV3Url(props.name + '.eth')}>
             {translate('ENS_SEND_TO_MANAGER', { $name: props.name + '.eth' })}
           </NewTabLink>
         </h3>

--- a/common/containers/Tabs/ENS/components/NameResolve/components/NameOpen.tsx
+++ b/common/containers/Tabs/ENS/components/NameResolve/components/NameOpen.tsx
@@ -11,7 +11,7 @@ export const NameOpen: React.SFC<IBaseDomainRequest> = props => (
       <div className="ens-title">
         <h1>{translate('ENS_DOMAIN_OPEN', { $name: props.name + '.eth' })}</h1>
         <h3>
-          <NewTabLink className="text-center" href={ensV3Url(props.name)}>
+          <NewTabLink className="text-center" href={ensV3Url(props.name + '.eth')}>
             {translate('ENS_SEND_TO_MANAGER', { $name: props.name + '.eth' })}
           </NewTabLink>
         </h3>

--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -544,7 +544,7 @@
     "ENS_INVALID_INPUT": "Names must be at least 7 characters and contain no special characters. Auctions for ENS names with less than 7 characters will be open in the summer of 2019.",
     "ENS_SEND_TO_MANAGER": "Head over to the ENS Manager to register, update, or migrate **$name** now.",
     "LINK": "[$name]($link)",
-    "NAME_AUCTION_PROMPT_BID": "Want to place a bid on {name}.eth? ",
+    "NAME_AUCTION_PROMPT_BID": "Want to place a bid on **$name.eth**?",
     "NAME_OWNED_DEEDOWNER": "Highest Bidder / Deed Owner",
     "NAME_OWNED_HIGHEST_BID": "Highest Bid",
     "NAME_OWNED_HIGHEST_BIDDER": "Highest Bidder",

--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -544,7 +544,7 @@
     "ENS_INVALID_INPUT": "Names must be at least 7 characters and contain no special characters. Auctions for ENS names with less than 7 characters will be open in the summer of 2019.",
     "ENS_SEND_TO_MANAGER": "Head over to the ENS Manager to register, update, or migrate **$name** now.",
     "LINK": "[$name]($link)",
-    "NAME_AUCTION_PROMPT_BID_1": "Want to place a bid on {name}.eth? ",
+    "NAME_AUCTION_PROMPT_BID": "Want to place a bid on {name}.eth? ",
     "NAME_OWNED_DEEDOWNER": "Highest Bidder / Deed Owner",
     "NAME_OWNED_HIGHEST_BID": "Highest Bid",
     "NAME_OWNED_HIGHEST_BIDDER": "Highest Bidder",


### PR DESCRIPTION
Reported by @jspence425 

Please review as soon as possible, ENS manager updates on May 4th and it would be great to release this hotfix today before users will start relying on it more.

https://mycryptobuilds.com/hotfix/incorrect-url-for-non-auctioned-ens-domains/#/ens

## Expected behavior
Visiting a non-auctioned ENS domain goes to a valid ENS manager URL ending in `.eth`.

## Actual behavior
Visiting a non-auctioned ENS domain goes to an invalid URL not ending with `.eth` which has JS errors that lead to a blank page.