### PR TITLE
Create stateFactory to SendAssets

### DIFF
--- a/common/v2/config/constants.ts
+++ b/common/v2/config/constants.ts
@@ -8,3 +8,6 @@ export const GAS_PRICE_GWEI_UPPER_BOUND = 3000;
 export const GAS_PRICE_GWEI_DEFAULT = 20;
 
 export const GITHUB_RELEASE_NOTES_URL = 'https://github.com/MyCryptoHQ/MyCrypto/releases/latest';
+
+// this will be changed when we figure out networks
+export const DEFAULT_NETWORK_FOR_FALLBACK = 'ropsten';

--- a/common/v2/config/index.ts
+++ b/common/v2/config/index.ts
@@ -8,4 +8,4 @@ export * from './cacheData';
 export * from './navigation';
 export * from './links';
 export * from './accountTypes';
-export { GITHUB_RELEASE_NOTES_URL } from './constants';
+export { DEFAULT_NETWORK_FOR_FALLBACK, GITHUB_RELEASE_NOTES_URL } from './constants';

--- a/common/v2/features/SendAssets/SendAssets.tsx
+++ b/common/v2/features/SendAssets/SendAssets.tsx
@@ -1,159 +1,76 @@
-// Legacy
+import React, { useState } from 'react';
+
 import sendIcon from 'common/assets/images/icn-send.svg';
-import React, { Component } from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { ContentPanel } from 'v2/components';
+import { useApi } from 'v2/services';
+import { TWalletType } from 'v2/types';
 import {
   ConfirmTransaction,
   SendAssetsForm,
   SignTransaction,
   TransactionReceipt
 } from './components';
-import { SendState } from './types';
+import { txConfigInitialState, TxConfigFactory } from './stateFactory';
+import { IFormikFields, ITxReceipt, IPath } from './types';
 
