### PR TITLE
Added Test Accounts during Initialization of LC

### DIFF
--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -866,6 +866,8 @@
     "NOTIFICATIONS_WALLET_RESOURCE_SUPPORT": "Support Center",
     "NOTIFICATIONS_WALLET_ADDED_TITLE": "Your wallet has been added.",
     "NOTIFICATIONS_WALLET_ADDED_DESCRIPTION": "Your account with the address **$address** has been successfully added!",
+    "NOTIFICATIONS_WALLET_NOT_ADDED_TITLE": "Your wallet could not been added.",
+    "NOTIFICATIONS_WALLET_NOT_ADDED_DESCRIPTION": "Your account with the address **$address** could not be successfully added. This can be due to an invalid network being selected, or if the account is already present on your dashboard.",
     "NOTIFICATIONS_SAVE_DASHBOARD_TITLE": "Save Your Dashboard Settings",
     "NOTIFICATIONS_SAVE_DASHBOARD_DESCRIPTION": "You've spent a lot of time customizing your dashboard. Make sure to back it up so you don’t lose your settings.",
     "NOTIFICATIONS_SAVE_DASHBOARD_RESOURCE": "Export Settings Now",

--- a/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
+++ b/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
@@ -20,7 +20,7 @@ function SaveAndRedirect(payload: { formData: FormData }) {
       network: payload.formData.network,
       accountType: payload.formData.accountType,
       derivationPath: payload.formData.derivationPath,
-      assets: network ? network.unit : 'DefaultAsset',
+      assets: network ? [network.unit] : ['DefaultAsset'],
       value: 0,
       label: 'New Account', // @TODO: we really should have the correct label before!
       localSettings: 'default',

--- a/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
+++ b/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
@@ -2,10 +2,13 @@ import React, { useContext, useEffect } from 'react';
 import { Route, Redirect } from 'react-router';
 import { FormData } from 'v2/features/AddAccount/types';
 import { AccountContext, NotificationsContext } from 'v2/providers';
-import { getNetworkByName } from 'v2/libs';
+import { getNetworkByName, getNewDefaultAssetTemplateByNetwork, generateUUID } from 'v2/libs';
 import { NetworkOptions } from 'v2/services/NetworkOptions/types';
 import { Account } from 'v2/services/Account/types';
 import { NotificationTemplates } from 'v2/providers/NotificationsProvider/constants';
+import { Asset } from 'v2/services/Asset/types';
+import { createAssetWithID } from 'v2/services';
+import { getAccountByAddress } from 'v2/libs/accounts/accounts';
 
 /*
   Create a new account in localStorage and redirect to dashboard.
@@ -15,21 +18,30 @@ function SaveAndRedirect(payload: { formData: FormData }) {
   const { displayNotification } = useContext(NotificationsContext);
   useEffect(() => {
     const network: NetworkOptions | undefined = getNetworkByName(payload.formData.network);
-    const account: Account = {
-      address: payload.formData.account,
-      network: payload.formData.network,
-      accountType: payload.formData.accountType,
-      derivationPath: payload.formData.derivationPath,
-      assets: network ? [network.unit] : ['DefaultAsset'],
-      value: 0,
-      label: 'New Account', // @TODO: we really should have the correct label before!
-      localSettings: 'default',
-      transactionHistory: ''
-    };
-    createAccount(account);
-    displayNotification(NotificationTemplates.walletAdded, {
-      address: account.address
-    });
+    if (!network || getAccountByAddress(payload.formData.account)) {
+      displayNotification(NotificationTemplates.walletNotAdded, {
+        address: payload.formData.account
+      });
+    } else {
+      const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(network);
+      const newAssetID: string = generateUUID();
+      const account: Account = {
+        address: payload.formData.account,
+        network: payload.formData.network,
+        accountType: payload.formData.accountType,
+        derivationPath: payload.formData.derivationPath,
+        assets: [newAssetID],
+        value: 0,
+        label: 'New Account', // @TODO: we really should have the correct label before!
+        localSettings: 'default',
+        transactionHistory: ''
+      };
+      createAccount(account);
+      createAssetWithID(newAsset, newAssetID);
+      displayNotification(NotificationTemplates.walletAdded, {
+        address: account.address
+      });
+    }
   });
 
   return (

--- a/common/v2/features/Dashboard/NotificationsPanel/components/WalletNotAddedNotification.tsx
+++ b/common/v2/features/Dashboard/NotificationsPanel/components/WalletNotAddedNotification.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import translate from 'translations';
+import { BREAK_POINTS } from 'v2/features/constants';
+import NotificationWrapper from './NotificationWrapper';
+
+// Legacy
+import champagneIcon from 'common/assets/images/icn-champagne-2.svg';
+import howBuyIcon from 'common/assets/images/icn-how-do-i-buy-crypto.svg';
+import dontLoseCryptoIcon from 'common/assets/images/icn-don-t-lose-crypto.svg';
+import questionsIcon from 'common/assets/images/icn-questions.svg';
+
+const { SCREEN_XS } = BREAK_POINTS;
+
+const ResourceItemWrapper = styled.a`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  width: 140px;
+  font-weight: normal;
+  font-size: 16px;
+
+  @media (max-width: ${SCREEN_XS}) {
+    font-size: 12px;
+    max-width: 105px;
+  }
+`;
+
+const Image = styled.img`
+  width: 50px;
+  height: 51px;
+  margin-bottom: 10px;
+`;
+
+interface ResourceItemProps {
+  src: string;
+  title: React.ReactElement<any>;
+  link: string;
+}
+
+const ResourceItem: React.SFC<ResourceItemProps> = ({ src, title, link }) => {
+  return (
+    <ResourceItemWrapper href={link} target="_blank" rel="noopener noreferrer">
+      <Image src={src} />
+      {title}
+    </ResourceItemWrapper>
+  );
+};
+
+const getResources = () => {
+  return (
+    <>
+      <ResourceItem
+        src={howBuyIcon}
+        title={translate('NOTIFICATIONS_WALLET_RESOURCE_BUY')}
+        link="/how-to-buy"
+      />
+      <ResourceItem
+        src={dontLoseCryptoIcon}
+        title={translate('NOTIFICATIONS_WALLET_RESOURCE_LOSE')}
+        link="/dont-lose-crypto"
+      />
+      <ResourceItem
+        src={questionsIcon}
+        title={translate('NOTIFICATIONS_WALLET_RESOURCE_SUPPORT')}
+        link="https://support.mycrypto.com/"
+      />
+    </>
+  );
+};
+
+interface NotificationProps {
+  address: string;
+}
+
+export default function WalletCreatedNotification({ address }: NotificationProps) {
+  return (
+    <NotificationWrapper
+      alignCenterOnSmallScreen={true}
+      leftImg={{
+        src: champagneIcon,
+        width: '71px',
+        height: '70px',
+        transform: 'rotateY(180deg)',
+        hideOnMobile: true
+      }}
+      title={translate('NOTIFICATIONS_WALLET_NOT_ADDED_TITLE')}
+      description={translate('NOTIFICATIONS_WALLET_NOT_ADDED_DESCRIPTION', {
+        $address: address
+      })}
+      additionalDescription={translate('NOTIFICATIONS_WALLET_DESCRIPTION_ADD')}
+      resources={getResources()}
+    />
+  );
+}

--- a/common/v2/features/Dashboard/NotificationsPanel/components/index.ts
+++ b/common/v2/features/Dashboard/NotificationsPanel/components/index.ts
@@ -3,3 +3,4 @@ export { default as WalletAddedNotification } from './WalletAddedNotification';
 export { default as SaveDashboardNotification } from './SaveDashboardNotification';
 export { default as PrintPaperWalletNotification } from './PrintPaperWalletNotification';
 export { default as GetHardwareWalletNotification } from './GetHardwareWalletNotification';
+export { default as WalletNotAddedNotification } from './WalletNotAddedNotification';

--- a/common/v2/features/DevTools/DevTools.tsx
+++ b/common/v2/features/DevTools/DevTools.tsx
@@ -38,7 +38,7 @@ const DevTools = () => {
                   address: '0x80200997f095da94E404F7E0d581AAb1fFba9f7d',
                   network: 'Ethereum',
                   localSettings: '17ed6f49-ff23-4bef-a676-69174c266b37',
-                  assets: '12d3cbf2-de3a-4050-a0c6-521592e4b85a',
+                  assets: ['12d3cbf2-de3a-4050-a0c6-521592e4b85a'],
                   accountType: SecureWalletName.WEB3,
                   value: 0,
                   transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',

--- a/common/v2/libs/assetOptions.ts
+++ b/common/v2/libs/assetOptions.ts
@@ -2,10 +2,10 @@ import { getCache } from 'v2/services/LocalCache';
 import { AssetOption } from 'v2/services/AssetOption/types';
 
 export const getAssetByTicker = (ticker: string): AssetOption | undefined => {
-  const assets = getAllAssets() || [];
+  const assets = getAllAssetOptions() || [];
   return assets.find((asset: AssetOption) => asset.ticker.toLowerCase() === ticker.toLowerCase());
 };
 
-export const getAllAssets = () => {
+export const getAllAssetOptions = () => {
   return Object.values(getCache().assetOptions);
 };

--- a/common/v2/libs/assets/assets.ts
+++ b/common/v2/libs/assets/assets.ts
@@ -1,0 +1,37 @@
+import { getCache } from 'v2/services/LocalCache';
+import { Asset } from 'v2/services/Asset/types';
+import { NetworkOptions } from 'v2/services/NetworkOptions/types';
+import { getAssetByTicker } from '../assetOptions';
+import { AssetOption } from 'v2/services/AssetOption/types';
+
+export const getAllAssets = () => {
+  return Object.values(getCache().assets);
+};
+
+export const getAssetBySymbol = (symbol: string): Asset | undefined => {
+  const assets: Asset[] = getAllAssets();
+  return assets.find(asset => asset.symbol.toLowerCase() === symbol.toLowerCase());
+};
+
+export const getNewDefaultAssetTemplateByNetwork = (network: NetworkOptions): Asset => {
+  const baseAssetOfNetwork: AssetOption | undefined = getAssetByTicker(network.unit);
+  if (!baseAssetOfNetwork) {
+    return {
+      option: network.name,
+      amount: '0',
+      network: network.unit,
+      type: 'base',
+      symbol: network.unit,
+      decimal: 18
+    };
+  } else {
+    return {
+      option: baseAssetOfNetwork.name,
+      amount: '0',
+      network: baseAssetOfNetwork.network,
+      type: 'base',
+      symbol: baseAssetOfNetwork.ticker,
+      decimal: baseAssetOfNetwork.decimal
+    };
+  }
+};

--- a/common/v2/libs/assets/index.ts
+++ b/common/v2/libs/assets/index.ts
@@ -1,0 +1,1 @@
+export * from './assets';

--- a/common/v2/libs/index.ts
+++ b/common/v2/libs/index.ts
@@ -4,3 +4,4 @@ export * from './assetOptions';
 export * from './helpers';
 export * from './preFillTx';
 export * from './networks';
+export * from './assets';

--- a/common/v2/providers/NotificationsProvider/constants.ts
+++ b/common/v2/providers/NotificationsProvider/constants.ts
@@ -5,12 +5,14 @@ import {
   WalletAddedNotification,
   SaveDashboardNotification,
   PrintPaperWalletNotification,
-  GetHardwareWalletNotification
+  GetHardwareWalletNotification,
+  WalletNotAddedNotification
 } from 'v2/features/Dashboard/NotificationsPanel/components';
 
 export const NotificationTemplates = {
   walletCreated: 'wallet-created',
   walletAdded: 'wallet-added',
+  walletNotAdded: 'wallet-not-added',
   saveSettings: 'save-settings',
   printPaperWallet: 'print-paper-wallet',
   getHardwareWallet: 'get-hardware-wallet'
@@ -26,6 +28,12 @@ export const notificationsConfigs: NotificationsConfigsProps = {
   [NotificationTemplates.walletAdded]: {
     analyticsEvent: 'New Account (Wallet) Added',
     layout: WalletAddedNotification,
+    showOneTime: true,
+    dismissOnOverwrite: true
+  },
+  [NotificationTemplates.walletNotAdded]: {
+    analyticsEvent: 'New Account (Wallet) Could Not Be Added',
+    layout: WalletNotAddedNotification,
     showOneTime: true,
     dismissOnOverwrite: true
   },

--- a/common/v2/services/Account/types.ts
+++ b/common/v2/services/Account/types.ts
@@ -5,7 +5,7 @@ export interface Account {
   address: string;
   network: string;
   localSettings: string;
-  assets: string;
+  assets: string[];
   accountType: WalletName;
   value: number;
   transactionHistory: string;

--- a/common/v2/services/Asset/Asset.ts
+++ b/common/v2/services/Asset/Asset.ts
@@ -1,6 +1,7 @@
-import { create, read, update, destroy, readAll } from 'v2/services/LocalCache';
+import { create, read, update, destroy, readAll, createWithID } from 'v2/services/LocalCache';
 
 export const createAsset = create('assets');
+export const createAssetWithID = createWithID('assets');
 export const readAsset = read('assets');
 export const updateAsset = update('assets');
 export const deleteAsset = destroy('assets');

--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -1,11 +1,13 @@
 import * as utils from 'v2/libs';
-import * as types from 'v2/services';
 import { CACHE_INIT, CACHE_KEY, ENCRYPTED_CACHE_KEY, LocalCache } from './constants';
 import { DPaths, Fiats } from 'config';
 import { ContractsData, AssetOptionsData } from 'v2/config/cacheData';
-import { ACCOUNTTYPES } from 'v2/config';
+import { ACCOUNTTYPES, SecureWalletName } from 'v2/config';
 import { NODE_CONFIGS } from 'libs/nodes';
 import { STATIC_NETWORKS_INITIAL_STATE } from 'features/config/networks/static/reducer';
+import { createAccount, Account } from '../Account';
+import { default as types, Asset, createAssetWithID } from 'v2/services';
+import { isDevelopment } from 'v2/utils/environment';
 
 // Initialization
 export const initializeCache = () => {
@@ -30,6 +32,10 @@ export const initializeCache = () => {
     initContractOptions();
 
     initAssetOptions();
+
+    if (isDevelopment) {
+      initTestAccounts();
+    }
   }
 };
 
@@ -288,4 +294,66 @@ export const readAll = <K extends CollectionKey>(key: K) => () => {
   const section: LocalCache[K] = getCache()[key];
   const sectionEntries: [string, LocalCache[K][string]][] = Object.entries(section);
   return sectionEntries.map(([uuid, value]) => ({ ...value, uuid }));
+};
+
+export const initTestAccounts = () => {
+  const newAccounts: Account[] = [
+    {
+      label: 'ETH Test 1',
+      address: '0xc7bfc8a6bd4e52bfe901764143abef76caf2f912',
+      network: 'Ethereum',
+      localSettings: '17ed6f49-ff23-4bef-a676-69174c266b37',
+      assets: ['10e14757-78bb-4bb2-a17a-8333830f6698', 'f7e30bbe-08e2-41ce-9231-5236e6aab702'],
+      accountType: SecureWalletName.WEB3,
+      value: 1e16,
+      transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',
+      derivationPath: `m/44'/60'/0'/0/0`
+    },
+    {
+      label: 'Goerli ETH Test 1',
+      address: '0xc7bfc8a6bd4e52bfe901764143abef76caf2f912',
+      network: 'Goerli',
+      localSettings: '17ed6f49-ff23-4bef-a676-69174c266b37',
+      assets: ['12d3cbf2-de3a-4050-a0c6-521592e4b85a'],
+      accountType: SecureWalletName.WEB3,
+      value: 1e16,
+      transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',
+      derivationPath: `m/44'/60'/0'/0/0`
+    }
+  ];
+
+  const newAssets: { [key in string]: Asset } = {
+    '10e14757-78bb-4bb2-a17a-8333830f6698': {
+      option: 'WrappedETH',
+      amount: '0.01',
+      network: 'Ethereum',
+      type: 'erc20',
+      symbol: 'WETH',
+      contractAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      decimal: 18
+    },
+    'f7e30bbe-08e2-41ce-9231-5236e6aab702': {
+      option: 'ETH',
+      amount: '0.001',
+      network: 'Ethereum',
+      type: 'base',
+      symbol: 'ETH',
+      decimal: 18
+    },
+    '12d3cbf2-de3a-4050-a0c6-521592e4b85a': {
+      option: 'GoerliETH',
+      amount: '0.01',
+      network: 'Goerli',
+      type: 'base',
+      symbol: 'GoerliETH',
+      decimal: 18
+    }
+  };
+
+  newAccounts.map(accountToAdd => {
+    createAccount(accountToAdd);
+  });
+  Object.keys(newAssets).map(assetToAdd => {
+    createAssetWithID(newAssets[assetToAdd], assetToAdd);
+  });
 };

--- a/common/v2/services/LocalCache/LocalCache.ts
+++ b/common/v2/services/LocalCache/LocalCache.ts
@@ -1,12 +1,11 @@
 import * as utils from 'v2/libs';
+import * as types from 'v2/services';
 import { CACHE_INIT, CACHE_KEY, ENCRYPTED_CACHE_KEY, LocalCache } from './constants';
 import { DPaths, Fiats } from 'config';
 import { ContractsData, AssetOptionsData } from 'v2/config/cacheData';
 import { ACCOUNTTYPES, SecureWalletName } from 'v2/config';
 import { NODE_CONFIGS } from 'libs/nodes';
 import { STATIC_NETWORKS_INITIAL_STATE } from 'features/config/networks/static/reducer';
-import { createAccount, Account } from '../Account';
-import { default as types, Asset, createAssetWithID } from 'v2/services';
 import { isDevelopment } from 'v2/utils/environment';
 
 // Initialization
@@ -297,7 +296,8 @@ export const readAll = <K extends CollectionKey>(key: K) => () => {
 };
 
 export const initTestAccounts = () => {
-  const newAccounts: Account[] = [
+  const newStorage = getCacheRaw();
+  const newAccounts: types.Account[] = [
     {
       label: 'ETH Test 1',
       address: '0xc7bfc8a6bd4e52bfe901764143abef76caf2f912',
@@ -322,7 +322,7 @@ export const initTestAccounts = () => {
     }
   ];
 
-  const newAssets: { [key in string]: Asset } = {
+  const newAssets: { [key in string]: types.Asset } = {
     '10e14757-78bb-4bb2-a17a-8333830f6698': {
       option: 'WrappedETH',
       amount: '0.01',
@@ -351,9 +351,12 @@ export const initTestAccounts = () => {
   };
 
   newAccounts.map(accountToAdd => {
-    createAccount(accountToAdd);
+    const uuid = utils.generateUUID();
+    newStorage.accounts[uuid] = accountToAdd;
+    newStorage.currents.accounts.push(uuid);
   });
   Object.keys(newAssets).map(assetToAdd => {
-    createAssetWithID(newAssets[assetToAdd], assetToAdd);
+    newStorage.assets[assetToAdd] = newAssets[assetToAdd];
   });
+  setCache(newStorage);
 };

--- a/common/v2/services/LocalCache/constants.ts
+++ b/common/v2/services/LocalCache/constants.ts
@@ -46,7 +46,7 @@ export const CACHE_INIT_DEV: LocalCache = {
       address: '0x80200997f095da94E404F7E0d581AAb1fFba9f7d',
       network: 'ETH',
       localSettings: '17ed6f49-ff23-4bef-a676-69174c266b37',
-      assets: '12d3cbf2-de3a-4050-a0c6-521592e4b85a',
+      assets: ['12d3cbf2-de3a-4050-a0c6-521592e4b85a'],
       accountType: SecureWalletName.WEB3,
       value: 1e18,
       transactionHistory: '76b50f76-afb2-4185-ab7d-4d62c0654882',


### PR DESCRIPTION
### Description

Initializes/Creates test accounts during initialization of local cache for use in development of other features.

Also handles account-not-added notification due to invalid network and duplicate address.

Adds new default asset on account addition.