### PR TITLE
Added additional information to Confirm Transaction Panel

### DIFF
--- a/common/v2/features/SendAssets/components/ConfirmTransaction.scss
+++ b/common/v2/features/SendAssets/components/ConfirmTransaction.scss
@@ -56,6 +56,16 @@
           text-align: right;
         }
       }
+
+      &-data {
+        width: 30%;
+        display: block;
+        overflow-wrap: break-word;
+        align-items: center;
+        @media (min-width: 700px) {
+          display: inline-block;
+        }
+      }
     }
   }
   &-button {

--- a/common/v2/features/SendAssets/components/ConfirmTransaction.tsx
+++ b/common/v2/features/SendAssets/components/ConfirmTransaction.tsx
@@ -30,11 +30,11 @@ export default function ConfirmTransaction({ txConfig, onComplete }: IStepCompon
   const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
   const [showDetails, setShowDetails] = useState(false);
 
-  const recipientAccount = getContactByAddressAndNetwork(
+  const recipientContact = getContactByAddressAndNetwork(
     txConfig.receiverAddress,
     txConfig.network
   );
-  const recipientLabel = recipientAccount ? recipientAccount.label : 'Unknown Address';
+  const recipientLabel = recipientContact ? recipientContact.label : 'Unknown Address';
 
   /* ToDo: Figure out how to extract this */
   const {
@@ -61,8 +61,16 @@ export default function ConfirmTransaction({ txConfig, onComplete }: IStepCompon
   const totalEtherEgress = parseFloat(fromWei(valueWei.add(transactionFeeWei), 'ether')).toFixed(6); // @TODO: BN math, add amount + maxCost !In same symbol
   const networkName = network ? network.name : undefined;
 
+  /* Calculate User's Asset Balance */
+  const userAssetToSend = senderAccount.assets.find(
+    accountAsset => accountAsset.uuid === asset.uuid
+  );
+  const userAssetBalance = userAssetToSend ? userAssetToSend.balance : 'Unknown Balance';
+
+  /* Determing User's Contact */
   const senderContact = getContactByAccount(senderAccount);
   const senderAccountLabel = senderContact ? senderContact.label : 'Unknown Account';
+
   return (
     <div className="ConfirmTransaction">
       <div className="ConfirmTransaction-row">
@@ -112,10 +120,10 @@ export default function ConfirmTransaction({ txConfig, onComplete }: IStepCompon
           {assetType === 'base' ? (
             <Amount assetValue={`${totalEtherEgress} ${asset.ticker}`} fiatValue="$1" />
           ) : (
-            <Amount
-              assetValue={`${amount} ${asset.ticker} + ${totalEtherEgress} ${baseAsset.ticker}`}
-              fiatValue="$1"
-            />
+            <>
+              <Amount assetValue={`${amount} ${asset.ticker}`} fiatValue="$1" />
+              <Amount assetValue={`${totalEtherEgress} ${baseAsset.ticker}`} fiatValue="$1" />
+            </>
           )}
         </div>
       </div>
@@ -129,8 +137,14 @@ export default function ConfirmTransaction({ txConfig, onComplete }: IStepCompon
       {showDetails && (
         <div className="ConfirmTransaction-details">
           <div className="ConfirmTransaction-details-row">
-            <div className="ConfirmTransaction-details-row-column">Account Balance:</div>
+            <div className="ConfirmTransaction-details-row-column">Current Account Balance:</div>
             <div className="ConfirmTransaction-details-row-column">
+              {assetType === 'erc20' && (
+                <>
+                  {' '}
+                  {userAssetBalance} {asset.ticker} <br />{' '}
+                </>
+              )}
               {`${senderAccount ? senderAccount.balance : 'Unknown'} ${baseAsset.ticker}`}
             </div>
           </div>

--- a/common/v2/features/SendAssets/stateFactory.tsx
+++ b/common/v2/features/SendAssets/stateFactory.tsx
@@ -8,12 +8,14 @@ import {
   getDecimalFromEtherUnit,
   gasPriceToBase,
   hexWeiToString,
-  getAccountByAddressAndNetworkName
+  getAccountByAddressAndNetworkName,
+  getBaseAssetByNetwork
 } from 'v2/services';
 import { ProviderHandler } from 'v2/services/EthService';
 
 import { ITxConfig, ITxReceipt, IFormikFields, TStepAction, ISignedTx, ITxObject } from './types';
 import { processFormDataToTx, decodeTransaction, fromTxReceiptObj } from './helpers';
+import { Asset, Network } from 'v2/types';
 
 const txConfigInitialState = {
   tx: {
@@ -39,6 +41,7 @@ interface State {
 const TxConfigFactory: TUseApiFactory<State> = ({ state, setState }) => {
   const handleFormSubmit: TStepAction = (payload: IFormikFields, after) => {
     const rawTransaction: ITxObject = processFormDataToTx(payload);
+    const baseAsset: Asset | undefined = getBaseAssetByNetwork(payload.network);
     setState((prevState: State) => ({
       ...prevState,
       txConfig: {
@@ -48,6 +51,7 @@ const TxConfigFactory: TUseApiFactory<State> = ({ state, setState }) => {
         receiverAddress: payload.receiverAddress.value,
         network: payload.network,
         asset: payload.asset,
+        baseAsset: baseAsset || ({} as Asset),
         from: payload.account.address,
         gasPrice: hexWeiToString(rawTransaction.gasPrice),
         gasLimit: payload.gasLimitField,
@@ -103,6 +107,7 @@ const TxConfigFactory: TUseApiFactory<State> = ({ state, setState }) => {
     const decodedTx = decodeTransaction(payload);
     const networkDetected = getNetworkByChainId(decodedTx.chainId);
     const contractAsset = getAssetByContractAndNetwork(decodedTx.to || undefined, networkDetected);
+    const baseAsset = getBaseAssetByNetwork(networkDetected || ({} as Network));
 
     setState((prevState: State) => ({
       ...prevState,
@@ -119,6 +124,7 @@ const TxConfigFactory: TUseApiFactory<State> = ({ state, setState }) => {
         network: networkDetected || prevState.txConfig.network,
         value: toWei(decodedTx.value, getDecimalFromEtherUnit('ether')).toString(),
         asset: contractAsset || prevState.txConfig.asset,
+        baseAsset: baseAsset || prevState.txConfig.baseAsset,
         senderAccount:
           decodedTx.from && networkDetected
             ? getAccountByAddressAndNetworkName(decodedTx.from, networkDetected.name) ||

--- a/common/v2/features/SendAssets/types.ts
+++ b/common/v2/features/SendAssets/types.ts
@@ -27,6 +27,7 @@ export interface ITxConfig {
   readonly senderAccount: IExtendedAccount;
   readonly from: string;
   readonly asset: Asset;
+  readonly baseAsset: Asset;
   readonly network: INetwork;
   readonly gasPrice: string;
   readonly gasLimit: string;

--- a/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
+++ b/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
@@ -1,6 +1,6 @@
 import React, { Component, createContext } from 'react';
 
-import { AddressBook, ExtendedAddressBook, ExtendedAccount } from 'v2/types';
+import { AddressBook, ExtendedAddressBook, ExtendedAccount, Network } from 'v2/types';
 import * as service from './AddressBook';
 
 interface ProviderState {
@@ -10,6 +10,7 @@ interface ProviderState {
   deleteAddressBooks(uuid: string): void;
   updateAddressBooks(uuid: string, addressBooksData: AddressBook): void;
   getContactByAddress(address: string): ExtendedAddressBook | undefined;
+  getContactByAddressAndNetwork(address: string, network: Network): ExtendedAddressBook | undefined;
   getContactByAccount(account: ExtendedAccount): ExtendedAddressBook | undefined;
 }
 
@@ -36,6 +37,12 @@ export class AddressBookProvider extends Component {
     getContactByAddress: address => {
       const { addressBook } = this.state;
       return addressBook.find(contact => contact.address.toLowerCase() === address.toLowerCase());
+    },
+    getContactByAddressAndNetwork: (address, network) => {
+      const { addressBook } = this.state;
+      return addressBook
+        .filter(contact => contact.network === network.name)
+        .find(contact => contact.address.toLowerCase() === address.toLowerCase());
     },
     getContactByAccount: account => {
       const { addressBook } = this.state;


### PR DESCRIPTION
Changes:
- Use baseAsset to split out asset to send and baseAsset for the confirm panel.
- Removed implicit asset tickers.

Note: This PR isn't intended to clean up Confirm Panel styles, just to make sure logic is all there. :-)