### PR TITLE
Implement custom radio buttons with images (select address)

### DIFF
--- a/common/assets/images/radio-checked.svg
+++ b/common/assets/images/radio-checked.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22">
+    <g fill="none" fill-rule="nonzero" transform="translate(1 1)">
+        <circle cx="10" cy="10" r="10" stroke="#E5ECF3"/>
+        <circle cx="10" cy="10" r="7" fill="#B5BFC7"/>
+    </g>
+</svg>

--- a/common/assets/images/radio.svg
+++ b/common/assets/images/radio.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22">
+    <circle cx="10" cy="10" r="10" fill="none" fill-rule="nonzero" stroke="#E5ECF3" transform="translate(1 1)"/>
+</svg>

--- a/common/v2/features/AddAccount/components/DeterministicWallets.scss
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.scss
@@ -96,6 +96,6 @@
   }
 }
 
-.radio-image {
+.clickable {
   cursor: pointer;
 }

--- a/common/v2/features/AddAccount/components/DeterministicWallets.scss
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.scss
@@ -95,3 +95,7 @@
     }
   }
 }
+
+.radio-image {
+  cursor: pointer;
+}

--- a/common/v2/features/AddAccount/components/DeterministicWallets.scss
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.scss
@@ -55,12 +55,7 @@
 
       &-address-select {
         display: flex;
-        align-items: center;
-
-        input[type='radio'] {
-          margin-top: 0;
-          margin-left: 0.5rem;
-        }
+        justify-content: space-between;
       }
 
       &-more {

--- a/common/v2/features/AddAccount/components/DeterministicWallets.tsx
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import Select, { Option } from 'react-select';
 import { connect } from 'react-redux';
 import { Table, Address, IconLink, Typography, Button } from '@mycrypto/ui';
@@ -17,6 +17,18 @@ import './DeterministicWallets.scss';
 import { truncate } from 'v2/libs';
 import nextIcon from 'assets/images/next-page-button.svg';
 import prevIcon from 'assets/images/previous-page-button.svg';
+import radio from 'assets/images/radio.svg';
+import radioChecked from 'assets/images/radio-checked.svg';
+
+function Radio({
+  checked,
+  onClick
+}: {
+  checked: boolean;
+  onClick(event: MouseEvent<HTMLImageElement>): void;
+}) {
+  return <img src={checked ? radioChecked : radio} onClick={onClick} />;
+}
 
 const WALLETS_PER_PAGE = 5;
 
@@ -249,12 +261,8 @@ class DeterministicWalletsClass extends React.PureComponent<Props, State> {
     return [
       <div className="DW-addresses-table-address-select">
         {wallet.index + 1}
-        <input
-          type="radio"
-          name="selectedAddress"
+        <Radio
           checked={selectedAddress === wallet.address}
-          value={wallet.address}
-          readOnly={true}
           onClick={this.selectAddress.bind(this, wallet.address, wallet.index)}
         />
       </div>,

--- a/common/v2/features/AddAccount/components/DeterministicWallets.tsx
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.tsx
@@ -27,7 +27,7 @@ function Radio({
   checked: boolean;
   onClick(event: MouseEvent<HTMLImageElement>): void;
 }) {
-  return <img src={checked ? radioChecked : radio} onClick={onClick} />;
+  return <img className="radio-image" src={checked ? radioChecked : radio} onClick={onClick} />;
 }
 
 const WALLETS_PER_PAGE = 5;

--- a/common/v2/features/AddAccount/components/DeterministicWallets.tsx
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from 'react';
+import React from 'react';
 import Select, { Option } from 'react-select';
 import { connect } from 'react-redux';
 import { Table, Address, IconLink, Typography, Button } from '@mycrypto/ui';
@@ -20,14 +20,8 @@ import prevIcon from 'assets/images/previous-page-button.svg';
 import radio from 'assets/images/radio.svg';
 import radioChecked from 'assets/images/radio-checked.svg';
 
-function Radio({
-  checked,
-  onClick
-}: {
-  checked: boolean;
-  onClick(event: MouseEvent<HTMLImageElement>): void;
-}) {
-  return <img className="radio-image" src={checked ? radioChecked : radio} onClick={onClick} />;
+function Radio({ checked }: { checked: boolean }) {
+  return <img className="clickable" src={checked ? radioChecked : radio} />;
 }
 
 const WALLETS_PER_PAGE = 5;
@@ -261,10 +255,7 @@ class DeterministicWalletsClass extends React.PureComponent<Props, State> {
     return [
       <div className="DW-addresses-table-address-select">
         {wallet.index + 1}
-        <Radio
-          checked={selectedAddress === wallet.address}
-          onClick={this.selectAddress.bind(this, wallet.address, wallet.index)}
-        />
+        <Radio checked={selectedAddress === wallet.address} />
       </div>,
       <Address title={label} address={wallet.address} truncate={truncate} />,
       <UnitDisplay
@@ -274,10 +265,22 @@ class DeterministicWalletsClass extends React.PureComponent<Props, State> {
         displayShortBalance={true}
         checkOffline={true}
       />,
-      <a target="_blank" href={blockExplorer.addressUrl(wallet.address)} rel="noopener noreferrer">
+      <a
+        target="_blank"
+        href={blockExplorer.addressUrl(wallet.address)}
+        rel="noopener noreferrer"
+        onClick={event => event.stopPropagation()}
+      >
         <i className="DW-addresses-table-more" />
       </a>
-    ];
+    ].map(element => (
+      <div
+        className="clickable"
+        onClick={this.selectAddress.bind(this, wallet.address, wallet.index)}
+      >
+        {element}
+      </div>
+    ));
     // tslint:enable:jsx-key
   }
 }


### PR DESCRIPTION
 

https://mycryptobuilds.com/add-existing-account-views-select-address-radio-buttons/#/add-account

![image](https://user-images.githubusercontent.com/927220/57342641-d1ce9100-710d-11e9-992f-2afe0c1accf2.png)

## Tasks

### High priority
- [x] Fix layout
- [x] Mouse Interaction: pointer cursor
- [x] Make entire rows clickable

### Low priority
- Implement [WAI ARIA Authoring Practices 1.1 Section 2.8 Radio Group](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/#radiobutton)
  - [ ] Keyboard Interaction
  - [ ] WAI-ARIA Roles, States, and Properties