### PR TITLE
Added handling for new-registrar ens name resolve

### DIFF
--- a/common/features/ens/selectors.ts
+++ b/common/features/ens/selectors.ts
@@ -10,6 +10,10 @@ const isOwned = (data: IBaseDomainRequest): data is IOwnedDomainRequest => {
   return !!(data as IOwnedDomainRequest).ownerAddress;
 };
 
+const hasResolvedAddress = (data: IBaseDomainRequest): data is IOwnedDomainRequest => {
+  return !!(data as IOwnedDomainRequest).resolvedAddress;
+};
+
 export const getEns = (state: AppState) => state.ens;
 
 export const getCurrentDomainData = (state: AppState) => {
@@ -31,7 +35,7 @@ export const getResolvedAddress = (state: AppState, noGenesisAddress: boolean = 
     return null;
   }
 
-  if (isOwned(data)) {
+  if (isOwned(data) || hasResolvedAddress(data)) {
     const { resolvedAddress } = data;
     if (noGenesisAddress) {
       return !isCreationAddress(resolvedAddress) ? resolvedAddress : null;


### PR DESCRIPTION
### Closes #2545 
🎉 🎉 🎉

### Description

Re-enables ENS resolution for registrar 

### Changes

* Enables handling of ens names that have been migrated to the new ENS registrar.

### Steps to Test

1. Access http://localhost/account. Select "View Only Account"
2. In the bottom field, enter "mycryptoid.eth" this should resolve correctly. - This is on the old registrar
3. In the bottom field, enter "harrydenley.eth" this should resolve correctly. - This is on the new registrar
4. In the bottom field, enter "mycryptoidddddd.eth" this should *NOT* resolve correctly. - This is not registered

