### PR TITLE
Add iframe web3/ethereum provider polyfill to MyCrypto to support iframe based wallets

### DIFF
--- a/common/index.tsx
+++ b/common/index.tsx
@@ -3,6 +3,7 @@ import 'font-awesome/scss/font-awesome.scss';
 import 'sass/styles.scss';
 import 'babel-polyfill';
 import 'whatwg-fetch';
+import '@ethvault/iframe-provider-polyfill';
 
 import React from 'react';
 import { render } from 'react-dom';

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "npm": ">= 5.0.0"
   },
   "dependencies": {
+    "@ethvault/iframe-provider-polyfill": "0.1.2",
     "@hot-loader/react-dom": "16.8.6",
     "@ledgerhq/hw-app-eth": "4.48.0",
     "@ledgerhq/hw-transport-node-hid-noevents": "4.48.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "npm": ">= 5.0.0"
   },
   "dependencies": {
-    "@ethvault/iframe-provider-polyfill": "0.1.2",
+    "@ethvault/iframe-provider-polyfill": "0.1.3",
     "@hot-loader/react-dom": "16.8.6",
     "@ledgerhq/hw-app-eth": "4.48.0",
     "@ledgerhq/hw-transport-node-hid-noevents": "4.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,6 +850,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@ethvault/iframe-provider-polyfill@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@ethvault/iframe-provider-polyfill/-/iframe-provider-polyfill-0.1.2.tgz#fe7b939bef34d0cd756764a47bb9809165fdd43b"
+  integrity sha512-txJOkk5XQ/+cmTqPrvC3DFN0XtZNLIqvclEidbi5iAsD/aeFZlidCZ7VnShzkgypFJbhDznPbH/mDvcqwrTeQg==
+
 "@hot-loader/react-dom@16.8.6":
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,10 +850,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@ethvault/iframe-provider-polyfill@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@ethvault/iframe-provider-polyfill/-/iframe-provider-polyfill-0.1.2.tgz#fe7b939bef34d0cd756764a47bb9809165fdd43b"
-  integrity sha512-txJOkk5XQ/+cmTqPrvC3DFN0XtZNLIqvclEidbi5iAsD/aeFZlidCZ7VnShzkgypFJbhDznPbH/mDvcqwrTeQg==
+"@ethvault/iframe-provider-polyfill@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@ethvault/iframe-provider-polyfill/-/iframe-provider-polyfill-0.1.3.tgz#405daf8cfedbbbef052dd0891a70e060ca668975"
+  integrity sha512-G1JE7nn0fzCbGlSsqIU2S+w64H6vd0CGJZOD6FFEPcbGglAXUTpQR3ambkreKwgKYW/GKy4Jk1zJcTkH9LTw+g==
 
 "@hot-loader/react-dom@16.8.6":
   version "16.8.6"


### PR DESCRIPTION
## Closes #2661

🎉 🎉 🎉

## Description

Support iframe based wallets, where MyCrypto is embedded in an iframe of a parent window that represents the user wallet.

## Changes

- Adds a polyfill that automatically overrides web3 when MyCrypto is embedded within an iframe

### Reusable Code/Components

<!-- Preferably, include automated tests instead. -->
## Steps to Test

1. Open app.ethvault.dev
2. Browse to local instance
3. Try connecting to wallet via Web3
4. Try sending transactions or signing messages

<!-- Contributors: Delete this section. -->
## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56)
<!-- Upload screenshots here. -->

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
