### PR TITLE
Added support for storing multiple EthersJS singletons

### DIFF
--- a/common/v2/services/EthService/network/ethersJsProvider.ts
+++ b/common/v2/services/EthService/network/ethersJsProvider.ts
@@ -3,26 +3,27 @@ import { FallbackProvider } from 'ethers/providers';
 import { Network } from 'v2/types';
 import { createNetworkProviders } from './helpers';
 
+interface InstancesObject {
+  [key: string]: FallbackProvider;
+}
+
 // Singleton that handles all our network requests
 // Generates FallbackProviders depending on the network.
 // Should only be used through `ProviderHandler`
 export class EthersJS {
   public static getEthersInstance(network: Network): FallbackProvider {
-    if (!EthersJS.instance || !EthersJS.networkName) {
-      EthersJS.instance = createNetworkProviders(network);
-      EthersJS.networkName = network.name;
+    if (!EthersJS.instances[network.id]) {
+      EthersJS.instances[network.id] = createNetworkProviders(network);
     }
-    return EthersJS.instance;
+    return EthersJS.instances[network.id];
   }
 
   public static updateEthersInstance(network: Network): FallbackProvider {
-    EthersJS.instance = createNetworkProviders(network);
-    EthersJS.networkName = network.name;
-    return EthersJS.instance;
+    EthersJS.instances[network.id] = createNetworkProviders(network);
+    return EthersJS.instances[network.id];
   }
 
-  private static instance: FallbackProvider;
-  private static networkName: string;
+  private static instances: InstancesObject = {};
 
   private constructor() {}
 }


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

🎉 🎉 🎉

## Description

Added support for storing multiple EthersJS singletons fixing issues where testnet balances would be calculated on the wrong network.

## Changes

* Added object for storing multiple EthersJS singletons

<!-- Preferably, include automated tests instead. -->
## Steps to Test

View the dashboard and see that Ropsten, Rinkeby etc. accounts have valid balances.

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
