### PR TITLE
Display fiat value in AccountList

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -65,8 +65,8 @@ interface AccountListProps {
 
 export default function AccountList(props: AccountListProps) {
   const { className, currentsOnly, deletable, favoritable, footerAction, footerActionLink } = props;
-  const { currentAccounts } = useContext(StoreContext);
-  const { accounts, deleteAccount, updateAccount } = useContext(AccountContext);
+  const { currentAccounts, accounts } = useContext(StoreContext);
+  const { deleteAccount, updateAccount } = useContext(AccountContext);
   const shouldRedirect = accounts === undefined || accounts === null || accounts.length === 0;
   if (shouldRedirect) {
     return <Redirect to="/no-accounts" />;
@@ -98,7 +98,7 @@ export default function AccountList(props: AccountListProps) {
 }
 
 function buildAccountTable(
-  accounts: ExtendedAccount[],
+  accounts: StoreAccount[],
   deleteAccount: DeleteAccount,
   updateAccount: UpdateAccount,
   deletable?: boolean,
@@ -117,7 +117,7 @@ function buildAccountTable(
     head: deletable ? [...columns, translateRaw('ACCOUNT_LIST_DELETE')] : columns,
     body: accounts.map((account, index) => {
       const addressCard: AddressBook | undefined = getLabelByAccount(account);
-      const total = totalFiat([account as StoreAccount])(getRate);
+      const total = totalFiat([account])(getRate);
       const label = addressCard ? addressCard.label : 'Unknown Account';
       const bodyContent = [
         <Label key={index}>

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -1,17 +1,23 @@
 import React, { useContext } from 'react';
 import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
-import { Button, CollapsibleTable, Copyable, Network, Typography, Identicon } from '@mycrypto/ui';
+import { Button, CollapsibleTable, Copyable, Network, Identicon } from '@mycrypto/ui';
 
 import { translateRaw } from 'translations';
 import { ROUTE_PATHS, Fiats } from 'v2/config';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
 import { ExtendedAccount, AddressBook, StoreAccount } from 'v2/types';
-import { AccountContext, getLabelByAccount, StoreContext } from 'v2/services/Store';
+import {
+  AccountContext,
+  getLabelByAccount,
+  StoreContext,
+  SettingsContext
+} from 'v2/services/Store';
 import { DashboardPanel } from './DashboardPanel';
 import './AccountList.scss';
 import { RatesContext } from 'v2/services';
+import { Currency } from '.';
 
 const Label = styled.span`
   display: flex;
@@ -105,6 +111,7 @@ function buildAccountTable(
 ) {
   const { totalFiat } = useContext(StoreContext);
   const { getRate } = useContext(RatesContext);
+  const { settings } = useContext(SettingsContext);
   const columns = [
     translateRaw('ACCOUNT_LIST_LABEL'),
     translateRaw('ACCOUNT_LIST_ADDRESS'),
@@ -127,10 +134,12 @@ function buildAccountTable(
         <Network key={index} color="#a682ff">
           {account.networkId}
         </Network>,
-        <Typography key={index}>
-          {Fiats[0].symbol}
-          {total.toFixed(2)}
-        </Typography>
+        <Currency
+          key={index}
+          amount={total.toString()}
+          symbol={Fiats[settings.fiatCurrency].symbol}
+          decimals={2}
+        />
       ];
       return deletable
         ? [

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -7,16 +7,12 @@ import { translateRaw } from 'translations';
 import { ROUTE_PATHS } from 'v2/config';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
-import { ExtendedAccount, AddressBook } from 'v2/types';
-import {
-  AccountContext,
-  SettingsContext,
-  getCurrentsFromContext,
-  getLabelByAccount,
-  getBalanceFromAccount
-} from 'v2/services/Store';
+import { Fiats } from 'v2/config';
+import { ExtendedAccount, AddressBook, StoreAccount } from 'v2/types';
+import { AccountContext, getLabelByAccount, StoreContext } from 'v2/services/Store';
 import { DashboardPanel } from './DashboardPanel';
 import './AccountList.scss';
+import { RatesContext } from 'v2/services';
 
 const Label = styled.span`
   display: flex;
@@ -69,12 +65,8 @@ interface AccountListProps {
 
 export default function AccountList(props: AccountListProps) {
   const { className, currentsOnly, deletable, favoritable, footerAction, footerActionLink } = props;
-  const { settings } = useContext(SettingsContext);
+  const { currentAccounts } = useContext(StoreContext);
   const { accounts, deleteAccount, updateAccount } = useContext(AccountContext);
-  const currentAccounts: ExtendedAccount[] = getCurrentsFromContext(
-    accounts,
-    settings.dashboardAccounts
-  );
   const shouldRedirect = accounts === undefined || accounts === null || accounts.length === 0;
   if (shouldRedirect) {
     return <Redirect to="/no-accounts" />;
@@ -93,7 +85,7 @@ export default function AccountList(props: AccountListProps) {
         <CollapsibleTable
           breakpoint={breakpointToNumber(BREAK_POINTS.SCREEN_XS)}
           {...buildAccountTable(
-            currentsOnly ? currentAccounts : accounts,
+            currentsOnly ? currentAccounts() : accounts,
             deleteAccount,
             updateAccount,
             deletable,
@@ -112,6 +104,8 @@ function buildAccountTable(
   deletable?: boolean,
   favoritable?: boolean
 ) {
+  const { totalFiat } = useContext(StoreContext);
+  const { getRate } = useContext(RatesContext);
   const columns = [
     translateRaw('ACCOUNT_LIST_LABEL'),
     translateRaw('ACCOUNT_LIST_ADDRESS'),
@@ -123,6 +117,7 @@ function buildAccountTable(
     head: deletable ? [...columns, translateRaw('ACCOUNT_LIST_DELETE')] : columns,
     body: accounts.map((account, index) => {
       const addressCard: AddressBook | undefined = getLabelByAccount(account);
+      const total = totalFiat([account as StoreAccount])(getRate);
       const label = addressCard ? addressCard.label : 'Unknown Account';
       const bodyContent = [
         <Label key={index}>
@@ -133,7 +128,10 @@ function buildAccountTable(
         <Network key={index} color="#a682ff">
           {account.networkId}
         </Network>,
-        <Typography key={index}>{getBalanceFromAccount(account)}</Typography>
+        <Typography key={index}>
+          {Fiats[0].symbol}
+          {total.toFixed(2)}
+        </Typography>
       ];
       return deletable
         ? [

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -4,10 +4,9 @@ import styled from 'styled-components';
 import { Button, CollapsibleTable, Copyable, Network, Typography, Identicon } from '@mycrypto/ui';
 
 import { translateRaw } from 'translations';
-import { ROUTE_PATHS } from 'v2/config';
+import { ROUTE_PATHS, Fiats } from 'v2/config';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
-import { Fiats } from 'v2/config';
 import { ExtendedAccount, AddressBook, StoreAccount } from 'v2/types';
 import { AccountContext, getLabelByAccount, StoreContext } from 'v2/services/Store';
 import { DashboardPanel } from './DashboardPanel';

--- a/common/v2/config/cacheData.ts
+++ b/common/v2/config/cacheData.ts
@@ -7,19 +7,23 @@ import { NetworkAssets, Token } from './tokens';
 export interface Fiat {
   code: string;
   name: string;
+  symbol: string;
 }
 
 export const USD = {
   code: 'USD',
-  name: 'US Dollars'
+  name: 'US Dollars',
+  symbol: '$'
 };
 export const EUR = {
   code: 'EUR',
-  name: 'Euros'
+  name: 'Euros',
+  symbol: '€'
 };
 export const GBP = {
   code: 'GBP',
-  name: 'British Pounds'
+  name: 'British Pounds',
+  symbol: '£'
 };
 
 export const Fiats: Fiat[] = [USD, EUR, GBP];

--- a/common/v2/config/cacheData.ts
+++ b/common/v2/config/cacheData.ts
@@ -3,30 +3,35 @@ import { Asset, Contract, NetworkId } from 'v2/types';
 
 import { Contracts } from './contracts';
 import { NetworkAssets, Token } from './tokens';
+import { TSymbol } from 'v2/types/symbols';
 
 export interface Fiat {
   code: string;
   name: string;
-  symbol: string;
+  symbol: TSymbol;
+}
+
+interface FiatObject {
+  [key: string]: Fiat;
 }
 
 export const USD = {
   code: 'USD',
   name: 'US Dollars',
-  symbol: '$'
+  symbol: '$' as TSymbol
 };
 export const EUR = {
   code: 'EUR',
   name: 'Euros',
-  symbol: '€'
+  symbol: '€' as TSymbol
 };
 export const GBP = {
   code: 'GBP',
   name: 'British Pounds',
-  symbol: '£'
+  symbol: '£' as TSymbol
 };
 
-export const Fiats: Fiat[] = [USD, EUR, GBP];
+export const Fiats: FiatObject = { USD: USD, EUR: EUR, GBP: GBP };
 
 export const ContractsData = (): Record<string, Contract> => {
   const data: any = Object.keys(Contracts);

--- a/common/v2/config/cacheData.ts
+++ b/common/v2/config/cacheData.ts
@@ -31,7 +31,7 @@ export const GBP = {
   symbol: '£' as TSymbol
 };
 
-export const Fiats: FiatObject = { USD: USD, EUR: EUR, GBP: GBP };
+export const Fiats: FiatObject = { USD, EUR, GBP };
 
 export const ContractsData = (): Record<string, Contract> => {
   const data: any = Object.keys(Contracts);

--- a/common/v2/services/Store/LocalCache/seedCache.ts
+++ b/common/v2/services/Store/LocalCache/seedCache.ts
@@ -184,6 +184,7 @@ export const initTestAccounts = () => {
         const match = Object.values(newStorage.networks).find(
           network => network.id === assetDefinition.networkId
         );
+        // @ts-ignore readonly
         asset.uuid = match ? match.baseAsset : asset.uuid;
       } else {
         const match = Object.values(newStorage.assets).find(
@@ -192,6 +193,7 @@ export const initTestAccounts = () => {
             assetDefinition.contractAddress &&
             a.contractAddress === assetDefinition.contractAddress
         );
+        // @ts-ignore readonly
         asset.uuid = match ? match.uuid : asset.uuid;
       }
     });

--- a/common/v2/services/Store/LocalCache/seedCache.ts
+++ b/common/v2/services/Store/LocalCache/seedCache.ts
@@ -155,7 +155,7 @@ export const initContracts = () => {
 
 export const initFiatCurrencies = () => {
   const newStorage = getCacheRaw();
-  Fiats.map(en => {
+  Object.values(Fiats).map(en => {
     const uuid = generateUUID();
     newStorage.assets[uuid] = {
       uuid,

--- a/common/v2/services/Store/LocalCache/seedCache.ts
+++ b/common/v2/services/Store/LocalCache/seedCache.ts
@@ -177,14 +177,29 @@ export const initTestAccounts = () => {
 
   newAccounts.map(accountToAdd => {
     const uuid = generateUUID();
+    // Map test UUID to actual UUID generated previously
+    Object.values(accountToAdd.assets).forEach(asset => {
+      const assetDefinition = newAssets[asset.uuid];
+      if (assetDefinition.type === 'base') {
+        const match = Object.values(newStorage.networks).find(
+          network => network.id === assetDefinition.networkId
+        );
+        asset.uuid = match ? match.baseAsset : asset.uuid;
+      } else {
+        const match = Object.values(newStorage.assets).find(
+          a =>
+            a.contractAddress &&
+            assetDefinition.contractAddress &&
+            a.contractAddress === assetDefinition.contractAddress
+        );
+        asset.uuid = match ? match.uuid : asset.uuid;
+      }
+    });
     newStorage.accounts[uuid] = accountToAdd;
     newStorage.settings.dashboardAccounts.push(uuid);
   });
   Object.keys(newLabels).map(labelId => {
     newStorage.addressBook[labelId] = newLabels[labelId];
-  });
-  Object.keys(newAssets).map(assetToAdd => {
-    newStorage.assets[assetToAdd] = newAssets[assetToAdd];
   });
   setCache(newStorage);
 };

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -64,13 +64,15 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
       selectedAssets.filter((asset: StoreAsset) => asset.type !== 'base'),
     totals: (selectedAccounts = state.accounts) =>
       Object.values(getTotalByAsset(state.assets(selectedAccounts))),
-    totalFiat: (selectedAccounts = state.accounts) => {
-      return (getRate: (ticker: TTicker) => number | undefined) => {
-        return state.totals(selectedAccounts).reduce((sum, asset) => {
-          return (sum += convertToFiat(asset.balance, getRate(asset.ticker as TTicker)));
-        }, 0);
-      };
-    },
+    totalFiat: (selectedAccounts = state.accounts) => (
+      getRate: (ticker: TTicker) => number | undefined
+    ) =>
+      state
+        .totals(selectedAccounts)
+        .reduce(
+          (sum, asset) => (sum += convertToFiat(asset.balance, getRate(asset.ticker as TTicker))),
+          0
+        ),
     currentAccounts: () => getDashboardAccounts(state.accounts, settings.dashboardAccounts),
     assetTickers: (targetAssets = state.assets()) => [
       ...new Set(targetAssets.map(a => a.ticker as TTicker))

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useMemo, createContext } from 'react';
 
 import { StoreAccount, StoreAsset, Network, TTicker } from 'v2/types';
-import { isArrayEqual, useInterval } from 'v2/utils';
+import { isArrayEqual, useInterval, convertToFiat } from 'v2/utils';
 
 import { getAccountsAssetsBalances } from './BalanceService';
 import { getStoreAccounts } from './helpers';
@@ -16,6 +16,9 @@ interface State {
   tokens(selectedAssets?: StoreAsset[]): StoreAsset[];
   assets(selectedAccounts?: StoreAccount[]): StoreAsset[];
   totals(selectedAccounts?: StoreAccount[]): StoreAsset[];
+  totalFiat(
+    selectedAccounts?: StoreAccount[]
+  ): (getRate: (ticker: TTicker) => number | undefined) => Number;
   currentAccounts(): StoreAccount[];
   assetTickers(targetAssets?: StoreAsset[]): TTicker[];
 }
@@ -61,6 +64,13 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
       selectedAssets.filter((asset: StoreAsset) => asset.type !== 'base'),
     totals: (selectedAccounts = state.accounts) =>
       Object.values(getTotalByAsset(state.assets(selectedAccounts))),
+    totalFiat: (selectedAccounts = state.accounts) => {
+      return (getRate: (ticker: TTicker) => number | undefined) => {
+        return state.totals(selectedAccounts).reduce((sum, asset) => {
+          return (sum += convertToFiat(asset.balance, getRate(asset.ticker as TTicker)));
+        }, 0);
+      };
+    },
     currentAccounts: () => getDashboardAccounts(state.accounts, settings.dashboardAccounts),
     assetTickers: (targetAssets = state.assets()) => [
       ...new Set(targetAssets.map(a => a.ticker as TTicker))

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -18,7 +18,7 @@ interface State {
   totals(selectedAccounts?: StoreAccount[]): StoreAsset[];
   totalFiat(
     selectedAccounts?: StoreAccount[]
-  ): (getRate: (ticker: TTicker) => number | undefined) => Number;
+  ): (getRate: (ticker: TTicker) => number | undefined) => number;
   currentAccounts(): StoreAccount[];
   assetTickers(targetAssets?: StoreAsset[]): TTicker[];
 }


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

🎉 🎉 🎉

## Description

Displayed fiat value in AccountList used on the Dashboard and Settings page

## Changes

- Added `totalFiat` method to `StoreProvider`
- Displayed fiat value in AccountList using `totalFiat`

<!--### Reusable Code/Components -->

<!-- Preferably, include automated tests instead. -->
## Steps to Test

View either the Dashboard or Settings page 😄 

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
