### PR TITLE
Add Auxilium crypto support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -192,6 +192,11 @@ export const ASK_TREZOR: DPath = {
   value: "m/44'/2221'/0'/0"
 };
 
+export const AUX_DEFAULT: DPath = {
+  label: 'Default (AUX)',
+  value: "m/44'/344'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -230,7 +235,8 @@ export const DPaths: DPath[] = [
   SOLIDUM_DEFAULT,
   DEXON_DEFAULT,
   ASK_DEFAULT,
-  ASK_TREZOR
+  ASK_TREZOR,
+  AUX_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "WEB",
+      "AUX",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -1015,9 +1015,7 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
     tokens: [],
     contracts: [],
     dPathFormats: {
-      [SecureWalletName.TREZOR]: AUX_DEFAULT,
       [SecureWalletName.SAFE_T]: AUX_DEFAULT,
-      [SecureWalletName.LEDGER_NANO_S]: AUX_DEFAULT,
       [InsecureWalletName.MNEMONIC_PHRASE]: AUX_DEFAULT
     },
     gasPriceSettings: {

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -44,7 +44,8 @@ import {
   THUNDERCORE_DEFAULT,
   TOMO_DEFAULT,
   UBQ_DEFAULT,
-  WEB_DEFAULT
+  WEB_DEFAULT,
+  AUX_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import * as types from './types';
@@ -999,6 +1000,31 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       initial: 4.77
     },
     shouldEstimateGasPrice: false
+  },
+  AUX: {
+    id: 'AUX',
+    name: 'Auxilium',
+    unit: 'AUX',
+    chainId: 28945486,
+    isCustom: false,
+    color: '#85dc35',
+    blockExplorer: makeExplorer({
+      name: 'Auxilium Explore',
+      origin: 'https://explore.auxilium.global/'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: AUX_DEFAULT,
+      [SecureWalletName.SAFE_T]: AUX_DEFAULT,
+      [SecureWalletName.LEDGER_NANO_S]: AUX_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: AUX_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 0.1,
+      max: 40,
+      initial: 4
+    }
   }
 };
 

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -393,6 +393,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'node2.webchain.network',
       url: 'https://node2.webchain.network'
     }
+  ],
+
+  AUX: [
+    {
+      name: makeNodeName('AUX', 'auxilium'),
+      type: 'rpc',
+      service: 'auxilium.global',
+      url: 'https://rpc.auxilium.global'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -38,6 +38,7 @@ type StaticNetworkIds =
   | 'TOMO'
   | 'UBQ'
   | 'WEB'
+  | 'AUX'
   | 'ASK';
 
 export interface BlockExplorerConfig {


### PR DESCRIPTION
Auxilium (AUX) is a cryptocurrency foundation of a philantropic company Auxilium Global. Its current main network started in summer of 2018, after performing swap from Sprouts blockchain and running a modified fork of Ethereum Go implementation.

- Blockchain explorer: https://explore.auxilium.global
- R-RPC node: https://rpc.auxilium.global
- Node: https://github.com/auxiliumglobal/go-ethereum
- ChainID: 28945486
- SLIP-44 number: 344 

More information about Auxilium Global can be found here: https://auxilium.global

Gracias!