### PR TITLE
ev/update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "express": "4.16.2",
     "file-loader": "1.1.11",
     "friendly-errors-webpack-plugin": "1.6.1",
-    "hard-source-webpack-plugin": "0.6.4",
+    "hard-source-webpack-plugin": "0.13.1",
     "html-webpack-plugin": "3.0.6",
     "husky": "1.3.1",
     "image-webpack-loader": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7039,16 +7039,22 @@ har-validator@~5.1.0:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
-hard-source-webpack-plugin@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.6.4.tgz#d80575d42c53e6af6dadc92271577a61cda20b12"
+hard-source-webpack-plugin@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.13.1.tgz#a99071e25b232f1438a5bc3c99f10a3869e4428e"
+  integrity sha512-r9zf5Wq7IqJHdVAQsZ4OP+dcUSvoHqDMxJlIzaE2J0TZWn3UjMMrHqwDHR8Jr/pzPfG7XxSe36E7Y8QGNdtuAw==
   dependencies:
+    chalk "^2.4.1"
+    find-cache-dir "^2.0.0"
+    graceful-fs "^4.1.11"
     lodash "^4.15.0"
     mkdirp "^0.5.1"
     node-object-hash "^1.2.0"
+    parse-json "^4.0.0"
+    pkg-dir "^3.0.0"
     rimraf "^2.6.2"
+    semver "^5.6.0"
     tapable "^1.0.0-beta.5"
-    webpack-core "~0.6.0"
     webpack-sources "^1.0.1"
     write-json-file "^2.3.0"
 
@@ -15506,7 +15512,7 @@ webpack-cli@2.0.13:
     yeoman-environment "^2.0.0"
     yeoman-generator "^2.0.3"
 
-webpack-core@^0.6.8, webpack-core@~0.6.0:
+webpack-core@^0.6.8:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
   dependencies:


### PR DESCRIPTION
After pulling the latest changes webpack would fail to launch the dev server with this error:
https://github.com/mzgoddard/hard-source-webpack-plugin/issues/316

Updating the package to 0.13.1 fixes the issue.