### PR TITLE
Fixed tokens initialization in networkOptions

### DIFF
--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -132,10 +132,10 @@ export const initNetworkOptions = () => {
 
 export const initAssetOptions = () => {
   const newStorage = getCacheRaw();
-  const contracts = AssetOptionsData();
-  Object.keys(contracts).map(en => {
-    newStorage.assetOptions[en] = contracts[en];
-    newStorage.networkOptions[contracts[en].network].contracts.push(en);
+  const assets = AssetOptionsData();
+  Object.keys(assets).map(en => {
+    newStorage.assetOptions[en] = assets[en];
+    newStorage.networkOptions[assets[en].network].assets.push(en);
   });
   setCache(newStorage);
 };

--- a/common/v2/services/LocalCache/constants.ts
+++ b/common/v2/services/LocalCache/constants.ts
@@ -154,7 +154,8 @@ export const CACHE_INIT_DEV: LocalCache = {
         max: 100,
         initial: 15
       },
-      shouldEstimateGasPrice: true
+      shouldEstimateGasPrice: true,
+      assets: []
     }
   },
   nodeOptions: {

--- a/common/v2/services/NetworkOptions/types.ts
+++ b/common/v2/services/NetworkOptions/types.ts
@@ -2,7 +2,7 @@ import { GasPriceSetting, DPathFormats } from 'types/network';
 
 export interface NetworkOptions {
   contracts: string[];
-  assets?: string[];
+  assets: string[];
   nodes: string[];
   id: string;
   name: string;


### PR DESCRIPTION
Fixes a bug where tokens aren't correctly added to `networkOptions.asset` array.