### PR TITLE
White border for Parity Signer QR codes

### DIFF
--- a/common/components/ParityQrSigner.scss
+++ b/common/components/ParityQrSigner.scss
@@ -11,7 +11,11 @@
   margin: 0 auto 1.5em;
   border-radius: 4px;
   overflow: hidden;
-
+  
+  & img {
+    border: solid white 15px;
+  }
+  
   &.is-disabled {
     background: color(gray-lighter);
   }


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->
## Closes https://github.com/MyCryptoHQ/MyCrypto/issues/2620

🎉 🎉 🎉

## Description

This adds a white border to make sure the QR code can be scanned correctly.

## Changes

Self explanatory. 

### Reusable Code/Components

<!-- Preferably, include automated tests instead. -->
## Steps to Test

1. Connect with Parity Signer
2. Make a transactions
3. Click on "Sign"

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
