### PR TITLE
Added asset icons to WalletBreakdown

### DIFF
--- a/common/v2/components/AssetIcon.tsx
+++ b/common/v2/components/AssetIcon.tsx
@@ -23,12 +23,13 @@ const SImg = styled('img')`
 interface Props {
   symbol: TSymbol;
   size?: string;
+  className?: string;
 }
 
-function AssetIcon({ symbol, size = '32px' }: Props) {
+function AssetIcon({ symbol, size = '32px', className }: Props) {
   const iconUrl = getIconUrl(symbol);
 
-  return <SImg src={iconUrl} size={size} />;
+  return <SImg src={iconUrl} size={size} className={className} />;
 }
 
 export default AssetIcon;

--- a/common/v2/features/Dashboard/components/WalletBreakdown/BalancesDetailView.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/BalancesDetailView.tsx
@@ -3,9 +3,10 @@ import { Button } from '@mycrypto/ui';
 import styled from 'styled-components';
 
 import { translateRaw } from 'translations';
-import { DashboardPanel, CollapsibleTable } from 'v2/components';
+import { DashboardPanel, CollapsibleTable, AssetIcon } from 'v2/components';
 import { WalletBreakdownProps } from './types';
 import { BREAK_POINTS } from 'v2/theme';
+import { TSymbol } from 'v2/types';
 
 import backArrowIcon from 'common/assets/images/icn-back-arrow.svg';
 
@@ -54,6 +55,15 @@ const RowAlignment = styled.div`
   float: ${(props: { align?: string }) => props.align || 'inherit'};
 `;
 
+const Label = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
+const Icon = styled(AssetIcon)`
+  margin-right: 10px;
+`;
+
 export default function BalancesDetailView({
   balances,
   toggleShowChart,
@@ -75,7 +85,10 @@ export default function BalancesDetailView({
     ],
     body: balances.map((balance, index) => {
       return [
-        balance.name,
+        <Label key={index}>
+          <Icon symbol={balance.ticker as TSymbol} size={'26px'} />
+          {balance.name}
+        </Label>,
         <RowAlignment key={index} align="right">
           {`${balance.amount.toFixed(6)} ${balance.ticker}`}
         </RowAlignment>,
@@ -87,6 +100,11 @@ export default function BalancesDetailView({
     config: {
       primaryColumn: TOKEN,
       sortableColumn: TOKEN,
+      sortFunction: (a: any, b: any) => {
+        const aLabel = a.props.children[1];
+        const bLabel = b.props.children[1];
+        return aLabel === bLabel ? true : aLabel.localeCompare(bLabel);
+      },
       hiddenHeadings: []
     }
   };

--- a/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdownView.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdownView.tsx
@@ -6,6 +6,8 @@ import BreakdownChart from './BreakdownChart';
 import NoAssets from './NoAssets';
 import { WalletBreakdownProps, Balance } from './types';
 import { COLORS, BREAK_POINTS } from 'v2/theme';
+import { TSymbol } from 'v2/types';
+import { AssetIcon } from 'v2/components';
 
 import moreIcon from 'common/assets/images/icn-more.svg';
 
@@ -126,10 +128,20 @@ const BreakDownBalance = styled.div`
   justify-content: space-between;
   margin: 11px 0;
   line-height: 1.2;
+  align-items: center;
 
   &:first-of-type {
     margin-top: 16px;
   }
+`;
+
+const BreakDownBalanceAssetIcon = styled(AssetIcon)`
+  margin-right: 10px;
+`;
+
+const BreakDownBalanceAssetInfo = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 const BreakDownBalanceAssetName = styled.div`
@@ -230,12 +242,17 @@ export default function WalletBreakdownView({
         <BreakDownBalanceList>
           {breakdownBalances.map(({ name, amount, fiatValue, ticker, isOther }) => (
             <BreakDownBalance key={name}>
-              <div>
-                <BreakDownBalanceAssetName>{name}</BreakDownBalanceAssetName>
-                <BreakDownBalanceAssetAmount silent={true}>
-                  {!isOther && `${amount.toFixed(4)} ${ticker}`}
-                </BreakDownBalanceAssetAmount>
-              </div>
+              <BreakDownBalanceAssetInfo>
+                <div>
+                  <BreakDownBalanceAssetIcon symbol={ticker as TSymbol} size={'26px'} />
+                </div>
+                <div>
+                  <BreakDownBalanceAssetName>{name}</BreakDownBalanceAssetName>
+                  <BreakDownBalanceAssetAmount silent={true}>
+                    {!isOther && `${amount.toFixed(4)} ${ticker}`}
+                  </BreakDownBalanceAssetAmount>
+                </div>
+              </BreakDownBalanceAssetInfo>
               <BreakDownBalanceAssetAmount>
                 {fiat.symbol}
                 {fiatValue.toFixed(2)}


### PR DESCRIPTION
<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

🎉 🎉 🎉

## Description

Added asset icons to both WalletBreakdown UI modes

## Changes

* Added `AssetIcon` to `WalletBreakdownView` and `BalancesDetailView`
* Added `className` to `AssetIcon` for styling

<!-- Preferably, include automated tests instead. -->
## Steps to Test

- View dashboard and see that icons have been added to WalletBreakdown. 
- Also click "view details" to see icons on the detailed breakdown.

## Quality Assurance

- [x] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [x] The base branch is develop or gau (no nested branches)
- [x] This is related to a maximum of one Clubhouse story or GitHub issue
- [x] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [x] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
