### PR TITLE
Fix error rendering when importing invalid file type that is not a json file

### DIFF
--- a/common/v2/features/Settings/Import/components/ImportBox.tsx
+++ b/common/v2/features/Settings/Import/components/ImportBox.tsx
@@ -33,7 +33,7 @@ interface ImportProps {
 }
 
 export default class ImportBox extends React.Component<ImportProps> {
-  public state = { badImport: true, dragging: false };
+  public state = { badImport: false, dragging: false };
   public submit = (importedCache: string) => {
     const importSuccess = this.props.importCache(importedCache);
     if (Boolean(importSuccess) === false) {


### PR DESCRIPTION


## Description
Fix issue where an error was displaying by default on the import page before an import was attempted

## Changes
Stops error from showing before import