### PR TITLE
Add WalletType filtering for networks tab

### DIFF
--- a/common/v2/features/AddAccount/AddAccount.tsx
+++ b/common/v2/features/AddAccount/AddAccount.tsx
@@ -51,7 +51,7 @@ import * as WalletActions from 'v2/features/Wallets';
 import { NetworkOptionsContext, AccountContext } from 'v2/providers';
 import { Account } from 'v2/services/Account/types';
 import { Web3Decrypt } from 'components/WalletDecrypt/components/Web3';
-import { getNetworkByName } from 'v2/libs';
+import { getNetworkByName, isWalletFormatSupportedOnNetwork } from 'v2/libs';
 import { NetworkOptions } from 'v2/services/NetworkOptions/types';
 
 interface OwnProps {
@@ -509,8 +509,11 @@ const WalletDecrypt = withRouter<Props>(
               {({ networkOptions = [] }) => {
                 const networkNames: any[] = [];
                 networkOptions.map(en => {
-                  networkNames.push(en.name);
+                  if (isWalletFormatSupportedOnNetwork(en, this.state.accountData.accountType)) {
+                    networkNames.push(en.name);
+                  }
                 });
+                console.log(networkNames);
                 return (
                   <ComboBox
                     className="Panel-dropdown"

--- a/common/v2/features/Wallets/types.ts
+++ b/common/v2/features/Wallets/types.ts
@@ -1,0 +1,34 @@
+import { getValues } from 'utils/helpers';
+
+export enum SecureWalletName {
+  WEB3 = 'web3',
+  LEDGER_NANO_S = 'ledgerNanoS',
+  TREZOR = 'trezor',
+  SAFE_T = 'safeTmini',
+  PARITY_SIGNER = 'paritySigner'
+}
+
+export enum HardwareWalletName {
+  LEDGER_NANO_S = 'ledgerNanoS',
+  TREZOR = 'trezor',
+  SAFE_T = 'safeTmini'
+}
+
+export enum InsecureWalletName {
+  PRIVATE_KEY = 'privateKey',
+  KEYSTORE_FILE = 'keystoreFile',
+  MNEMONIC_PHRASE = 'mnemonicPhrase'
+}
+
+export enum MiscWalletName {
+  VIEW_ONLY = 'viewOnly'
+}
+
+export const walletNames = getValues(
+  SecureWalletName,
+  HardwareWalletName,
+  InsecureWalletName,
+  MiscWalletName
+);
+
+export type WalletName = SecureWalletName | InsecureWalletName | MiscWalletName;

--- a/common/v2/libs/networks/networks.ts
+++ b/common/v2/libs/networks/networks.ts
@@ -1,5 +1,8 @@
 import { getCache } from 'v2/services/LocalCache';
 import { NetworkOptions } from 'v2/services/NetworkOptions/types';
+import { SecureWalletName, InsecureWalletName } from 'config/data';
+import * as types from './types';
+import { WalletName } from 'v2/features/Wallets/types';
 
 export const getAllNetworks = () => {
   return Object.values(getCache().networkOptions);
@@ -13,4 +16,38 @@ export const getNetworkByChainId = (chainId: string): NetworkOptions | undefined
 export const getNetworkByName = (name: string): NetworkOptions | undefined => {
   const networks = getAllNetworks() || [];
   return networks.find((network: NetworkOptions) => network.name === name);
+};
+
+export const isWalletFormatSupportedOnNetwork = (
+  network: NetworkOptions,
+  format: WalletName
+): boolean => {
+  const chainId = network ? network.chainId : 0;
+
+  const CHECK_FORMATS: types.DPathFormat[] = [
+    SecureWalletName.LEDGER_NANO_S,
+    SecureWalletName.TREZOR,
+    SecureWalletName.SAFE_T,
+    InsecureWalletName.MNEMONIC_PHRASE
+  ];
+
+  const isHDFormat = (f: string): f is types.DPathFormat =>
+    CHECK_FORMATS.includes(f as types.DPathFormat);
+
+  // Ensure DPath's are found
+  if (isHDFormat(format)) {
+    if (!network) {
+      return false;
+    }
+    const dPath: DPath | undefined = network.dPathFormats && network.dPathFormats[format];
+    return !!dPath;
+  }
+
+  // Parity signer on RSK
+  if ((chainId === 30 || chainId === 31) && format === SecureWalletName.PARITY_SIGNER) {
+    return false;
+  }
+
+  // All other wallet formats are supported
+  return true;
 };

--- a/common/v2/libs/networks/types.ts
+++ b/common/v2/libs/networks/types.ts
@@ -1,0 +1,7 @@
+import { SecureWalletName, InsecureWalletName } from 'v2/features/Wallets/types';
+
+export type DPathFormat =
+  | SecureWalletName.TREZOR
+  | SecureWalletName.SAFE_T
+  | SecureWalletName.LEDGER_NANO_S
+  | InsecureWalletName.MNEMONIC_PHRASE;

--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -104,7 +104,7 @@ export const initNetworkOptions = () => {
       blockExplorer: {},
       tokenExplorer: {},
       tokens: {},
-      dPathFormats: {},
+      dPathFormats: STATIC_NETWORKS_INITIAL_STATE[en].dPathFormats,
       gasPriceSettings: STATIC_NETWORKS_INITIAL_STATE[en].gasPriceSettings,
       shouldEstimateGasPrice: STATIC_NETWORKS_INITIAL_STATE[en].shouldEstimateGasPrice
     };

--- a/common/v2/services/LocalCache/constants.ts
+++ b/common/v2/services/LocalCache/constants.ts
@@ -1,5 +1,7 @@
 import * as serviceTypes from 'v2/services/types';
 import { SecureWalletName } from 'config/data';
+import { InsecureWalletName } from 'v2/features/Wallets/types';
+import { ETH_DEFAULT } from 'config/dpaths';
 
 export const CACHE_KEY = 'MyCryptoCache';
 export const ENCRYPTED_CACHE_KEY = 'ENCRYPTED_CACHE';
@@ -144,7 +146,9 @@ export const CACHE_INIT_DEV: LocalCache = {
       tokens: [],
       contracts: ['17ed6f49-ff23-4bef-a676-69174c266b38'],
       nodes: ['eth_mycrypto'],
-      dPathFormats: {},
+      dPathFormats: {
+        [InsecureWalletName.MNEMONIC_PHRASE]: ETH_DEFAULT
+      },
       gasPriceSettings: {
         min: 1,
         max: 100,

--- a/common/v2/services/NetworkOptions/types.ts
+++ b/common/v2/services/NetworkOptions/types.ts
@@ -1,4 +1,4 @@
-import { GasPriceSetting } from 'types/network';
+import { GasPriceSetting, DPathFormats } from 'types/network';
 
 export interface NetworkOptions {
   contracts: string[];
@@ -13,7 +13,7 @@ export interface NetworkOptions {
   blockExplorer: {};
   tokenExplorer: {};
   tokens: {};
-  dPathFormats: {};
+  dPathFormats: DPathFormats;
   gasPriceSettings: GasPriceSetting;
   shouldEstimateGasPrice: boolean | undefined;
 }


### PR DESCRIPTION
###### To play around on this: 
https://mycryptobuilds.com/network-filter-unsupported-wallets


### Description

Only shows supported networks when the user selects a wallet type

### Changes

* Added dPath shit to local cache initialization.
* Added filtering for networks where wallet type is supported. *This depends on the presence of a DPath option in the Network's Config List*.

### Steps to Test

1. Navigate to http://localhost/add-account. Access a ledger device.
2. Try to select the Webchain network. Note that it does not exist in the list.
