### PR TITLE
Added support for prefixing currency symbols

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -138,6 +138,7 @@ function buildAccountTable(
           key={index}
           amount={total.toString()}
           symbol={Fiats[settings.fiatCurrency].symbol}
+          prefix={Fiats[settings.fiatCurrency].prefix}
           decimals={2}
         />
       ];

--- a/common/v2/components/Currency.tsx
+++ b/common/v2/components/Currency.tsx
@@ -18,9 +18,10 @@ interface Props {
   symbol: TSymbol;
   decimals?: number;
   icon?: boolean;
+  prefix?: boolean;
 }
 
-function Currency({ amount, symbol, decimals = 5, icon = false, ...props }: Props) {
+function Currency({ amount, symbol, decimals = 5, icon = false, prefix = false, ...props }: Props) {
   const format = (value: string, decimalPlaces: number) => {
     const v = parseFloat(value);
     return Number(v).toFixed(decimalPlaces);
@@ -36,8 +37,9 @@ function Currency({ amount, symbol, decimals = 5, icon = false, ...props }: Prop
         </span>
       )}
       <STypography>
+        {prefix && `${symbol}`}
         {format(amount, decimals)}
-        {` ${symbol}`}
+        {!prefix && `${symbol}`}
       </STypography>
     </SContainer>
   );

--- a/common/v2/config/cacheData.ts
+++ b/common/v2/config/cacheData.ts
@@ -9,6 +9,7 @@ export interface Fiat {
   code: string;
   name: string;
   symbol: TSymbol;
+  prefix?: boolean;
 }
 
 interface FiatObject {
@@ -18,7 +19,8 @@ interface FiatObject {
 export const USD = {
   code: 'USD',
   name: 'US Dollars',
-  symbol: '$' as TSymbol
+  symbol: '$' as TSymbol,
+  prefix: true
 };
 export const EUR = {
   code: 'EUR',


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

🎉 🎉 🎉

## Description

Added support for prefixing currency symbols.
I.e. USD should be prefixed to the value as "$10" instead of "10$".

## Changes

* Added prefix prop to Currency component
* Added prefix field to Fiat interface
* Used prefix prop in AccountList

## Steps to Test

View dashboard and see that $ is used correctly as prefix instead of postfix.

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
