### PR TITLE
Update LRC token address

### DIFF
--- a/common/config/tokens/eth.json
+++ b/common/config/tokens/eth.json
@@ -8,7 +8,7 @@
     "address": "0xA024E8057EEC474a9b2356833707Dd0579E26eF3",
     "symbol": "$FXY",
     "decimal": 18
-  },
+  },0xEF68e7C694F40c8202821eDF525dE3782458639f
   {
     "address": "0xCDB7eCFd3403Eef3882c65B761ef9B5054890a47",
     "symbol": "$HUR",
@@ -3315,7 +3315,7 @@
     "decimal": 18
   },
   {
-    "address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
+    "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
     "symbol": "LRC",
     "decimal": 18
   },

--- a/common/config/tokens/eth.json
+++ b/common/config/tokens/eth.json
@@ -8,7 +8,7 @@
     "address": "0xA024E8057EEC474a9b2356833707Dd0579E26eF3",
     "symbol": "$FXY",
     "decimal": 18
-  },0xEF68e7C694F40c8202821eDF525dE3782458639f
+  },
   {
     "address": "0xCDB7eCFd3403Eef3882c65B761ef9B5054890a47",
     "symbol": "$HUR",


### PR DESCRIPTION
LRC's address has changed from 0xEF68e7C694F40c8202821eDF525dE3782458639f to 0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD (lrctoken.eth)

More details: https://medium.com/loopring-protocol/lrc-token-upgraded-a26ee6f87b84