### PR TITLE
fix for safari / client-side csp / workers-src / child-src issue

### DIFF
--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -168,7 +168,7 @@ module.exports = function(opts = {}) {
         creator: config.twitter.creator
       },
       metaCsp: options.isProduction
-        ? "default-src 'none'; script-src 'self' https://0x.mycrypto.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://0x.mycrypto.com; manifest-src 'self'; font-src 'self' https://0x.mycrypto.com; img-src 'self' data: https://shapeshift.io; connect-src *; frame-src 'self' https://connect.trezor.io;"
+        ? "default-src 'none'; script-src 'self' https://0x.mycrypto.com; worker-src 'self' blob:; child-src 'self'; style-src 'self' 'unsafe-inline' https://0x.mycrypto.com; manifest-src 'self'; font-src 'self' https://0x.mycrypto.com; img-src 'self' data: https://shapeshift.io; connect-src *; frame-src 'self' https://connect.trezor.io;"
         : ''
     }),
 


### PR DESCRIPTION
⚠do not merge until security review ⚠

https://app.clubhouse.io/mycrypto/story/2559/can-t-open-https-mycryptobuilds-com-gau-in-safari

test fix to see if will fix safari csp issues regarding workers since safari doesn't recognize the `workers-src` parameter

