### PR TITLE
Temporarily fall back to U2F on Windows with Ledger devices

### DIFF
--- a/common/libs/wallet/deterministic/ledger.ts
+++ b/common/libs/wallet/deterministic/ledger.ts
@@ -130,7 +130,8 @@ export class LedgerWallet extends HardwareWallet {
 
 async function makeApp() {
   let transport: Transport<any>;
-  if (await TransportUSB.isSupported()) {
+  // TODO: Remove check for Windows once Windows issues are resolved
+  if (!navigator.platform.toLowerCase().includes('win') && (await TransportUSB.isSupported())) {
     // Use WebUSB protocol instead of U2F if it's supported
     transport = await TransportUSB.create();
   } else {


### PR DESCRIPTION
### Description

Fixes an incompatibility issue regarding Windows and WebUSB. This can be reverted once this issue is fixed. The desktop app is not affected by this.

### Changes

* Added a fall back to U2F for Windows

### Steps to Test

Try to unlock with a Ledger device on Windows