### PR TITLE
Added filter for removed accounts in dashboard accounts list

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -71,8 +71,8 @@ interface AccountListProps {
 
 export default function AccountList(props: AccountListProps) {
   const { className, currentsOnly, deletable, favoritable, footerAction, footerActionLink } = props;
-  const { currentAccounts, accounts } = useContext(StoreContext);
-  const { deleteAccount, updateAccount } = useContext(AccountContext);
+  const { currentAccounts, accounts, deleteAccountFromCache } = useContext(StoreContext);
+  const { updateAccount } = useContext(AccountContext);
   const shouldRedirect = accounts === undefined || accounts === null || accounts.length === 0;
   if (shouldRedirect) {
     return <Redirect to="/no-accounts" />;
@@ -92,7 +92,7 @@ export default function AccountList(props: AccountListProps) {
           breakpoint={breakpointToNumber(BREAK_POINTS.SCREEN_XS)}
           {...buildAccountTable(
             currentsOnly ? currentAccounts() : accounts,
-            deleteAccount,
+            deleteAccountFromCache,
             updateAccount,
             deletable,
             favoritable

--- a/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
@@ -4,7 +4,7 @@ import styled, { StyledFunction } from 'styled-components';
 
 import { translateRaw } from 'translations';
 import { Checkbox } from 'v2/components';
-import { useOnClickOutside } from 'v2/utils';
+import { useOnClickOutside, truncate } from 'v2/utils';
 import { getLabelByAccount, AddressBookContext } from 'v2/services/Store';
 import { COLORS } from 'v2/theme';
 import { ExtendedAccount, ExtendedAddressBook } from 'v2/types';
@@ -88,14 +88,14 @@ const renderAccounts = (
 ) =>
   accounts.map((account: ExtendedAccount) => {
     const addressCard = getLabelByAccount(account, addressBook);
-    const addressLabel = addressCard ? addressCard.address : 'Unknown Account';
+    const addressLabel = addressCard ? addressCard.label : 'Unknown Account';
     return (
       <Checkbox
         key={account.uuid}
         name={`account-${account.uuid}`}
         checked={selected.includes(account.uuid)}
         onChange={() => handleChange(account.uuid)}
-        label={addressLabel}
+        label={`${truncate(account.address)} - ${addressLabel}`}
         icon={() => (
           <Identicon className="AccountDropdown-menu-identicon" address={account.address} />
         )}

--- a/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
@@ -113,7 +113,13 @@ const AccountDropdown = ({ accounts = [], selected = [], onSubmit }: AccountDrop
 
   // Only update our draft if the prop changed.
   // https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
-  useEffect(() => setDraftSelected(selected), [selected]);
+  useEffect(() => {
+    // Filters out dashboard account uuids that have been deleted.
+    const filteredSelected = selected.filter(selectedAccountUUID => {
+      return accounts.find(account => account.uuid === selectedAccountUUID) ? true : false;
+    });
+    setDraftSelected(filteredSelected);
+  }, [selected, accounts]);
 
   const allVisible = accounts.length !== 0 && accounts.length === draftSelected.length;
 

--- a/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
@@ -113,13 +113,7 @@ const AccountDropdown = ({ accounts = [], selected = [], onSubmit }: AccountDrop
 
   // Only update our draft if the prop changed.
   // https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
-  useEffect(() => {
-    // Filters out dashboard account uuids that have been deleted.
-    const filteredSelected = selected.filter(selectedAccountUUID => {
-      return accounts.find(account => account.uuid === selectedAccountUUID) ? true : false;
-    });
-    setDraftSelected(filteredSelected);
-  }, [selected, accounts]);
+  useEffect(() => setDraftSelected(selected), [selected, accounts]);
 
   const allVisible = accounts.length !== 0 && accounts.length === draftSelected.length;
 


### PR DESCRIPTION
#### Description

Gets rid of the "Showing 15 out of 14 accounts" bug with account dropdown on dashboard. Also truncates addresses and adds labels.

#### Changes

- Filter dashboardAccounts from settings when there is no account the uuid is assigned to.
- Truncates addresses in account dropdown.
- Adds labels to account dropdown.