### PR TITLE
Fix undefined file hash

### DIFF
--- a/webpack_config/makeConfig.js
+++ b/webpack_config/makeConfig.js
@@ -26,7 +26,6 @@ const DEFAULT_OPTIONS = {
 module.exports = function(opts = {}) {
   const options = Object.assign({}, DEFAULT_OPTIONS, opts);
   const isDownloadable = options.isHTMLBuild || options.isElectronBuild;
-  const commitHash = process.env.npm_package_gitHead;
 
   // ====================
   // ====== Entry =======
@@ -303,7 +302,7 @@ module.exports = function(opts = {}) {
   // ====================
   const output = {
     path: path.resolve(config.path.output, options.outputDir),
-    filename: options.isProduction ? `[name].${commitHash}.js` : '[name].js',
+    filename: options.isProduction ? '[name].[hash].js' : '[name].js',
     publicPath: isDownloadable && options.isProduction ? './' : '/',
     crossOriginLoading: 'anonymous',
     // Fix workers & HMR https://github.com/webpack/webpack/issues/6642


### PR DESCRIPTION
## Closes #2563 
🎉 🎉 🎉

## Description

`npm_package_gitHead` is not defined when using `yarn`, resulting in undefined file hashes on the production build. This PR replaces it with the Webpack build hash.

## Changes

* Replaced `npm_package_gitHead` with Webpack's hash.

## Steps to Test

1. `yarn build`
2. Check if filenames in `dist/prod` include file hashes.

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
