### PR TITLE
Use self-hosted CDN for asset icons

### DIFF
--- a/common/v2/components/AssetIcon.tsx
+++ b/common/v2/components/AssetIcon.tsx
@@ -5,10 +5,10 @@ import manifest from 'cryptocurrency-icons/manifest.json';
 import { IAsset, TSymbol } from 'v2/types';
 // Relies on https://github.com/atomiclabs/cryptocurrency-icons using fixed version number through CDN
 // @TODO: We should be using our own sprite served over a trusted CDN
-const baseURL = 'https://cdn.jsdelivr.net/gh/atomiclabs/cryptocurrency-icons@0.13.0/svg/color/';
+const baseURL = 'https://cdn.mycryptoapi.com/icons';
 
 function buildUrl(symbol: TSymbol) {
-  return `${baseURL}/${symbol.toLowerCase()}.svg`;
+  return `${baseURL}/${symbol.toLowerCase()}.png`;
 }
 
 function getIconUrl(symbol: TSymbol) {

--- a/common/v2/components/AssetIcon.tsx
+++ b/common/v2/components/AssetIcon.tsx
@@ -5,10 +5,10 @@ import manifest from 'cryptocurrency-icons/manifest.json';
 import { IAsset, TSymbol } from 'v2/types';
 // Relies on https://github.com/atomiclabs/cryptocurrency-icons using fixed version number through CDN
 // @TODO: We should be using our own sprite served over a trusted CDN
-const baseURL = 'https://cdn.mycryptoapi.com/icons';
+const baseURL = 'https://cdn.mycryptoapi.com/v1/icons';
 
 function buildUrl(symbol: TSymbol) {
-  return `${baseURL}/${symbol.toLowerCase()}.png`;
+  return `${baseURL}/${symbol.toLowerCase()}.svg`;
 }
 
 function getIconUrl(symbol: TSymbol) {

--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -178,7 +178,7 @@ module.exports = function(opts = {}) {
         creator: config.twitter.creator
       },
       metaCsp: options.isProduction
-        ? "default-src 'none'; script-src 'self' https://0x.mycrypto.com; worker-src 'self' blob:; child-src 'self'; style-src 'self' 'unsafe-inline' https://0x.mycrypto.com; manifest-src 'self'; font-src 'self' https://0x.mycrypto.com; img-src 'self' data: https://shapeshift.io; connect-src *; frame-src 'self' https://connect.trezor.io;"
+        ? "default-src 'none'; script-src 'self' https://0x.mycrypto.com; worker-src 'self' blob:; child-src 'self'; style-src 'self' 'unsafe-inline' https://0x.mycrypto.com; manifest-src 'self'; font-src 'self' https://0x.mycrypto.com; img-src 'self' data: https://shapeshift.io https://cdn.mycryptoapi.com; connect-src *; frame-src 'self' https://connect.trezor.io;"
         : ''
     }),
 


### PR DESCRIPTION
~Todo: get feedback from @miagx about whether or not we can have the endpoint modified for `.svg`s instead of `.png`s~
