### PR TITLE
ev/fix accountlist breakpoint bug

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -6,7 +6,7 @@ import { Button, CollapsibleTable, Copyable, Network, Typography, Identicon } fr
 import { translateRaw } from 'translations';
 import { ROUTE_PATHS } from 'v2/config';
 import { truncate } from 'v2/utils';
-import { BREAK_POINTS, COLORS } from 'v2/theme';
+import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
 import { ExtendedAccount, AddressBook } from 'v2/types';
 import {
   AccountContext,
@@ -91,7 +91,7 @@ export default function AccountList(props: AccountListProps) {
     >
       <TableContainer>
         <CollapsibleTable
-          breakpoint={Number(BREAK_POINTS.SCREEN_XS)}
+          breakpoint={breakpointToNumber(BREAK_POINTS.SCREEN_XS)}
           {...buildAccountTable(
             currentsOnly ? currentAccounts : accounts,
             deleteAccount,

--- a/common/v2/theme/constants.ts
+++ b/common/v2/theme/constants.ts
@@ -1,3 +1,15 @@
+import { light } from '@mycrypto/ui';
+
+// Direct require to customise the webpack default scss loader
+const GAU_COLORS = require('sass-extract-loader?{"plugins": ["sass-extract-js"]}!./colors.scss');
+
+// Combine the themes in a single object to be consummed by SC ThemeProvider
+export const GAU_THEME = Object.assign({}, light, {
+  GAU: {
+    COLORS: GAU_COLORS
+  }
+});
+
 export const COLORS = {
   DARK_SLATE_BLUE: '#163150',
   GREYISH_BROWN: '#424242',

--- a/common/v2/theme/helpers.ts
+++ b/common/v2/theme/helpers.ts
@@ -1,0 +1,2 @@
+export const breakpointToNumber = (str: string): number =>
+  parseInt(str.substring(0, str.indexOf('px')), 10);

--- a/common/v2/theme/index.js
+++ b/common/v2/theme/index.js
@@ -1,13 +1,2 @@
-import { light } from '@mycrypto/ui';
-
-export { COLORS, BREAK_POINTS } from './constants';
-
-// Direct require to customise the webpack default scss loader
-const COLORS = require('sass-extract-loader?{"plugins": ["sass-extract-js"]}!./colors.scss');
-
-// Combine the themes in a single object to be consummed by SC ThemeProvider
-export const GAU_THEME = Object.assign({}, light, {
-  GAU: {
-    COLORS
-  }
-});
+export { GAU_THEME, COLORS, BREAK_POINTS } from './constants';
+export { breakpointToNumber } from './helpers';


### PR DESCRIPTION
[2849]
Remove console warning about `breakpoint` in AccountList.
AccountList passes NaN as breakpoint prop to Collapsible table.
Pass breakpoint as a number instead