-const steps = [
-  { label: 'Send Assets', elem: SendAssetsForm },
-  { label: '', elem: SignTransaction },
-  { label: 'ConfirmTransaction', elem: ConfirmTransaction },
-  { label: 'Transaction Complete', elem: TransactionReceipt }
-];
+function SendAssets() {
+  const [step, setStep] = useState(0);
+  const {
+    handleFormSubmit,
+    handleConfirmAndSign,
+    handleConfirmAndSend,
+    handleSignedTx,
+    state: txConfigState
+  } = useApi(TxConfigFactory, txConfigInitialState);
 
-// due to MetaMask deprecating eth_sign method, it has different step order, where sign and send are one panel
-const web3Steps = [
-  { label: 'Send Assets', elem: SendAssetsForm },
-  { label: 'ConfirmTransaction', elem: ConfirmTransaction },
-  { label: '', elem: SignTransaction },
-  { label: 'Transaction Complete', elem: TransactionReceipt }
-];
+  // tslint:disable-next-line
+  const goToDashoard = () => {};
 
-export class SendAssets extends Component<RouteComponentProps<{}>, SendState> {
-  public state: SendState = {
-    step: 0,
-    transactionData: {
-      to: '',
-      gasLimit: '',
-      gasPrice: '',
-      nonce: '',
-      data: '',
-      value: '',
-      chainId: undefined
-    },
-    sharedConfig: {
-      senderAddress: '',
-      senderAddressLabel: '',
-      senderWalletBalanceBase: '',
-      senderWalletBalanceToken: '',
-      senderAccountType: '',
-      senderNetwork: '',
-      assetSymbol: '',
-      assetType: undefined,
-      dPath: '',
-      recipientAddressLabel: '',
-      recipientResolvedNSAddress: ''
-    },
-    transaction: {
-      serialized: '',
-      signed: '',
-      txHash: ''
-    }
+  // Due to MetaMask deprecating eth_sign method,
+  // it has different step order, where sign and send are one panel
+  const web3Steps: IPath[] = [
+    { label: 'Send Assets', component: SendAssetsForm, action: handleFormSubmit },
+    { label: 'Confirm Transaction', component: ConfirmTransaction, action: handleConfirmAndSign },
+    { label: '', component: SignTransaction, action: handleSignedTx },
+    { label: 'Transaction Complete', component: TransactionReceipt, action: goToDashoard }
+  ];
+
+  const defaultSteps: IPath[] = [
+    { label: 'Send Assets', component: SendAssetsForm, action: handleFormSubmit },
+    { label: '', component: SignTransaction, action: handleSignedTx },
+    { label: 'Confirm Transaction', component: ConfirmTransaction, action: handleConfirmAndSend },
+    { label: 'Transaction Complete', component: TransactionReceipt, action: goToDashoard }
+  ];
+
+  const getStep = (walletType: TWalletType, stepIndex: number) => {
+    const path = walletType === 'web3' ? web3Steps : defaultSteps;
+    const { label, component, action } = path[stepIndex]; // tslint:disable-line
+    return { currentPath: path, label, Step: component, stepAction: action };
   };
 
-  public render() {
-    const { step, sharedConfig } = this.state;
-    const Step = steps[step];
-    const Web3Steps = web3Steps[step];
-    const transactionFields = { account: {} };
+  const { senderAccount } = txConfigState;
+  const { currentPath, label, Step, stepAction } = getStep(
+    senderAccount ? senderAccount.wallet : undefined,
+    step
+  );
 
-    return (
-      <ContentPanel
-        onBack={this.goToPrevStep}
-        className="SendAssets"
-        heading={sharedConfig.senderAccountType === 'web3' ? Web3Steps.label : Step.label}
-        icon={sendIcon}
-        stepper={{ current: step + 1, total: steps.length - 1 }}
-      >
-        {sharedConfig.senderAccountType === 'web3' ? (
-          <Web3Steps.elem
-            onNext={this.goToNextStep}
-            updateState={this.updateSendState}
-            stateValues={this.state}
-          />
-        ) : (
-          <Step.elem
-            onNext={this.goToNextStep}
-            updateState={this.updateSendState}
-            stateValues={this.state}
-          />
-        )}
-      </ContentPanel>
-    );
-  }
+  const goToNextStep = () => setStep(Math.min(step + 1, currentPath.length - 1));
+  const goToPrevStep = () => setStep(Math.max(0, step - 1));
 
-  private goToNextStep = () =>
-    this.setState((prevState: SendState) => ({
-      step: Math.min(prevState.step + 1, steps.length - 1)
-    }));
-
-  private goToPrevStep = () =>
-    this.setState((prevState: SendState) => ({
-      step: Math.max(0, prevState.step - 1)
-    }));
-
-  private updateSendState = (formikValues: any) => {
-    // console.log('formik', formikValues);
-    const sharedConfig = {
-      senderAddress: formikValues.account.address,
-      senderAddressLabel: formikValues.account.label,
-      senderWalletBalanceBase: formikValues.account.balance,
-      senderWalletBalanceToken: '',
-      senderAccountType: formikValues.account.wallet,
-      senderNetwork: formikValues.account.network,
-      assetNetwork: formikValues.asset.network, //TODO: properly set this field in formik
-      assetSymbol: formikValues.sharedConfig.assetSymbol,
-      assetType: formikValues.sharedConfig.assetType,
-      dPath: formikValues.account.dPath,
-      recipientAddressLabel: formikValues.sharedConfig.recipientAddressLabel,
-      recipientResolvedNSAddress: formikValues.sharedConfig.recipientResolvedNSAddress
-    };
-
-    const transactionData = {
-      to: formikValues.sharedConfig.recipientResolvedNSAddress
-        ? formikValues.sharedConfig.recipientResolvedNSAddress
-        : formikValues.transactionData.to,
-      gasLimit: formikValues.formikState.isAdvancedTransaction
-        ? formikValues.formikState.gasLimitField
-        : formikValues.formikState.gasLimitEstimated,
-      gasPrice: formikValues.formikState.isAdvancedTransaction
-        ? formikValues.formikState.gasPriceField
-        : formikValues.formikState.gasEstimates.standard, //TODO: Properly set correcy gasPrice field in formik
-      nonce: formikValues.formikState.nonceEstimated,
-      data: formikValues.transactionData.data,
-      value: formikValues.transactionData.value,
-      chainId: formikValues.transactionData.network //TODO: grab chain from network name
-    };
-    this.setState({
-      transactionData,
-      sharedConfig
-    });
-    /*NEXT STEPS: Process transaction data according to formik values
-    * Set conditional gas price and gas limit depending on isAdvancedTransaction in Formik and set transactionData.gasLimit and transactionData.gasPrice
-    * process transaction correctly and serialize transaction
-    * pass serialized transaction to SendState transaction.serialized
-    */
-
-    this.processTransactionData();
-  };
-
-  private processTransactionData() {
-    // console.log(processFormDataToTx(this.state));
-    // console.log('state', this.state);
-  }
-
-  // private updateTransactionStrings = (transactionString: any) => {
-  //   console.log(transactionString);
-  // };
-
-  // private handleReset = () => this.setState(getInitialState());
+  return (
+    <ContentPanel
+      onBack={goToPrevStep}
+      className="SendAssets"
+      heading={label}
+      icon={sendIcon}
+      stepper={{ current: step + 1, total: currentPath.length - 1 }}
+    >
+      <Step
+        txConfig={txConfigState}
+        onComplete={(payload: IFormikFields | ITxReceipt) => stepAction(payload, goToNextStep)}
+      />
+    </ContentPanel>
+  );
 }
 
-export default withRouter(SendAssets);
+export default SendAssets;

--- a/common/v2/features/SendAssets/components/ConfirmTransaction.tsx
+++ b/common/v2/features/SendAssets/components/ConfirmTransaction.tsx
@@ -1,261 +1,141 @@
-import { Address, Button, Network } from '@mycrypto/ui';
-import feeIcon from 'common/assets/images/icn-fee.svg';
-// Legacy
-import sendIcon from 'common/assets/images/icn-send.svg';
+import React, { useContext, useState } from 'react';
 import { utils } from 'ethers';
-import { FallbackProvider } from 'ethers/providers';
-import React, { Component } from 'react';
-import { getNetworkByChainId } from 'v2';
+import { Address, Button, Network } from '@mycrypto/ui';
+
+import feeIcon from 'common/assets/images/icn-fee.svg';
+import sendIcon from 'common/assets/images/icn-send.svg';
+
 import { Amount } from 'v2/components';
-import { allProviders } from 'v2/config/networks/globalProvider';
+
 import { AddressBookContext } from 'v2/providers';
-import { ISendState } from '../types';
 import './ConfirmTransaction.scss';
-
-interface Props {
-  stateValues: ISendState;
-  onNext(): void;
-}
-
-interface State {
-  showingDetails: boolean;
-  toAddressFromSignedTransaction: string;
-  senderAddressFromSignedTransaction: string;
-  amountToSendFromSignedTransaction: string;
-  gasLimitWeiFromSignedTransaction: string | number;
-  gasPriceWeiFromSignedTransaction: string | number;
-  nonceFromSignedTransaction: number;
-  networkFromSignedTransaction: string;
-  dataFromSignedTransaction: string;
-  maxCostFeeEther: string;
-  totalAmountEther: string;
-}
+import { IStepComponentProps } from '../types';
 
 const truncate = (children: string) => {
   return [children.substring(0, 6), '…', children.substring(children.length - 4)].join('');
 };
 
-export default class ConfirmTransaction extends Component<Props> {
-  public state: State = {
-    showingDetails: false,
-    toAddressFromSignedTransaction: '',
-    senderAddressFromSignedTransaction: '',
-    amountToSendFromSignedTransaction: '',
-    gasLimitWeiFromSignedTransaction: '',
-    gasPriceWeiFromSignedTransaction: '',
-    nonceFromSignedTransaction: 0,
-    networkFromSignedTransaction: '',
-    dataFromSignedTransaction: '',
-    maxCostFeeEther: '',
-    totalAmountEther: ''
-  };
+/*
+  Confirm should only display values! There are no data transformations.
+  The currentPath in SendAssets determines which action should be called.
+*/
 
-  public decodeTransaction() {
-    const decodedTranasction = utils.parseTransaction(this.props.stateValues.signedTransaction);
+export default function ConfirmTransaction({ txConfig, onComplete }: IStepComponentProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const { getContactByAddress } = useContext(AddressBookContext);
 
-    if (!decodedTranasction) {
-      return;
-    } else {
-      const toAddress = decodedTranasction.to;
-      const fromAddress = decodedTranasction.from;
-      const gasLimitWei = utils.bigNumberify(decodedTranasction.gasLimit);
-      const gasPriceWei = utils.bigNumberify(decodedTranasction.gasPrice);
-      const nonce = decodedTranasction.nonce;
-      const data = decodedTranasction.data;
+  const {
+    recipientAddress,
+    senderAccount,
+    amount,
+    gasLimit,
+    gasPrice,
+    nonce,
+    data,
+    network
+  } = txConfig;
 
-      const amountToSendWei = utils.bigNumberify(decodedTranasction.value);
-      const amountToSendEther = utils.formatEther(amountToSendWei);
+  const recipientAccount = getContactByAddress(recipientAddress);
+  const recipientLabel = recipientAccount ? recipientAccount.label : 'Unknown Address';
 
-      const maxCostWei = gasPriceWei.mul(gasLimitWei);
-      const maxCostFeeEther = utils.formatEther(maxCostWei);
+  const maxCostFeeEther = '123120983'; // @TODO: BN math, multiply gasLimit * Price
+  const totalAmountEther = '102398120398'; // @TODO: BN math, add amount + maxCost !In same symbol
 
-      const totalAmountWei = amountToSendWei.add(maxCostWei);
-      const totalAmountEther = utils.formatEther(totalAmountWei);
+  const { name: networkName } = network;
 
-      this.setState({
-        toAddressFromSignedTransaction: toAddress,
-        senderAddressFromSignedTransaction: fromAddress,
-        amountToSendFromSignedTransaction: amountToSendEther.toString(),
-        gasLimitWeiFromSignedTransaction: gasLimitWei.toString(),
-        gasPriceWeiFromSignedTransaction: gasPriceWei.toString(),
-        nonceFromSignedTransaction: nonce,
-        dataFromSignedTransaction: data,
-        maxCostFeeEther: maxCostFeeEther.toString(),
-        totalAmountEther
-      });
-    }
-    this.getNetworkFromSignedTransaction();
-  }
-
-  public async getNetworkFromSignedTransaction() {
-    const decodedTranasction = utils.parseTransaction(this.props.stateValues.signedTransaction);
-    const chainId = decodedTranasction.chainId.toString();
-    const network = await getNetworkByChainId(chainId);
-
-    if (network) {
-      const networkName = network.name;
-      this.setState({ networkFromSignedTransaction: networkName });
-    }
-  }
-
-  public componentWillMount() {
-    this.decodeTransaction();
-  }
-
-  public render() {
-    const { stateValues: { transactionFields: { account: { label } } } } = this.props;
-    const {
-      showingDetails,
-      toAddressFromSignedTransaction,
-      senderAddressFromSignedTransaction,
-      amountToSendFromSignedTransaction,
-      gasLimitWeiFromSignedTransaction,
-      gasPriceWeiFromSignedTransaction,
-      nonceFromSignedTransaction,
-      networkFromSignedTransaction,
-      dataFromSignedTransaction,
-      maxCostFeeEther,
-      totalAmountEther
-    } = this.state;
-
-    return (
-      <div className="ConfirmTransaction">
-        <AddressBookContext.Consumer>
-          {({ addressBook }) => {
-            let recipientLabel: string = 'Unknown Account';
-            let senderLabel: string | undefined = 'Unknown Account';
-            addressBook.map(en => {
-              if (en.address.toLowerCase() === toAddressFromSignedTransaction.toLowerCase()) {
-                recipientLabel = en.label;
-              }
-              if (en.address.toLowerCase() === senderAddressFromSignedTransaction.toLowerCase()) {
-                senderLabel = en.label;
-              }
-            });
-            return (
-              <div className="ConfirmTransaction-row">
-                <div className="ConfirmTransaction-row-column">
-                  To:
-                  <div className="ConfirmTransaction-addressWrapper">
-                    <Address
-                      address={toAddressFromSignedTransaction}
-                      title={recipientLabel}
-                      truncate={truncate}
-                    />
-                  </div>
-                </div>
-                <div className="ConfirmTransaction-row-column">
-                  From:
-                  <div className="ConfirmTransaction-addressWrapper">
-                    <Address
-                      address={senderAddressFromSignedTransaction}
-                      title={senderLabel}
-                      truncate={truncate}
-                    />
-                  </div>
-                </div>
-              </div>
-            );
-          }}
-        </AddressBookContext.Consumer>
-
-        <div className="ConfirmTransaction-row">
-          <div className="ConfirmTransaction-row-column">
-            <img src={sendIcon} alt="Send" /> Send Amount:
+  return (
+    <div className="ConfirmTransaction">
+      <div className="ConfirmTransaction-row">
+        <div className="ConfirmTransaction-row-column">
+          To:
+          <div className="ConfirmTransaction-addressWrapper">
+            <Address address={recipientAddress} title={recipientLabel} truncate={truncate} />
           </div>
-          <div className="ConfirmTransaction-row-column">
-            <Amount
-              assetValue={`${amountToSendFromSignedTransaction} ETH`}
-              fiatValue="$12,000.00"
+        </div>
+        <div className="ConfirmTransaction-row-column">
+          From:
+          <div className="ConfirmTransaction-addressWrapper">
+            <Address
+              address={senderAccount.address}
+              title={senderAccount.label}
+              truncate={truncate}
             />
           </div>
         </div>
-        <div className="ConfirmTransaction-row">
-          <div className="ConfirmTransaction-row-column">
-            <img src={feeIcon} alt="Fee" /> Transaction Fee:
-          </div>
-          <div className="ConfirmTransaction-row-column">
-            <Amount assetValue={`${maxCostFeeEther} ETH`} fiatValue="$0.21" />
-          </div>
-        </div>
-        <div className="ConfirmTransaction-divider" />
-        <div className="ConfirmTransaction-row">
-          <div className="ConfirmTransaction-row-column">
-            <img src={sendIcon} alt="Total" /> You'll Send:
-          </div>
-          <div className="ConfirmTransaction-row-column">
-            <Amount assetValue={totalAmountEther} fiatValue="$12,000.21" />
-          </div>
-        </div>
-        <Button
-          basic={true}
-          onClick={this.toggleShowingDetails}
-          className="ConfirmTransaction-detailButton"
-        >
-          {showingDetails ? 'Hide' : 'Show'} Details
-        </Button>
-        {showingDetails && (
-          <div className="ConfirmTransaction-details">
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Account Balance:</div>
-              <div className="ConfirmTransaction-details-row-column">0.231935129 ETH</div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Network:</div>
-              <div className="ConfirmTransaction-details-row-column">
-                <Network color="blue">{networkFromSignedTransaction}</Network>
-              </div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Gas Limit:</div>
-              <div className="ConfirmTransaction-details-row-column">
-                {`${utils.formatEther(gasLimitWeiFromSignedTransaction)} ETH`}
-              </div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Gas Price:</div>
-              <div className="ConfirmTransaction-details-row-column">
-                {`${utils.formatEther(gasPriceWeiFromSignedTransaction)} ETH`}
-              </div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Max TX Fee:</div>
-              <div className="ConfirmTransaction-details-row-column">{maxCostFeeEther} ETH</div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Nonce:</div>
-              <div className="ConfirmTransaction-details-row-column">
-                {nonceFromSignedTransaction}
-              </div>
-            </div>
-            <div className="ConfirmTransaction-details-row">
-              <div className="ConfirmTransaction-details-row-column">Data:</div>
-              <div className="ConfirmTransaction-details-row-column">
-                {dataFromSignedTransaction}
-              </div>
-            </div>
-          </div>
-        )}
-        <Button onClick={this.sendTransaction} className="ConfirmTransaction-button">
-          Confirm and Send
-        </Button>
       </div>
-    );
-  }
-
-  private sendTransaction = async () => {
-    const network: string = this.state.networkFromSignedTransaction;
-    const signedTransaction: string = this.props.stateValues.signedTransaction;
-
-    //@ts-ignore
-    const transactionProvider: FallbackProvider = allProviders[network];
-    const broadcastTransaction = await transactionProvider.sendTransaction(signedTransaction);
-
-    console.log(broadcastTransaction);
-  };
-
-  private toggleShowingDetails = () =>
-    this.setState((prevState: State) => ({
-      showingDetails: !prevState.showingDetails
-    }));
+      <div className="ConfirmTransaction-row">
+        <div className="ConfirmTransaction-row-column">
+          <img src={sendIcon} alt="Send" /> Send Amount:
+        </div>
+        <div className="ConfirmTransaction-row-column">
+          <Amount assetValue={`${amount} ETH`} fiatValue="$12,000.00" />
+        </div>
+      </div>
+      <div className="ConfirmTransaction-row">
+        <div className="ConfirmTransaction-row-column">
+          <img src={feeIcon} alt="Fee" /> Transaction Fee:
+        </div>
+        <div className="ConfirmTransaction-row-column">
+          <Amount assetValue={`${maxCostFeeEther} ETH`} fiatValue="$0.21" />
+        </div>
+      </div>
+      <div className="ConfirmTransaction-divider" />
+      <div className="ConfirmTransaction-row">
+        <div className="ConfirmTransaction-row-column">
+          <img src={sendIcon} alt="Total" /> You'll Send:
+        </div>
+        <div className="ConfirmTransaction-row-column">
+          <Amount assetValue={totalAmountEther} fiatValue="$12,000.21" />
+        </div>
+      </div>
+      <Button
+        basic={true}
+        onClick={() => setShowDetails(!showDetails)}
+        className="ConfirmTransaction-detailButton"
+      >
+        {showDetails ? 'Hide' : 'Show'} Details
+      </Button>
+      {showDetails && (
+        <div className="ConfirmTransaction-details">
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Account Balance:</div>
+            <div className="ConfirmTransaction-details-row-column">0.231935129 ETH</div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Network:</div>
+            <div className="ConfirmTransaction-details-row-column">
+              <Network color="blue">{networkName}</Network>
+            </div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Gas Limit:</div>
+            <div className="ConfirmTransaction-details-row-column">
+              {`${utils.formatEther(gasLimit)} ETH`}
+            </div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Gas Price:</div>
+            <div className="ConfirmTransaction-details-row-column">
+              {`${utils.formatEther(gasPrice)} ETH`}
+            </div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Max TX Fee:</div>
+            <div className="ConfirmTransaction-details-row-column">{maxCostFeeEther} ETH</div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Nonce:</div>
+            <div className="ConfirmTransaction-details-row-column">{nonce}</div>
+          </div>
+          <div className="ConfirmTransaction-details-row">
+            <div className="ConfirmTransaction-details-row-column">Data:</div>
+            <div className="ConfirmTransaction-details-row-column">{data}</div>
+          </div>
+        </div>
+      )}
+      <Button onClick={onComplete} className="ConfirmTransaction-button">
+        Confirm and Send
+      </Button>
+    </div>
+  );
 }

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Keystore.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Keystore.tsx
@@ -1,38 +1,26 @@
-import PrivateKeyicon from 'common/assets/images/icn-privatekey-new.svg';
+import React, { Component } from 'react';
+import { ethers, utils } from 'ethers';
+
 import { Input } from 'components/ui';
 import Spinner from 'components/ui/Spinner';
-import { ethers, utils } from 'ethers';
-import { notificationsActions } from 'features/notifications';
+import PrivateKeyicon from 'common/assets/images/icn-privatekey-new.svg';
+// import { notificationsActions } from 'features/notifications';
 import { isKeystorePassRequired } from 'libs/wallet';
-import React, { Component } from 'react';
 import translate, { translateRaw } from 'translations';
-import { ISendState, ITxFields } from '../../types';
+
+import { ISignComponentProps } from '../../types';
 import './Keystore.scss';
 
-//Test Transaction
-const transaction = {
-  nonce: 0,
-  gasLimit: 21000,
-  gasPrice: utils.bigNumberify('20000000000'),
-  to: '0x88a5C2d9919e46F883EB62F7b8Dd9d0CC45bc290',
-  // ... or supports ENS names
-  value: utils.parseEther('2'),
-  data: '0x',
-  // This ensures the transaction cannot be replayed on different networks
-  chainId: ethers.utils.getNetwork('ropsten').chainId
-};
-
-interface Props {
-  stateValues: ISendState;
-  transactionFields: ITxFields;
-  wallet: any;
-  isWalletPending: boolean;
-  isPasswordPending: boolean;
-  onChange(value: KeystoreValueState): void;
-  onUnlock(param: any): void;
-  showNotification(level: string, message: string): notificationsActions.TShowNotification;
-  onNext(signedTransaction: string): void;
-}
+// interface Props {
+//   transactionFields: IFormikFields;
+//   wallet: any;
+//   isWalletPending: boolean;
+//   isPasswordPending: boolean;
+//   onChange(value: KeystoreValueState): void;
+//   onUnlock(param: any): void;
+//   showNotification(level: string, message: string): notificationsActions.TShowNotification;
+//   onNext(signedTransaction: string): void;
+// }
 
 export interface KeystoreValueState {
   file: string;
@@ -65,7 +53,10 @@ function isValidFile(rawFile: File): boolean {
   return fileType === '' || fileType === 'application/json';
 }
 
-export default class SignTransactionKeystore extends Component<Props, KeystoreValueState> {
+export default class SignTransactionKeystore extends Component<
+  ISignComponentProps,
+  KeystoreValueState
+> {
   public state: KeystoreValueState = {
     file: '',
     password: '',
@@ -77,7 +68,8 @@ export default class SignTransactionKeystore extends Component<Props, KeystoreVa
   };
 
   public render() {
-    const { isWalletPending } = this.props;
+    // const { isWalletPending } = this.props;
+    const isWalletPending = false;
     const { file, password, filename, walletState, hasCorrectPassword, isSigning } = this.state;
     const passReq = file ? isPassRequired(file) : true;
     const unlockDisabled = !file || (passReq && !password);
@@ -181,7 +173,8 @@ export default class SignTransactionKeystore extends Component<Props, KeystoreVa
   }
 
   private checkPublicKeyMatchesCache(walletAddres: string) {
-    const localCacheAddress = utils.getAddress(this.props.transactionFields.account.address);
+    const { rawTransaction: { from: senderAddress } } = this.props;
+    const localCacheAddress = utils.getAddress(senderAddress);
     const keystoreFileAddress = walletAddres;
 
     if (localCacheAddress === keystoreFileAddress) {
@@ -194,12 +187,13 @@ export default class SignTransactionKeystore extends Component<Props, KeystoreVa
   }
 
   private async signTransaction() {
+    const { rawTransaction } = this.props;
     const signerWallet = await ethers.Wallet.fromEncryptedJson(
       this.state.file,
       this.state.password
     );
-    const rawSignedTransaction: any = await signerWallet.sign(transaction);
-    this.props.onNext(rawSignedTransaction);
+    const rawSignedTransaction: any = await signerWallet.sign(rawTransaction);
+    this.props.onSuccess(rawSignedTransaction);
   }
   private onPasswordChange = (e: any) => {
     this.setState({
@@ -229,7 +223,7 @@ export default class SignTransactionKeystore extends Component<Props, KeystoreVa
     if (isValidFile(inputFile)) {
       fileReader.readAsText(inputFile, 'utf-8');
     } else {
-      this.props.showNotification('danger', translateRaw('ERROR_3'));
+      // this.props.showNotification('danger', translateRaw('ERROR_3'));
     }
   };
 }

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Ledger.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Ledger.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
+import { ISignComponentProps } from '../../types';
 import './Ledger.scss';
 import ledgerIcon from 'common/assets/images/icn-ledger-nano-large.svg';
 
-export default function SignTransactionLedger() {
+export default function SignTransactionLedger({  }: ISignComponentProps) {
   return (
     <div className="SignTransaction-panel">
       <div className="SignTransactionLedger-title">Sign the Transaction with your Ledger</div>

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Metamask.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Metamask.tsx
@@ -1,23 +1,12 @@
-import MetamaskSVG from 'common/assets/images/wallets/metamask-2.svg';
+import React, { Component } from 'react';
 import { ethers, utils } from 'ethers';
 import { Web3Provider } from 'ethers/providers/web3-provider';
-import React, { Component } from 'react';
-import { getNetworkByChainId } from 'v2';
-import { ISendState, ITxFields } from '../../types';
-import './MetaMask.scss';
 
-//Test Transaction
-const transaction = {
-  nonce: 0,
-  gasLimit: 21000,
-  gasPrice: utils.bigNumberify('20000000000'),
-  to: '0x88a5C2d9919e46F883EB62F7b8Dd9d0CC45bc290',
-  // ... or supports ENS names
-  value: utils.parseEther('0.00001'),
-  data: '0x',
-  // This ensures the transaction cannot be replayed on different networks
-  chainId: ethers.utils.getNetwork('ropsten').chainId
-};
+import { DEFAULT_NETWORK_FOR_FALLBACK } from 'v2/config';
+import { getNetworkByChainId } from 'v2/libs';
+import MetamaskSVG from 'common/assets/images/wallets/metamask-2.svg';
+import './MetaMask.scss';
+import { ISignComponentProps } from '../../types';
 
 declare global {
   interface Window {
@@ -26,12 +15,6 @@ declare global {
     metaMaskProvider: ethers.providers.Web3Provider;
     metaMaskSigner: Web3Provider;
   }
-}
-interface Props {
-  stateValues: ISendState;
-  transactionFields: ITxFields;
-  onNext(receipt: ethers.providers.TransactionResponse): void;
-  // updateState(state: DeepPartial<ISendState>): void;
 }
 
 enum WalletSigningState {
@@ -48,9 +31,6 @@ interface MetaMaskUserState {
   walletState: WalletSigningState;
 }
 
-// this will be changed when we figure out networks
-const DEFAULT_NETWORK_FOR_FALLBACK = 'ropsten';
-
 const ethereumProvider = window.ethereum;
 let metaMaskProvider: ethers.providers.Web3Provider;
 
@@ -63,7 +43,10 @@ async function getMetaMaskProvider() {
   }
 }
 
-export default class SignTransactionMetaMask extends Component<Props, MetaMaskUserState> {
+export default class SignTransactionMetaMask extends Component<
+  ISignComponentProps,
+  MetaMaskUserState
+> {
   public state: MetaMaskUserState = {
     account: undefined,
     network: undefined,
@@ -72,7 +55,7 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
     walletState: WalletSigningState.UNKNOWN
   };
 
-  constructor(props: Props) {
+  constructor(props: ISignComponentProps) {
     super(props);
     this.getMetaMaskAccount = this.getMetaMaskAccount.bind(this);
   }
@@ -93,7 +76,10 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
   }
 
   public render() {
-    const { stateValues } = this.props;
+    const { rawTransaction } = this.props;
+    const networkName = rawTransaction.chainId; // @TODO get networkName
+    const senderAddress = rawTransaction.from;
+
     const { accountMatches, networkMatches, walletState } = this.state;
     return (
       <div className="SignTransaction-panel">
@@ -114,14 +100,12 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
           {!networkMatches && (
             <div className="SignTransactionMetaMask-wrong-network">
               {' '}
-              Please switch the network in MetaMask to{' '}
-              {stateValues.transactionFields.account.network}
+              Please switch the network in MetaMask to {networkName}
             </div>
           )}
           {!accountMatches && (
             <div className="SignTransactionMetaMask-wrong-address">
-              Please switch the account in MetaMask to{' '}
-              {stateValues.transactionFields.account.address}
+              Please switch the account in MetaMask to {senderAddress}
               <br /> in order to proceed
             </div>
           )}
@@ -165,17 +149,19 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
   }
 
   private checkAddressMatches(metaMaskAddress: string) {
-    const desiredAddress = utils.getAddress(this.props.transactionFields.account.address);
+    const { senderAddress } = this.props;
+    const desiredAddress = utils.getAddress(senderAddress);
     this.setState({ accountMatches: metaMaskAddress === desiredAddress });
   }
 
   private checkNetworkMatches(metaMaskNetwork: ethers.utils.Network) {
+    const { networkName } = this.props;
     const getMetaMaskNetworkbyChainId = getNetworkByChainId(metaMaskNetwork.chainId.toString());
     if (!getMetaMaskNetworkbyChainId) {
       return;
     }
 
-    const localCacheSenderNetwork = this.props.transactionFields.account.network;
+    const localCacheSenderNetwork = networkName;
     if (getMetaMaskNetworkbyChainId.name === localCacheSenderNetwork) {
       this.setState({ networkMatches: true });
       this.maybeSendTransaction();
@@ -189,6 +175,7 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
   }
 
   private async maybeSendTransaction() {
+    const { rawTransaction, onSuccess } = this.props;
     if (!this.state.accountMatches || !this.state.networkMatches) {
       return;
     }
@@ -197,9 +184,10 @@ export default class SignTransactionMetaMask extends Component<Props, MetaMaskUs
     const signerWallet = metaMaskProvider.getSigner();
 
     try {
-      const receipt = await signerWallet.sendTransaction(transaction);
-      this.props.onNext(receipt);
+      const receipt = await signerWallet.sendTransaction(rawTransaction);
+      onSuccess(receipt);
     } catch (err) {
+      console.debug(`[SignTransactionMetaMask] ${err}`);
       if (err.message.includes('User denied transaction signature')) {
         this.setState({ walletState: WalletSigningState.NOT_READY });
       }

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Mnemonic.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Mnemonic.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
-export default function SignTransactionMnemonic() {
+import { ISignComponentProps } from '../../types';
+
+export default function SignTransactionMnemonic({  }: ISignComponentProps) {
   return <div>Sign Transaction with Mnemonic</div>;
 }

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Parity.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Parity.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
-export default function SignTransactionParity() {
+import { ISignComponentProps } from '../../types';
+
+export default function SignTransactionParity({  }: ISignComponentProps) {
   return <div>Sign Transaction with Parity</div>;
 }

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/PrivateKey.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/PrivateKey.tsx
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
-import './PrivateKey.scss';
-import { Button } from '@mycrypto/ui';
-import PrivateKeyicon from 'common/assets/images/icn-privatekey-new.svg';
-
-import { TogglablePassword } from 'components';
 import { stripHexPrefix } from 'ethjs-util';
-import { isValidPrivKey, isValidEncryptedPrivKey } from 'libs/validators';
+import { Button } from '@mycrypto/ui';
+
+import PrivateKeyicon from 'common/assets/images/icn-privatekey-new.svg';
+import { TogglablePassword } from 'components';
 import { Input } from 'components/ui';
+import { isValidPrivKey, isValidEncryptedPrivKey } from 'libs/validators';
+import { ISignComponentProps } from '../../types';
+import './PrivateKey.scss';
 
 export interface SignWithPrivKeyState {
   key: string;
@@ -43,8 +44,11 @@ function validatePkeyAndPass(pkey: string, pass: string): Validated {
   };
 }
 
-export default class SignTransactionPrivateKey extends Component {
-  public state: SignWithPrivKeyState = {
+export default class SignTransactionPrivateKey extends Component<
+  ISignComponentProps,
+  SignWithPrivKeyState
+> {
+  public state = {
     key: '',
     password: '',
     valid: false

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/SafeTmini.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/SafeTmini.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import SafeTIcon from 'common/assets/images/icn-safet-mini-new.svg';
+import { ISignComponentProps } from '../../types';
 import './SafeTmini.scss';
 
-export default function SignTransactionSafeT() {
+export default function SignTransactionSafeT({  }: ISignComponentProps) {
   return (
     <div className="SignTransaction-panel">
       <div className="SignTransactionSafeT-title">Sign the Transaction with your Safe-T Mini</div>

--- a/common/v2/features/SendAssets/components/SignTransactionWallets/Trezor.tsx
+++ b/common/v2/features/SendAssets/components/SignTransactionWallets/Trezor.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
+import { ISignComponentProps } from '../../types';
 import ConnectTrezor from 'common/assets/images/icn-connect-trezor-new.svg';
 import './Trezor.scss';
 
-export default function SignTransactionTrezor() {
+export default function SignTransactionTrezor({  }: ISignComponentProps) {
   return (
     <div className="SignTransaction-panel">
       <div className="SignTransactionTrezor-title">Sign the Transaction with your Trezor</div>

--- a/common/v2/features/SendAssets/components/TransactionReceipt.tsx
+++ b/common/v2/features/SendAssets/components/TransactionReceipt.tsx
@@ -3,24 +3,20 @@ import { Link } from 'react-router-dom';
 import { Address, Button, Copyable } from '@mycrypto/ui';
 
 import { Amount } from 'v2/components';
-import { ISendState } from '../types';
+import { IStepComponentProps } from '../types';
 import './TransactionReceipt.scss';
 
 // Legacy
 import sentIcon from 'common/assets/images/icn-sent.svg';
 
-interface Props {
-  stateValues: ISendState;
-  // onReset(): void; // RE-ADD RESET
-}
-
 const truncate = (children: string) => {
   return [children.substring(0, 6), '…', children.substring(children.length - 4)].join('');
 };
 
-export default function TransactionReceipt({
-  stateValues: { transactionFields: { recipientAddress, account: { address } } }
-}: Props) {
+export default function TransactionReceipt({ txReceipt, onComplete }: IStepComponentProps) {
+  const recipientAddress = txReceipt.to;
+  const address = txReceipt.from;
+
   return (
     <div className="TransactionReceipt">
       <div className="TransactionReceipt-row">

--- a/common/v2/features/SendAssets/components/displays/TransactionFeeDisplay.tsx
+++ b/common/v2/features/SendAssets/components/displays/TransactionFeeDisplay.tsx
@@ -2,29 +2,23 @@ import BN from 'bn.js';
 import React from 'react';
 import { getBaseAssetSymbolByNetwork } from 'v2/libs/networks/networks';
 import { fromWei, gasPriceToBase } from 'v2/libs/units';
-import { FormikFormState } from '../../types';
 
 interface Props {
-  values: FormikFormState;
+  gasLimitToUse: string;
+  gasPriceToUse: string;
+  network: object;
   fiatAsset: { fiat: string; value: string; symbol: string };
 }
 
-function TransactionFeeDisplay({ values, fiatAsset }: Props) {
-  const gasLimitToUse =
-    values.formikState.isAdvancedTransaction && values.formikState.isGasLimitManual
-      ? values.formikState.gasLimitField
-      : values.formikState.gasLimitEstimated;
-  const gasPriceToUse = values.formikState.isAdvancedTransaction
-    ? values.formikState.gasPriceField
-    : values.formikState.gasPriceSlider;
+function TransactionFeeDisplay({ gasLimitToUse, gasPriceToUse, network, fiatAsset }: Props) {
   const transactionFeeWei: BN = gasPriceToBase(
     parseFloat(gasPriceToUse) * parseFloat(gasLimitToUse)
   );
   const transactionFeeBaseAdv: string = fromWei(transactionFeeWei, 'ether').toString();
   const transactionFeeBase: string = parseFloat(transactionFeeBaseAdv).toFixed(4);
   let baseAssetSymbol: string | undefined;
-  if (values.sharedConfig.senderNetwork) {
-    baseAssetSymbol = getBaseAssetSymbolByNetwork(values.sharedConfig.senderNetwork);
+  if (network) {
+    baseAssetSymbol = getBaseAssetSymbolByNetwork(network);
   }
   const baseAsset: string = !baseAssetSymbol ? 'Ether' : baseAssetSymbol;
 

--- a/common/v2/features/SendAssets/components/fields/AccountDropdown.tsx
+++ b/common/v2/features/SendAssets/components/fields/AccountDropdown.tsx
@@ -4,7 +4,6 @@ import { translateRaw } from 'translations';
 import { AccountSummary, Divider, Dropdown } from 'v2/components';
 import { getNetworkByName } from 'v2/libs/networks/networks';
 import { ExtendedAccount, ExtendedAccount as IExtendedAccount, Network } from 'v2/services';
-import { FormikFormState } from '../../types';
 
 // Option item displayed in Dropdown menu. Props are passed by react-select Select.
 // To know: Select needs to receive a class in order to attach refs https://github.com/JedWatson/react-select/issues/2459
@@ -31,22 +30,21 @@ interface IAccountDropdownProps {
   accounts: IExtendedAccount[];
   name: string;
   value: IExtendedAccount;
-  values: FormikFormState;
   onSelect(option: IExtendedAccount): void;
 }
 
-function AccountDropdown({ accounts, name, value, values, onSelect }: IAccountDropdownProps) {
-  let relevantAccounts: ExtendedAccount[] = [];
-  if (values.sharedConfig.asset && values.sharedConfig.assetNetwork) {
-    relevantAccounts = accounts.filter((account: ExtendedAccount): boolean => {
-      const accountNetwork: Network | undefined = getNetworkByName(account.network);
-      const assetNetwork: Network | undefined =
-        values.sharedConfig.asset && values.sharedConfig.assetNetwork
-          ? getNetworkByName(values.sharedConfig.assetNetwork.name)
-          : undefined;
-      return !accountNetwork || !assetNetwork ? false : accountNetwork.name === assetNetwork.name;
-    });
-  }
+function AccountDropdown({ accounts, name, value, onSelect }: IAccountDropdownProps) {
+  let relevantAccounts: ExtendedAccount[] = accounts;
+  // if (values.sharedConfig.asset && values.sharedConfig.assetNetwork) {
+  //   relevantAccounts = accounts.filter((account: ExtendedAccount): boolean => {
+  //     const accountNetwork: Network | undefined = getNetworkByName(account.network);
+  //     const assetNetwork: Network | undefined =
+  //       values.sharedConfig.asset && values.sharedConfig.assetNetwork
+  //         ? getNetworkByName(values.sharedConfig.assetNetwork.name)
+  //         : undefined;
+  //     return !accountNetwork || !assetNetwork ? false : accountNetwork.name === assetNetwork.name;
+  //   });
+  // }
 
   return (
     <Dropdown

--- a/common/v2/features/SendAssets/components/fields/AmountField.tsx
+++ b/common/v2/features/SendAssets/components/fields/AmountField.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, Component } from 'react';
 import { Field, FieldProps, Formik } from 'formik';
 import { Input } from '@mycrypto/ui';
-import { ITxFields } from '../../types';
+import { IFormikFields } from '../../types';
 //import { donationAddressMap } from '';
 
 interface OwnProps {
@@ -39,7 +39,7 @@ export default class AmountField extends Component<Props> {
             id={'5'}
             name="amount"
             validate={this.isValidAmount}
-            render={({ field }: FieldProps<ITxFields>) => (
+            render={({ field }: FieldProps<IFormikFields>) => (
               <Input
                 {...field}
                 id={'6'}

--- a/common/v2/features/SendAssets/components/fields/AssetField.tsx
+++ b/common/v2/features/SendAssets/components/fields/AssetField.tsx
@@ -3,7 +3,7 @@ import { Field, FieldProps, Formik } from 'formik';
 import { ComboBox } from '@mycrypto/ui';
 
 import { AccountContext, NetworksContext } from 'v2/providers';
-import { ITxFields } from '../../types';
+import { IFormikFields } from '../../types';
 import { Network } from 'v2/services/Network/types';
 
 interface OwnProps {
@@ -55,7 +55,7 @@ export default class AssetField extends Component<Props> {
                   <Field
                     id={'7'}
                     name="asset"
-                    render={({ field }: FieldProps<ITxFields>) => (
+                    render={({ field }: FieldProps<IFormikFields>) => (
                       <ComboBox
                         {...field}
                         id={'8'}

--- a/common/v2/features/SendAssets/components/fields/EthAddressField.tsx
+++ b/common/v2/features/SendAssets/components/fields/EthAddressField.tsx
@@ -6,7 +6,7 @@ import { translateRaw } from 'translations';
 import { InlineErrorMsg } from 'v2/components';
 import { getENSTLDForChain } from 'v2/libs/ens/networkConfigs';
 import { isValidENSName } from 'v2/libs/validators';
-import { FormikFormState } from '../../types';
+import { IFormikFields } from '../../types';
 
 /*
   Eth address field to be used within a Formik Form
@@ -19,7 +19,7 @@ interface Props {
   fieldName: string;
   touched?: boolean;
   placeholder?: string;
-  values: FormikFormState;
+  chainId: number;
   handleENSResolve?(name: string): Promise<void>;
 }
 
@@ -27,7 +27,7 @@ function ETHAddressField({
   fieldName,
   error,
   touched,
-  values,
+  chainId,
   placeholder = 'Eth Address',
   handleENSResolve
 }: Props) {
@@ -55,8 +55,8 @@ function ETHAddressField({
             {...field}
             placeholder={placeholder}
             onBlur={e => {
-              if (values && values.sharedConfig.senderNetwork) {
-                const ensTLD = getENSTLDForChain(values.sharedConfig.senderNetwork.chainId);
+              if (chainId) {
+                const ensTLD = getENSTLDForChain(chainId);
                 const isENSAddress = e.currentTarget.value.endsWith(`.${ensTLD}`);
                 form.setFieldValue('resolvedNSAddress', '');
                 if (isENSAddress && handleENSResolve) {

--- a/common/v2/features/SendAssets/components/fields/GasPriceSlider.tsx
+++ b/common/v2/features/SendAssets/components/fields/GasPriceSlider.tsx
@@ -4,14 +4,13 @@ import Slider, { createSliderWithTooltip, Marks } from 'rc-slider';
 import React, { Component } from 'react';
 import translate, { translateRaw } from 'translations';
 import { GasEstimates } from 'v2/api/gas';
-import { FormikFormState } from '../../types';
+import { IFormikFields } from '../../types';
 import './GasPriceSlider.scss';
 
 const SliderWithTooltip = createSliderWithTooltip(Slider);
 
 interface OwnProps {
   gasPrice: string;
-  transactionFieldValues: FormikFormState;
   handleChange: Formik['handleChange'];
   gasEstimates: GasEstimates;
 }
@@ -53,13 +52,13 @@ export default class SimpleGas extends Component<Props> {
     return (
       <Field
         name="gasPriceSlider"
-        render={({ field, form }: FieldProps<FormikFormState>) => (
+        render={({ field, form }: FieldProps<IFormikFields>) => (
           <div className="GasPriceSlider">
             <div className="GasPriceSlider-input-group">
               <div className="GasPriceSlider-slider">
                 <SliderWithTooltip
                   {...field}
-                  onChange={e => form.setFieldValue('formikState.gasPriceSlider', e)}
+                  onChange={e => form.setFieldValue('gasPriceSlider', e)}
                   min={bounds.min}
                   max={bounds.max}
                   marks={gasNotches}

--- a/common/v2/features/SendAssets/helpers.ts
+++ b/common/v2/features/SendAssets/helpers.ts
@@ -1,0 +1,74 @@
+import { utils } from 'ethers';
+
+import { getNetworkByChainId } from 'v2/libs';
+import { ITxObject, ITxConfig, IFormikFields } from './types';
+
+export function fromStateToTxObject(state: ITxConfig): ITxObject {
+  return {
+    to: state.recipientAddress, // @TODO or token address
+    from: state.senderAccount.address,
+    value: state.amount,
+    data: state.data, // @TODO or generate contract call
+    gasLimit: state.gasLimit,
+    gasPrice: state.gasPrice,
+    nonce: state.nonce,
+    chainId: state.network!.chainId
+  };
+}
+
+export function fromFormikStateToTxObject(formikState: IFormikFields): ITxObject {
+  return {
+    to: formikState.recipientAddress, // @TODO compose data according to asset type
+    from: formikState.account.address,
+    value: formikState.amount, // @TODO value depends on asset type
+    data: formikState.txDataField, // @TODO compose data according to asset type
+    gasLimit: formikState.gasLimitField, // @TODO update with correct value.
+    gasPrice: formikState.gasPriceField, // @TODO update with correct value.
+    nonce: formikState.nonceField, // @TODO update with correct value.
+    chainId: formikState.network.chainId
+  };
+}
+
+export function decodeTransaction(signedTx: string) {
+  const decodedTranasction = utils.parseTransaction(signedTx);
+
+  if (!decodedTranasction) {
+    return;
+  }
+
+  const toAddress = decodedTranasction.to;
+  const fromAddress = decodedTranasction.from;
+  const gasLimitWei = utils.bigNumberify(decodedTranasction.gasLimit);
+  const gasPriceWei = utils.bigNumberify(decodedTranasction.gasPrice);
+  const nonce = decodedTranasction.nonce;
+  const data = decodedTranasction.data;
+
+  const amountToSendWei = utils.bigNumberify(decodedTranasction.value);
+  const amountToSendEther = utils.formatEther(amountToSendWei);
+
+  const maxCostWei = gasPriceWei.mul(gasLimitWei);
+  const maxCostFeeEther = utils.formatEther(maxCostWei);
+
+  const totalAmountWei = amountToSendWei.add(maxCostWei);
+  const totalAmountEther = utils.formatEther(totalAmountWei);
+
+  return {
+    to: toAddress,
+    from: fromAddress,
+    value: amountToSendEther.toString(),
+    gasLimit: gasLimitWei.toString(),
+    gasPrice: gasPriceWei.toString(),
+    nonce,
+    data,
+    maxCostFeeEther: maxCostFeeEther.toString(),
+    totalAmountEther
+  };
+}
+
+export async function getNetworkNameFromSignedTx(signedTx: string) {
+  const decodedTranasction = utils.parseTransaction(signedTx);
+  const chainId = decodedTranasction.chainId.toString();
+  const network = await getNetworkByChainId(chainId);
+
+  return network ? network.name : undefined;
+}

--- a/common/v2/features/SendAssets/index.ts
+++ b/common/v2/features/SendAssets/index.ts
@@ -1,1 +1,1 @@
-export { SendAssets } from './SendAssets';
+export { default as SendAssets } from './SendAssets';

--- a/common/v2/features/SendAssets/stateFactory.tsx
+++ b/common/v2/features/SendAssets/stateFactory.tsx
@@ -1,0 +1,75 @@
+import { useContext } from 'react';
+import { FallbackProvider } from 'ethers/providers';
+
+import { NetworksContext } from 'v2/providers';
+import { TUseApiFactory } from 'v2/services';
+import { allProviders } from 'v2/config/networks/globalProvider';
+import { ITxObject, ITxConfig, IFormikFields, TStepAction } from './types';
+import { fromStateToTxObject } from './helpers';
+
+const txConfigInitialState = {
+  gasLimit: null,
+  gasPrice: null,
+  nonce: null,
+  amount: null,
+  data: null,
+  recipientAddress: null,
+  senderAccount: null,
+  network: undefined,
+  asset: null
+};
+
+const TxConfigFactory: TUseApiFactory<ITxConfig> = ({ state, setState }) => {
+  const { getNetworkByName } = useContext(NetworksContext);
+
+  const handleFormSubmit: TStepAction = (payload: IFormikFields, after) => {
+    const data = {
+      gasLimit: payload.gasLimitField, // @TODO update with correct value.
+      gasPrice: payload.gasPriceField, // @TODO update with correct value.
+      nonce: payload.nonceField, // @TODO update with correct value.
+      data: payload.txDataField,
+      amount: payload.amount,
+      senderAccount: payload.account,
+      recipientAddress: payload.recipientAddress,
+      network: getNetworkByName(payload.account.network),
+      asset: payload.asset
+    };
+
+    setState((prevState: ITxConfig) => ({
+      ...prevState,
+      ...data
+    }));
+    after();
+  };
+
+  const handleConfirmAndSign: TStepAction = (payload, after) => {
+    const txObject: ITxObject = fromStateToTxObject(state);
+    const { network: { name: networkName } } = state;
+    const txHash = sendTransaction(txObject, networkName);
+
+    // updateState
+    after();
+  };
+
+  // tslint:disable-next-line:
+  const handleConfirmAndSend: TStepAction = (payload, after) => {};
+  // tslint:disable-next-line:
+  const handleSignedTx: TStepAction = (payload, after) => {};
+
+  return {
+    handleFormSubmit,
+    handleConfirmAndSign,
+    handleConfirmAndSend,
+    handleSignedTx,
+    state
+  };
+};
+
+export { txConfigInitialState, TxConfigFactory };
+
+// @TODO: Move to correct service
+async function sendTransaction(signedTx, network) {
+  const transactionProvider: FallbackProvider = allProviders[network];
+  const broadcastTransaction = await transactionProvider.sendTransaction(signedTx);
+  return broadcastTransaction;
+}

--- a/common/v2/features/SendAssets/types.ts
+++ b/common/v2/features/SendAssets/types.ts
@@ -1,121 +1,70 @@
-import { GasEstimates } from 'v2/api/gas';
-import { WalletName } from 'v2/config/data';
-import { ExtendedAccount as IExtendedAccount, Network } from 'v2/services';
-import { Asset, assetMethod } from 'v2/services/Asset/types';
-import { IAsset } from 'v2/types';
+import { FunctionComponent } from 'react';
 
-export interface FormikFormState {
-  transactionData: {
-    to: string;
-    gasLimit: string;
-    gasPrice: string;
-    nonce: string;
-    data: string;
-    value: string;
-    chainId: undefined;
-  };
-  sharedConfig: {
-    senderAddress: string;
-    senderAddressLabel: string;
-    senderWalletBalanceBase: string;
-    senderWalletBalanceToken: string;
-    senderAccountType: string;
-    senderNetwork: Network | undefined;
-    asset: IAsset | undefined;
-    assetNetwork: Network | undefined;
-    assetSymbol: string;
-    assetType: undefined;
-    dPath: string;
-    recipientAddressLabel: string;
-    recipientResolvedNSAddress: string;
-  };
-  transaction: {
-    serialized: string;
-    signed: string;
-    txHash: string;
-  };
-  formikState: {
-    gasPriceSlider: string;
-    gasPriceField: string;
-    gasLimitField: string;
-    gasLimitEstimated: string;
-    nonceEstimated: string;
-    nonceField: string;
-    isGasLimitManual: boolean;
-    gasEstimates: {
-      fastest: number;
-      fast: number;
-      standard: number;
-      isDefault: boolean;
-      safeLow: number;
-      time: number;
-      chainId: number;
-    };
-    isResolvingNSName: false;
-    isAdvancedTransaction: false;
-  };
+import { GasEstimates } from 'v2/api/gas';
+import { Asset } from 'v2/services/Asset/types';
+import { IAsset } from 'v2/types';
+import { ExtendedAccount as IExtendedAccount, Network } from 'v2/services';
+
+export interface ITxObject {
+  readonly to: string;
+  readonly from: string;
+  readonly gasLimit: string;
+  readonly gasPrice: string;
+  readonly nonce: string;
+  readonly data: string;
+  readonly value: string;
+  readonly chainId: number;
 }
-export interface ITxFields {
-  asset: IAsset | undefined;
+
+export interface ITxConfig {
+  readonly gasLimit: string; // Move to BN
+  readonly gasPrice: string; // Move to BN
+  readonly nonce: string;
+  readonly amount: string; // Move to BN
+  readonly data: string;
+  readonly recipientAddress: string; // Can't be an ExtendedAddressBook since recipient may not be registered
+  readonly senderAccount: IExtendedAccount;
+  readonly asset: IAsset | Asset;
+  readonly network?: Network;
+}
+
+export interface ITxReceipt {
+  [index: string]: any;
+}
+
+export interface IFormikFields {
+  asset: IAsset | Asset;
   recipientAddress: string;
   amount: string;
   account: IExtendedAccount;
-  data: string;
+  txDataField: string;
   gasLimitEstimated: string;
   gasPriceSlider: string;
   nonceEstimated: string;
   gasLimitField: string; // Use only if advanced tab is open AND isGasLimitManual is true
   gasPriceField: string; // Use only if advanced tab is open AND user has input gas price
   nonceField: string; // Use only if user has input a manual nonce value.
-
-  isGasLimitManual: boolean; // Used to indicate that user has un-clicked the user-input gas-limit checkbox.
-  accountType: WalletName | undefined; // Type of wallet selected.
-  network: Network | undefined;
   gasEstimates: GasEstimates;
-  resolvedNSAddress: string; // Address returned when attempting to resolve an ENS/RNS address.
-  isResolvingNSName: boolean; // Used to indicate recipient-address is ENS name that is currently attempting to be resolved.
+  resolvedENSAddress: string; // Address returned when attempting to resolve an ENS/RNS address.
 }
 
-export interface ISendState {
-  step: number;
-  transactionFields: ITxFields;
-  recipientAddressLabel: string; //  Recipient-address label found in address book.
-  asset: IAsset | Asset | undefined;
-  assetType: assetMethod; // Type of asset selected. Directs how rawTransactionValues field are handled when formatting transaction
-  // isFetchingAccountValue: boolean;
-  // isAddressLabelValid: boolean;
-  // isFetchingAssetPricing: boolean;
-  // isEstimatingGasLimit: boolean;
-  isAdvancedTransaction: boolean; // Used to indicate whether transaction fee slider should be displayed and if Advanced Tab fields should be displayed.
+export interface ISignComponentProps {
+  rawTransaction: ITxObject;
+  children?: never;
+  onSuccess(receipt: ITxReceipt): void;
 }
 
-export interface SendState {
-  step: number;
-  transactionData: {
-    to: string;
-    gasLimit: string;
-    gasPrice: string;
-    nonce: string;
-    data: string;
-    value: string;
-    chainId: undefined;
-  };
-  sharedConfig: {
-    senderAddress: string;
-    senderAddressLabel: string;
-    senderWalletBalanceBase: string;
-    senderWalletBalanceToken: string;
-    senderAccountType: string;
-    senderNetwork: string;
-    assetSymbol: string;
-    assetType: undefined;
-    dPath: string;
-    recipientAddressLabel: string;
-    recipientResolvedNSAddress: string;
-  };
-  transaction: {
-    serialized: string;
-    signed: string;
-    txHash: string;
-  };
+export interface IStepComponentProps {
+  txConfig: ITxConfig;
+  // txReceipt?: ITxReceipt;
+  children?: never;
+  onComplete(data: IFormikFields | ITxReceipt | null): void;
+}
+
+export type TStepAction = (payload: any, after: () => void) => void;
+
+export interface IPath {
+  label: string;
+  component: FunctionComponent;
+  action: TStepAction;
 }

--- a/common/v2/libs/transaction/process.ts
+++ b/common/v2/libs/transaction/process.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js';
 import { bufferToHex } from 'ethereumjs-util';
 import { DeepPartial } from 'shared/types/util';
-import { ITxFields, SendState } from 'v2/features/SendAssets/types';
+import { IFormikFields, SendState } from 'v2/features/SendAssets/types';
 import { getAssetByTicker } from 'v2/libs/assets';
 import { Asset } from 'v2/services/Asset/types';
 import { Network } from 'v2/services/Network/types';
@@ -12,9 +12,9 @@ import { IHexStrTransaction, IHexStrWeb3Transaction } from './typings';
 import { encodeTransfer } from './utils/token';
 
 export const processFormDataToWeb3Tx = (
-  formData: ITxFields
+  formData: IFormikFields
 ): IHexStrWeb3Transaction | undefined => {
-  const symbol = formData.asset!.symbol;
+  const symbol = formData.asset.symbol;
   const asset: Asset | undefined = getAssetByTicker(symbol);
 
   const txFields = formData;
@@ -29,11 +29,12 @@ export const processFormDataToWeb3Tx = (
     return undefined;
   }
 
+  let rawTransaction;
   if (asset.type === 'base') {
     if (!asset.decimal) {
       return undefined;
     }
-    const rawTransaction: IHexStrWeb3Transaction = {
+    rawTransaction: IHexStrWeb3Transaction = {
       from: txFields.account.address,
       to: txFields.recipientAddress,
       value: txFields.amount
@@ -47,13 +48,12 @@ export const processFormDataToWeb3Tx = (
       nonce: txFields.isAdvancedTransaction ? txFields.nonceField : txFields.nonceEstimated,
       chainId: network.chainId ? network.chainId : 1
     };
-    return rawTransaction;
   } else if (asset.type === 'erc20') {
     if (!asset.contractAddress || !asset.decimal) {
       return undefined;
     }
 
-    const rawTransaction: IHexStrWeb3Transaction = {
+    rawTransaction: IHexStrWeb3Transaction = {
       from: txFields.account.address,
       to: asset.contractAddress,
       value: '0x0',
@@ -70,8 +70,8 @@ export const processFormDataToWeb3Tx = (
       nonce: txFields.isAdvancedTransaction ? txFields.nonceField : txFields.nonceEstimated,
       chainId: network.chainId ? network.chainId : 1
     };
-    return rawTransaction;
   }
+  return rawTransaction;
 };
 
 export const processFormDataToTx = (

--- a/common/v2/providers/AddressBookProvider/AddressBookProvider.tsx
+++ b/common/v2/providers/AddressBookProvider/AddressBookProvider.tsx
@@ -8,6 +8,7 @@ interface ProviderState {
   createAddressBooks(addressBooksData: AddressBook): void;
   deleteAddressBooks(uuid: string): void;
   updateAddressBooks(uuid: string, addressBooksData: AddressBook): void;
+  getContactByAddress(address: string): ExtendedAddressBook | undefined;
 }
 
 export const AddressBookContext = createContext({} as ProviderState);
@@ -29,6 +30,10 @@ export class AddressBookProvider extends Component {
     updateAddressBooks: (uuid: string, addressBooksData: AddressBook) => {
       service.updateAddressBook(uuid, addressBooksData);
       this.getAddressBooks();
+    },
+    getContactByAddress: address => {
+      const { addressBook } = this.state;
+      return addressBook.find(contact => contact.address.toLowerCase() === address.toLowerCase());
     }
   };
 

--- a/common/v2/providers/NetworksProvider/NetworksProvider.tsx
+++ b/common/v2/providers/NetworksProvider/NetworksProvider.tsx
@@ -9,6 +9,7 @@ export interface ProviderState {
   deleteNetworks(uuid: string): void;
   createNetworksNode(uuid: string, nodeData: NodeOptions): void;
   updateNetworks(uuid: string, networksData: ExtendedNetwork): void;
+  getNetworkByName(name: string): Network | undefined;
 }
 
 export const NetworksContext = createContext({} as ProviderState);
@@ -39,6 +40,10 @@ export class NetworksProvider extends Component {
     updateNetworks: (uuid: string, networksData: ExtendedNetwork) => {
       service.updateNetworks(uuid, networksData);
       this.getNetworks();
+    },
+    getNetworkByName: (name: string): Network | undefined => {
+      const { networks } = this.state;
+      return networks.find((network: Network) => network.name === name);
     }
   };
 

--- a/common/v2/services/Account/types.ts
+++ b/common/v2/services/Account/types.ts
@@ -1,11 +1,12 @@
 import { WalletName } from 'v2/config/data';
+import { TWalletType } from 'v2/types';
 import { assetMethod } from '../Asset/types';
 
 export interface Account {
   address: string;
   network: string;
   assets: AssetBalanceObject[];
-  wallet: WalletName;
+  wallet: WalletName | TWalletType;
   balance: string;
   transactions: TransactionData[];
   dPath: string;

--- a/common/v2/services/index.ts
+++ b/common/v2/services/index.ts
@@ -15,4 +15,5 @@ export * from './ShapeShift';
 export * from './AddressBook';
 export { fetchGasPriceEstimates, getDefaultEstimates } from './Gas';
 export { getNonce } from './Nonce';
+export * from './useApi';
 export * from './types';

--- a/common/v2/services/useApi.ts
+++ b/common/v2/services/useApi.ts
@@ -1,0 +1,19 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+
+interface FactoryArguments<T> {
+  state: T;
+  setState: Dispatch<SetStateAction<T>>;
+}
+interface FactoryApi {
+  [key: string]: any;
+}
+
+export type TUseApiFactory<T> = (args: FactoryArguments<T>) => FactoryApi;
+export type TUseApi<T> = (factory: TUseApiFactory<T>, initialState: T) => FactoryApi;
+
+// Use a state hook like a reducer with a more custom API
+// https://medium.com/free-code-camp/why-you-should-choose-usestate-instead-of-usereducer-ffc80057f815
+export const useApi: TUseApi<object> = (apiFactory, initialState) => {
+  const [state, setState] = useState(initialState);
+  return apiFactory({ state, setState });
+};

--- a/common/v2/types/index.ts
+++ b/common/v2/types/index.ts
@@ -1,3 +1,4 @@
 export { default as TSymbol } from './symbols';
 export { default as IAsset } from './asset';
 export { default as IRate } from './rate';
+export { default as TWalletType } from './wallets';

--- a/common/v2/types/wallets.tsx
+++ b/common/v2/types/wallets.tsx
@@ -1,0 +1,36 @@
+import { getValues } from 'utils/helpers';
+
+export enum SecureWalletName {
+  WEB3 = 'web3',
+  LEDGER_NANO_S = 'ledgerNanoS',
+  TREZOR = 'trezor',
+  SAFE_T = 'safeTmini',
+  PARITY_SIGNER = 'paritySigner'
+}
+
+export enum HardwareWalletName {
+  LEDGER_NANO_S = 'ledgerNanoS',
+  TREZOR = 'trezor',
+  SAFE_T = 'safeTmini'
+}
+
+export enum InsecureWalletName {
+  PRIVATE_KEY = 'privateKey',
+  KEYSTORE_FILE = 'keystoreFile',
+  MNEMONIC_PHRASE = 'mnemonicPhrase'
+}
+
+export enum MiscWalletName {
+  VIEW_ONLY = 'viewOnly'
+}
+
+export const walletNames = getValues(
+  SecureWalletName,
+  HardwareWalletName,
+  InsecureWalletName,
+  MiscWalletName
+);
+
+type TWalletType = SecureWalletName | InsecureWalletName | MiscWalletName;
+
+export default TWalletType;


### PR DESCRIPTION

1. SendAssets is the main controller of the flow.
   - it has one state to handle the different steps.
   - it has a second state to bind all the steps together.
2. Each Step uses the same `IStepComponentProps` and has a custom `TStepAction`.
3. After a bit of thought, it seems better to share a single `ITxConfig` between the steps instead of a hashed version since:
    - it reduces the amount of manipulations of the data and provides more certainty in the manipulations.
    - the critical part is actually at the `SignTransaction` step. Here we make sure that the `ISignComponentProps` only receive a `ITxObject` that has the correct ethereum tx format and contains all the information we need to send it.
    - like this the critical part of the code is limited to `fromStateToTxObject()` and is easy to test.

Among others the next things I want to do are:
- cleanup and reactivate form (now can be done in isolation)
- select the correct `gasPrice` etc.
- create type TAddress (better than a simple string)
- move to BN
- change data format so we use uuid for account.network and account.wallet

----
FYI:
I may need to review `stateFactory` in the future to ensure that `after` is called on `setState` completion. Since the later is an async call, currently there is no guarantee that the state update is complete when we go to the next step.