### PR TITLE
Fix radio button stretching

### DIFF
--- a/common/v2/features/AddAccount/components/DeterministicWallets.scss
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.scss
@@ -99,3 +99,7 @@
 .clickable {
   cursor: pointer;
 }
+
+.radio-image {
+  align-self: center;
+}

--- a/common/v2/features/AddAccount/components/DeterministicWallets.tsx
+++ b/common/v2/features/AddAccount/components/DeterministicWallets.tsx
@@ -21,7 +21,7 @@ import radio from 'assets/images/radio.svg';
 import radioChecked from 'assets/images/radio-checked.svg';
 
 function Radio({ checked }: { checked: boolean }) {
-  return <img className="clickable" src={checked ? radioChecked : radio} />;
+  return <img className="clickable radio-image" src={checked ? radioChecked : radio} />;
 }
 
 const WALLETS_PER_PAGE = 5;


### PR DESCRIPTION
This fixes the following issue from #2550:

> @blurpesec Radio buttons appear oval-ish in desktop views for me. Is this intentional?
> ![image](https://user-images.githubusercontent.com/29407814/57453488-8662d280-7234-11e9-9838-ed34d4dde080.png)

