### PR TITLE
Fixes for get-account-balance usability

### DIFF
--- a/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
+++ b/common/v2/features/AddAccount/components/SaveAndRedirect.tsx
@@ -2,9 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import { Route, Redirect } from 'react-router';
 
 import { FormData } from 'v2/features/AddAccount/types';
-import { NotificationsContext } from 'v2/providers';
-import { createAssetWithID } from 'v2/services';
-import { NotificationTemplates } from 'v2/providers/NotificationsProvider/constants';
+import { NotificationsContext, NotificationTemplates } from 'v2/providers';
 import { generateUUID } from 'v2/utils';
 import {
   AccountContext,
@@ -35,14 +33,13 @@ function SaveAndRedirect(payload: { formData: FormData }) {
       });
     } else {
       const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(network);
-      const newAssetID: string = generateUUID();
       const newUUID = generateUUID();
       const account: Account = {
         address: payload.formData.account,
         networkId: payload.formData.network,
         wallet: payload.formData.accountType,
         dPath: payload.formData.derivationPath,
-        assets: [{ uuid: newAssetID, balance: '0', mtime: Date.now() }],
+        assets: [{ uuid: newAsset.uuid, balance: '0', mtime: Date.now() }],
         transactions: [],
         favorite: false,
         mtime: 0
@@ -56,7 +53,6 @@ function SaveAndRedirect(payload: { formData: FormData }) {
       createAddressBook(newLabel);
       createAccountWithID(account, newUUID);
       updateSettingsAccounts([...settings.dashboardAccounts, newUUID]);
-      createAssetWithID(newAsset, newAssetID);
       displayNotification(NotificationTemplates.walletAdded, {
         address: account.address
       });

--- a/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { translateRaw } from 'translations';
 import { AnalyticsService, ANALYTICS_CATEGORIES } from 'v2/services';
-import { SettingsContext, StoreContext } from 'v2/services/Store';
+import { SettingsContext, StoreContext, AccountContext } from 'v2/services/Store';
 import { StoreAsset } from 'v2/types';
 import { BREAK_POINTS } from 'v2/theme';
 
@@ -51,7 +51,8 @@ let wasNumOfAccountsTracked = false;
 
 export function WalletBreakdown() {
   const [showBalanceDetailView, setShowBalanceDetailView] = useState(false);
-  const { accounts, totals, currentAccounts } = useContext(StoreContext);
+  const { totals, currentAccounts } = useContext(StoreContext);
+  const { accounts } = useContext(AccountContext);
   const { settings, updateSettingsAccounts } = useContext(SettingsContext);
 
   // Track number of accounts that user has only once per session
@@ -62,7 +63,7 @@ export function WalletBreakdown() {
     });
   }
 
-  const assetValue = bigNumberify('333');
+  const assetValue = bigNumberify('170');
   const selectedAccounts = currentAccounts();
   // Adds/updates an asset in array of balances, which are later displayed in the chart, balance list and in the secondary view
 

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -3,7 +3,7 @@ import { Field, FieldProps, Form, Formik, FastField } from 'formik';
 import * as Yup from 'yup';
 import { Button, Input } from '@mycrypto/ui';
 import _ from 'lodash';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, formatEther } from 'ethers/utils';
 import BN from 'bn.js';
 
 import translate, { translateRaw } from 'translations';
@@ -165,7 +165,7 @@ export default function SendAssetsForm({
                       accountAsset => accountAsset.uuid === values.asset.uuid
                     ) || { balance: '0' }
                   ).balance
-                : getBalanceFromAccount(values.account);
+                : formatEther(getBalanceFromAccount(values.account));
               const gasPrice = values.advancedTransaction
                 ? values.gasPriceField
                 : values.gasPriceSlider;

--- a/common/v2/features/SendAssets/components/fields/AccountDropdown.tsx
+++ b/common/v2/features/SendAssets/components/fields/AccountDropdown.tsx
@@ -4,6 +4,7 @@ import { translateRaw } from 'translations';
 import { AccountSummary, AccountOption, Dropdown } from 'v2/components';
 import { StoreAccount } from 'v2/types';
 import { AddressBookContext, getBaseAsset, getAccountBaseBalance } from 'v2/services/Store';
+import { formatEther } from 'ethers/utils';
 
 // Option item displayed in Dropdown menu. Props are passed by react-select Select.
 // To know: Select needs to receive a class in order to attach refs https://github.com/JedWatson/react-select/issues/2459
@@ -21,7 +22,7 @@ function AccountDropdown({ accounts, name, value, onSelect }: IAccountDropdownPr
   const relevantAccounts: StoreAccount[] = accounts.map(account => ({
     ...account,
     label: getAccountLabel(account),
-    balance: getAccountBaseBalance(account),
+    balance: formatEther(getAccountBaseBalance(account)),
     baseAssetSymbol: getBaseAsset(account)!.ticker
   }));
 

--- a/common/v2/features/SendAssets/components/fields/AssetDropdown.tsx
+++ b/common/v2/features/SendAssets/components/fields/AssetDropdown.tsx
@@ -25,7 +25,7 @@ class AssetOption extends React.PureComponent<OptionComponentProps> {
 
 function AssetDropdown({ assets, name, value, onSelect }: Props<Asset>) {
   const filteredAssets: Asset[] = assets.filter(
-    (asset, index) => assets.indexOf(asset) >= index
+    (asset, index) => assets.map(assetObj => assetObj.uuid).indexOf(asset.uuid) >= index
   ); /* Removes duplicates */
   return (
     <Dropdown

--- a/common/v2/services/EthService/network/helpers.ts
+++ b/common/v2/services/EthService/network/helpers.ts
@@ -7,7 +7,7 @@ import { Network, NetworkId, NodeType, DPathFormat } from 'v2/types';
 type TValidEtherscanNetwork = 'homestead' | 'ropsten' | 'rinkeby' | 'kovan' | 'goerli';
 
 const getValidEthscanNetworkId = (id: NetworkId): TValidEtherscanNetwork =>
-  id.toLowerCase() as TValidEtherscanNetwork;
+  id === 'Ethereum' ? 'homestead' : (id.toLowerCase() as TValidEtherscanNetwork);
 
 export const createNetworkProviders = (network: Network): FallbackProvider => {
   const { id, nodes }: Partial<Network> = network;

--- a/common/v2/services/Store/Asset/helpers.ts
+++ b/common/v2/services/Store/Asset/helpers.ts
@@ -12,7 +12,7 @@ export const getAssetByTicker = (symbol: string): Asset | undefined => {
 };
 
 export const getNewDefaultAssetTemplateByNetwork = (network: Network): Asset => {
-  const baseAssetOfNetwork: Asset | undefined = getAssetByTicker(network.id);
+  const baseAssetOfNetwork: Asset | undefined = getAssetByUUID(network.baseAsset);
   if (!baseAssetOfNetwork) {
     return {
       uuid: generateUUID(),
@@ -24,7 +24,7 @@ export const getNewDefaultAssetTemplateByNetwork = (network: Network): Asset => 
     };
   } else {
     return {
-      uuid: generateUUID(),
+      uuid: baseAssetOfNetwork.uuid,
       name: baseAssetOfNetwork.name,
       networkId: baseAssetOfNetwork.networkId,
       type: 'base',
@@ -61,9 +61,9 @@ export const getAssetByContractAndNetwork = (
 export const getTotalByAsset = (assets: StoreAsset[]) =>
   assets.reduce(
     (dict, asset) => {
-      const prev = dict[asset.uuid];
+      const prev = dict[asset.name];
       if (prev) {
-        dict[asset.uuid] = {
+        dict[asset.name] = {
           ...prev,
           balance: prev.balance.add(asset.balance)
         };

--- a/common/v2/services/Store/LocalCache/seedCache.ts
+++ b/common/v2/services/Store/LocalCache/seedCache.ts
@@ -115,7 +115,7 @@ export const initNetworks = () => {
       uuid: baseAssetID,
       name: network.name,
       networkId: network.name as NetworkId,
-      ticker: networkId,
+      ticker: network.unit,
       type: 'base',
       decimal: 18
     };


### PR DESCRIPTION
There were some problems with get-account-balance usability that I wanted to fix. These are those fixes. This should get us up to near-parity with current `gau` functionality.

Changes:
1) Fixed a bug with duplicate entries when adding existing accounts.
2) Fixed an issue with base asset population when adding existing accounts.
3) Fixed Asset Dropdown duplication bug in Send-Assets flow (there still exists a mismatch bug between test accounts and add-existing accounts, but its not blocking anything -> To select an Ethereum account, make sure to click the "Ethereum" asset, NOT the "Ether" asset in dropdown).
4) Fixed Account Dropdown bug in Send-Assets flow.
5) Fixed bug with network usage for ethers.js provider initialization.
6) Fixed a bug with send-max button.