### PR TITLE
Force production build to use dev environment css loaders temporarily

### DIFF
--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -79,11 +79,18 @@ module.exports = function(opts = {}) {
     rules.push(
       {
         test: /\.css$/,
-        use: [MiniCSSExtractPlugin.loader, 'css-loader']
+        include: [
+          path.resolve(config.path.src, 'vendor'),
+          path.resolve(__dirname, '../node_modules/typeface-lato')
+        ],
+        use: ['style-loader', 'css-loader']
       },
       {
         test: /\.scss$/,
-        use: [MiniCSSExtractPlugin.loader, 'css-loader', sassLoader]
+        include: ['components', 'containers', 'sass', 'v2']
+          .map(dir => path.resolve(config.path.src, dir))
+          .concat([config.path.modules]),
+        use: ['style-loader', 'css-loader', sassLoader]
       }
     );
   } else {


### PR DESCRIPTION
We're going to alter the production build to use the dev-builds css loaders temporarily. 
This is to allow design team to review current state of `gau` without forcing us to figure out a solution to this bug yet since it's pretty low-priority until right before MVP release.

We're going to create a task that blocks GAU MVP release in order to fix this before MVP goes live.

This new task is here: https://app.clubhouse.io/mycrypto/story/2535/revert-https-github-com-mycryptohq-mycrypto-pull-2702-and-fix-dev-and-production-build-style-mismatch-bug

This pr closes this task: https://app.clubhouse.io/mycrypto/story/2531/create-way-for-avani-to-be-able-to-review-design-implementation