### PR TITLE
re-enabled base assets in send-assets dropdown

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -33,7 +33,13 @@ import { NewAppReleaseModal } from 'v2/components';
 import Dashboard from 'v2/features/Dashboard';
 import DevTools from 'v2/features/DevTools';
 import PrivateRoute from 'v2/features/NoAccounts/NoAccountAuth';
-import { NotificationsProvider, SettingsProvider, DevModeProvider, useDevMode } from 'v2/providers';
+import {
+  NotificationsProvider,
+  SettingsProvider,
+  DevModeProvider,
+  useDevMode,
+  AssetProvider
+} from 'v2/providers';
 import { AccountProvider } from 'v2/providers/AccountProvider';
 import { AddressBookProvider } from 'v2/providers/AddressBookProvider';
 import LockScreenProvider from 'v2/providers/LockScreenProvider/LockScreenProvider';
@@ -100,23 +106,25 @@ class RootClass extends Component<Props, State> {
               <SettingsProvider>
                 <AddressBookProvider>
                   <AccountProvider>
-                    <NotificationsProvider>
-                      <NetworksProvider>
-                        <Router>
-                          <LockScreenProvider>
-                            <PageVisitsAnalytics>
-                              {onboardingActive && <OnboardingModal />}
-                              {error ? <AppContainer error={error} /> : <AppContainer />}
-                              <LogOutPrompt />
-                              <QrSignerModal />
-                              {process.env.BUILD_ELECTRON && <NewAppReleaseModal />}
-                            </PageVisitsAnalytics>
-                          </LockScreenProvider>
-                        </Router>
-                        <DevToolsContainer />
-                        <div id="ModalContainer" />
-                      </NetworksProvider>
-                    </NotificationsProvider>
+                    <AssetProvider>
+                      <NotificationsProvider>
+                        <NetworksProvider>
+                          <Router>
+                            <LockScreenProvider>
+                              <PageVisitsAnalytics>
+                                {onboardingActive && <OnboardingModal />}
+                                {error ? <AppContainer error={error} /> : <AppContainer />}
+                                <LogOutPrompt />
+                                <QrSignerModal />
+                                {process.env.BUILD_ELECTRON && <NewAppReleaseModal />}
+                              </PageVisitsAnalytics>
+                            </LockScreenProvider>
+                          </Router>
+                          <DevToolsContainer />
+                          <div id="ModalContainer" />
+                        </NetworksProvider>
+                      </NotificationsProvider>
+                    </AssetProvider>
                   </AccountProvider>
                 </AddressBookProvider>
               </SettingsProvider>

--- a/common/v2/features/Dashboard/components/WalletBreakdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { Heading, Panel, Typography } from '@mycrypto/ui';
 
-import { AccountContext, SettingsContext } from 'v2/providers';
+import { AccountContext, SettingsContext, AssetContext } from 'v2/providers';
 import { ExtendedAccount } from 'v2/services/Account/types';
 import AccountDropdown from './AccountDropdown';
 import './WalletBreakdown.scss';
@@ -18,19 +18,19 @@ import { Link } from 'react-router-dom';
 
 function WalletBreakdown() {
   const { accounts } = useContext(AccountContext);
+  const { assets } = useContext(AssetContext);
   const { settings, updateSettingsAccounts } = useContext(SettingsContext);
   const balances: any[] = [];
   const currentAccounts: ExtendedAccount[] = getCurrentsFromContext(
     accounts,
     settings.dashboardAccounts
   );
-
   currentAccounts.forEach((account: ExtendedAccount) => {
-    const baseAsset = getBaseAssetFromAccount(account);
+    const baseAsset = getBaseAssetFromAccount(account, assets);
     if (!balances.find(asset => asset.asset === (baseAsset ? baseAsset.name : 'Unknown Asset'))) {
       balances.push({
         asset: baseAsset ? baseAsset.name : 'Unknown Asset',
-        amount: parseFloat(getBalanceFromAccount(account)).toFixed(4),
+        amount: parseFloat(getBalanceFromAccount(account, assets)).toFixed(4),
         value: 0
       });
     } else {
@@ -38,14 +38,15 @@ function WalletBreakdown() {
         asset => asset.asset === (baseAsset ? baseAsset.name : 'Unknown Asset')
       );
       balanceToUpdate.amount = (
-        parseFloat(balanceToUpdate.amount) + parseFloat(getBalanceFromAccount(account))
+        parseFloat(balanceToUpdate.amount) + parseFloat(getBalanceFromAccount(account, assets))
       ).toFixed(4);
     }
-    balances.push({
-      asset: 'Other Tokens',
-      amount: <Link to="/dashboard">View Details</Link>,
-      value: '$0'
-    });
+  });
+
+  balances.push({
+    asset: 'Other Tokens',
+    amount: <Link to="/dashboard">View Details</Link>,
+    value: '$0'
   });
 
   return (

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -80,7 +80,7 @@ export default function SendAssetsForm({
 
   const accountAssets: AssetBalanceObject[] = accounts.flatMap(a => a.assets);
 
-  const easyAssets: Asset[] = accountAssets
+  const tokenAssets: Asset[] = accountAssets
     .map((assetObj: AssetBalanceObject) => getAssetByUUID(assetObj.uuid, assets))
     .filter((asset: Asset | undefined) => asset)
     .map((asset: Asset) => asset);
@@ -91,8 +91,8 @@ export default function SendAssetsForm({
     .map((asset: Asset) => asset);
 
   const filteredAssets: string[] = _.union(
-    easyAssets.map(ass => ass.uuid),
-    baseAssets.map(ass => ass.uuid)
+    tokenAssets.map(token => token.uuid),
+    baseAssets.map(baseAsset => baseAsset.uuid)
   );
 
   const allAssets: IAsset[] = filteredAssets

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -78,34 +78,28 @@ export default function SendAssetsForm({
   const { assets } = useContext(AssetContext);
   // @TODO:SEND change the data structure to get an object
 
-  const allAssets: IAsset[] = [];
   const accountAssets: AssetBalanceObject[] = accounts.flatMap(a => a.assets);
 
-  /* ERC20 Tokens */
-  accountAssets
+  const easyAssets: Asset[] = accountAssets
     .map((assetObj: AssetBalanceObject) => getAssetByUUID(assetObj.uuid, assets))
     .filter((asset: Asset | undefined) => asset)
-    .map((asset: Asset) => {
-      return { symbol: asset.ticker as TSymbol, name: asset.name, network: asset.networkId, asset };
-    })
-    .forEach((asset: IAsset) => {
-      /* removes duplicates */
-      if (!(allAssets.map(allAssetItem => allAssetItem.name).indexOf(asset.name) > -1)) {
-        allAssets.push(asset);
-      }
-    });
+    .map((asset: Asset) => asset);
 
-  /* Base Assets */
-  accounts
+  const baseAssets: Asset[] = accounts
     .map(account => getBaseAssetFromAccount(account, assets))
+    .filter((asset: Asset | undefined) => asset)
+    .map((asset: Asset) => asset);
+
+  const filteredAssets: string[] = _.union(
+    easyAssets.map(ass => ass.uuid),
+    baseAssets.map(ass => ass.uuid)
+  );
+
+  const allAssets: IAsset[] = filteredAssets
+    .map(assetName => getAssetByUUID(assetName, assets))
     .filter((asset: Asset | undefined) => asset)
     .map((asset: Asset) => {
       return { symbol: asset.ticker as TSymbol, name: asset.name, network: asset.networkId, asset };
-    })
-    .forEach((asset: IAsset) => {
-      if (!(allAssets.map(allAssetItem => allAssetItem.name).indexOf(asset.name) > -1)) {
-        allAssets.push(asset);
-      }
     });
 
   return (

--- a/common/v2/features/SendAssets/components/displays/TransactionFeeDisplay.tsx
+++ b/common/v2/features/SendAssets/components/displays/TransactionFeeDisplay.tsx
@@ -3,13 +3,15 @@ import { gasPriceToBase, fromWei } from 'v2/libs/units';
 import BN from 'bn.js';
 import { getBaseAssetSymbolByNetwork } from 'v2/libs/networks/networks';
 import React from 'react';
+import { Asset } from 'v2/services/Asset/types';
 
 interface Props {
   values: ITxFields;
+  assets: Asset[];
   fiatAsset: { fiat: string; value: string; symbol: string };
 }
 
-function TransactionFeeDisplay({ values, fiatAsset }: Props) {
+function TransactionFeeDisplay({ values, fiatAsset, assets }: Props) {
   const gasLimitToUse =
     values.isAdvancedTransaction && values.isGasLimitManual
       ? values.gasLimitField
@@ -22,7 +24,7 @@ function TransactionFeeDisplay({ values, fiatAsset }: Props) {
   const transactionFeeBase: string = parseFloat(transactionFeeBaseAdv).toFixed(4);
   let baseAssetSymbol: string | undefined;
   if (values.network) {
-    baseAssetSymbol = getBaseAssetSymbolByNetwork(values.network);
+    baseAssetSymbol = getBaseAssetSymbolByNetwork(values.network, assets);
   }
   const baseAsset: string = !baseAssetSymbol ? 'Ether' : baseAssetSymbol;
 

--- a/common/v2/libs/accounts/accounts.ts
+++ b/common/v2/libs/accounts/accounts.ts
@@ -25,8 +25,8 @@ export const getCurrentsFromContext = (
   return accountList;
 };
 
-export const getBalanceFromAccount = (account: ExtendedAccount): string => {
-  const baseAsset = getBaseAssetFromAccount(account);
+export const getBalanceFromAccount = (account: ExtendedAccount, assets: Asset[]): string => {
+  const baseAsset = getBaseAssetFromAccount(account, assets);
   if (baseAsset) {
     return account.balance.toString();
   } else {
@@ -117,10 +117,13 @@ export const getAccountByAddress = (address: string): ExtendedAccount | undefine
   return undefined;
 };
 
-export const getBaseAssetFromAccount = (account: ExtendedAccount): Asset | undefined => {
+export const getBaseAssetFromAccount = (
+  account: ExtendedAccount,
+  assets: Asset[]
+): Asset | undefined => {
   const network: Network | undefined = getNetworkByName(account.network);
   if (network) {
-    return getAssetByUUID(network.baseAsset);
+    return getAssetByUUID(network.baseAsset, assets);
   }
 };
 

--- a/common/v2/libs/assets/assets.ts
+++ b/common/v2/libs/assets/assets.ts
@@ -40,7 +40,6 @@ export const getAssetByName = (name: string): Asset | undefined => {
   return allAssets.find(asset => asset.name === name);
 };
 
-export const getAssetByUUID = (uuid: string): Asset | undefined => {
-  const allAssets = getAllAssets();
-  return allAssets.find(asset => asset.uuid === uuid);
+export const getAssetByUUID = (uuid: string, assets: Asset[]): Asset | undefined => {
+  return assets.find(asset => asset.uuid === uuid);
 };

--- a/common/v2/libs/networks/networks.ts
+++ b/common/v2/libs/networks/networks.ts
@@ -86,11 +86,33 @@ export const createNode = (node: NodeOptions, network: Network): void => {
   setCache(newStorage);
 };
 
-export const getBaseAssetByNetwork = (networkObj: Network): Asset | undefined => {
-  return getAssetByUUID(networkObj.baseAsset);
+export const getBaseAssetByNetwork = (networkObj: Network, assets: Asset[]): Asset | undefined => {
+  return getAssetByUUID(networkObj.baseAsset, assets);
 };
 
-export const getBaseAssetSymbolByNetwork = (networkObj: Network): string | undefined => {
-  const baseAsset: Asset | undefined = getAssetByUUID(networkObj.baseAsset);
+export const getBaseAssetSymbolByNetwork = (
+  networkObj: Network,
+  assets: Asset[]
+): string | undefined => {
+  const baseAsset: Asset | undefined = getAssetByUUID(networkObj.baseAsset, assets);
   return baseAsset ? baseAsset.ticker : undefined;
+};
+
+export const getBaseAssetByNetworkName = (
+  networkName: string,
+  networks: Network[],
+  assets: Asset[]
+): Asset | undefined => {
+  const network: Network | undefined = getNetworkByNetworkName(networkName, networks);
+  if (network) {
+    const baseAsset: Asset | undefined = getAssetByUUID(network.baseAsset, assets);
+    return baseAsset;
+  }
+};
+
+export const getNetworkByNetworkName = (
+  networkName: string,
+  networks: Network[]
+): Network | undefined => {
+  return networks.find(network => network.name === networkName);
 };


### PR DESCRIPTION
Fixes an outstanding issue with showing base-assets in send-assets dropdown.

This *does not* fix the bug where there is a red screen of death on asset selection. This should be resolved by #2639 unless i'm mistaken.