### PR TITLE
Fix StoreProvider Bugs

### DIFF
--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useMemo, createContext } from 'react';
+import React, { useState, useContext, useMemo, createContext, useEffect } from 'react';
 
 import { StoreAccount, StoreAsset, Network, TTicker } from 'v2/types';
 import { isArrayEqual, useInterval, convertToFiat } from 'v2/utils';
@@ -40,6 +40,9 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
     networks
   ]);
   const [accounts, setAccounts] = useState(storeAccounts);
+  useEffect(() => {
+    setAccounts(storeAccounts);
+  }, [storeAccounts]);
 
   // Naive polling to get the Balances of baseAsset and tokens for each account.
   useInterval(
@@ -52,7 +55,7 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
     },
     60000,
     true,
-    [rawAccounts]
+    [accounts]
   );
 
   const state: State = {


### PR DESCRIPTION
### Changes
- [x] Fixed a bug with mismatched StoreProvider accounts/LocalCache accounts where re-renders didn't occur on deletions of accounts.
- [ ] Fix bug with newly-added accounts not being added correctly. Won't display on dashboard till page refresh.