### PR TITLE
Fix bug with storeprovider timeout by just returning unaltered account

### DIFF
--- a/common/v2/services/Store/BalanceService.tsx
+++ b/common/v2/services/Store/BalanceService.tsx
@@ -57,7 +57,9 @@ const getAccountAssetsBalancesWithEthScan = async (
   return Promise.all([
     scanner.getEtherBalances([account.address]),
     scanner.getTokensBalance(account.address, list)
-  ]).then(addBalancesToAccount(account));
+  ])
+    .then(addBalancesToAccount(account))
+    .catch(_ => account);
 };
 
 // Return an object containing the balance of the different tokens

--- a/common/v2/services/Store/BalanceService.tsx
+++ b/common/v2/services/Store/BalanceService.tsx
@@ -87,7 +87,9 @@ const getAccountAssetsBalancesWithJsonRPC = async (
   return Promise.all([
     provider.getRawBalance(account.address).then(balance => ({ [address]: balance })),
     getTokenBalances(provider, address as TAddress, tokens)
-  ]).then(addBalancesToAccount(account));
+  ])
+    .then(addBalancesToAccount(account))
+    .catch(_ => account);
 };
 
 export const getAccountsAssetsBalances = async (accounts: StoreAccount[]) => {


### PR DESCRIPTION
Return previous account on balance lookup error instead of undefined.