### PR TITLE
Add account deletion confirmation to table on desktop

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -91,7 +91,6 @@ const TableContainer = styled.div`
 `;
 
 const TableOverlay = styled.div`
-  max-width: 674px;
   height: 67px;
   display: flex;
   flex-direction: row;

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -210,13 +210,7 @@ function buildAccountTable(
       return deletable
         ? [
             ...bodyContent,
-            <DeleteButton
-              key={index}
-              onClick={() => {
-                setDeletingIndex(index);
-              }}
-              icon="exit"
-            />
+            <DeleteButton key={index} onClick={() => setDeletingIndex(index)} icon="exit" />
           ]
         : favoritable
         ? [

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -175,7 +175,7 @@ function buildAccountTable(
                 getLabelByAccount(accounts[overlayRows[0]], addressBook) !== undefined
                   ? getLabelByAccount(accounts[overlayRows[0]], addressBook)!.label
                   : ''
-              } account with address: ${truncate(accounts[overlayRows[0]].address)} ?`}
+              } account with address: ${accounts[overlayRows[0]].address} ?`}
           deleteAction={() => {
             deleteAccount(accounts[overlayRows[0]].uuid);
             setDeletingIndex(undefined);
@@ -213,12 +213,7 @@ function buildAccountTable(
             <DeleteButton
               key={index}
               onClick={() => {
-                if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === false) {
-                  setDeletingIndex(index);
-                }
-                if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === true) {
-                  deleteAccount(account.uuid);
-                }
+                setDeletingIndex(index);
               }}
               icon="exit"
             />

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -5,7 +5,7 @@ import { Button, Copyable, Identicon } from '@mycrypto/ui';
 
 import { translateRaw } from 'v2/translations';
 import { ROUTE_PATHS, Fiats } from 'v2/config';
-import { CollapsibleTable, Network } from 'v2/components';
+import { CollapsibleTable, Network, RowDeleteOverlay } from 'v2/components';
 import { default as Typography } from 'v2/components/Typography'; // @TODO solve Circular Dependency issue
 import { truncate, IS_MOBILE } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
@@ -90,39 +90,6 @@ const TableContainer = styled.div`
   overflow: auto;
 `;
 
-const TableOverlay = styled.div`
-  height: 67px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  background-color: #b5bfc7;
-  color: #fff;
-  padding: 1em;
-`;
-
-const OverlayText = styled(Typography)`
-  color: #fff;
-  flex-grow: 1;
-  text-overflow: hidden;
-  width: 50%;
-`;
-
-const OverlayButtons = styled.div`
-  align-self: flex-end;
-`;
-
-const OverlayDelete = styled(Button)`
-  font-size: 14px;
-  margin-left: 5px;
-`;
-
-const OverlayCancel = styled(Button)`
-  font-size: 14px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin-left: 5px;
-`;
-
 type DeleteAccount = (uuid: string) => void;
 type UpdateAccount = (uuid: string, accountData: ExtendedAccount) => void;
 interface AccountListProps {
@@ -203,28 +170,19 @@ function buildAccountTable(
     head: deletable ? [...columns, translateRaw('ACCOUNT_LIST_DELETE')] : columns,
     overlay:
       overlayRows && overlayRows[0] !== undefined ? (
-        <TableOverlay>
-          <OverlayText>
-            Are you sure you want to delete{' '}
-            {getLabelByAccount(accounts[overlayRows[0]], addressBook) !== undefined
-              ? getLabelByAccount(accounts[overlayRows[0]], addressBook)!.label
-              : ''}{' '}
-            account with address: {truncate(accounts[overlayRows[0]].address)}?
-          </OverlayText>
-          <OverlayButtons>
-            <OverlayDelete
-              onClick={() => {
-                deleteAccount(accounts[overlayRows[0]].uuid);
-                setDeletingIndex(undefined);
-              }}
-            >
-              Delete
-            </OverlayDelete>
-            <OverlayCancel secondary={true} onClick={() => setDeletingIndex(undefined)}>
-              Cancel
-            </OverlayCancel>
-          </OverlayButtons>
-        </TableOverlay>
+        <RowDeleteOverlay
+          prompt={`Are you sure you want to delete 
+              ${
+                getLabelByAccount(accounts[overlayRows[0]], addressBook) !== undefined
+                  ? getLabelByAccount(accounts[overlayRows[0]], addressBook)!.label
+                  : ''
+              } account with address: ${truncate(accounts[overlayRows[0]].address)} ?`}
+          deleteAction={() => {
+            deleteAccount(accounts[overlayRows[0]].uuid);
+            setDeletingIndex(undefined);
+          }}
+          cancelAction={() => setDeletingIndex(undefined)}
+        />
       ) : (
         <></>
       ),

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from 'react';
-import { Redirect } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { Button, Copyable, Identicon } from '@mycrypto/ui';
 
@@ -171,7 +170,7 @@ function buildAccountTable(
     overlay:
       overlayRows && overlayRows[0] !== undefined ? (
         <RowDeleteOverlay
-          prompt={`Are you sure you want to delete 
+          prompt={`Are you sure you want to delete
               ${
                 getLabelByAccount(accounts[overlayRows[0]], addressBook) !== undefined
                   ? getLabelByAccount(accounts[overlayRows[0]], addressBook)!.label

--- a/common/v2/components/CollapsibleTable.tsx
+++ b/common/v2/components/CollapsibleTable.tsx
@@ -129,6 +129,17 @@ const GroupHeadingCaret = styled(Icon)<Flippable>`
   `};
 `;
 
+const StackedCardContainer = styled.div`
+  position: relative;
+`;
+const StackedCardOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+`;
+
 export class CollapsibleTable extends Component<Props, State> {
   public static defaultProps = {
     head: [],
@@ -161,6 +172,7 @@ export class CollapsibleTable extends Component<Props, State> {
 
   public render() {
     const { mode, collapsedGroups } = this.state;
+    const { overlay, overlayRows } = this.props;
 
     return mode === CollapsibleTableModes.Mobile ? (
       transformTableToCards(this.props, collapsedGroups).map((cardData, index) =>
@@ -172,7 +184,12 @@ export class CollapsibleTable extends Component<Props, State> {
           </GroupHeading>
         ) : (
           // The element being iterated on is table data.
-          <StackedCard key={index} {...cardData} />
+          <StackedCardContainer>
+            <StackedCard key={index} {...cardData} />
+            {overlay && overlayRows!.includes(index) && (
+              <StackedCardOverlay>{overlay}</StackedCardOverlay>
+            )}
+          </StackedCardContainer>
         )
       )
     ) : (

--- a/common/v2/components/RowDeleteOverlay.tsx
+++ b/common/v2/components/RowDeleteOverlay.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, Typography } from '@mycrypto/ui';
+import styled from 'styled-components';
+
+const TableOverlay = styled.div`
+  height: 67px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background-color: #b5bfc7;
+  color: #fff;
+  padding: 1em;
+`;
+
+const OverlayText = styled(Typography)`
+  color: #fff;
+  flex-grow: 1;
+  text-overflow: hidden;
+  width: 50%;
+`;
+
+const OverlayButtons = styled.div`
+  align-self: flex-end;
+`;
+
+const OverlayDelete = styled(Button)`
+  font-size: 14px;
+  margin-left: 5px;
+`;
+
+const OverlayCancel = styled(Button)`
+  font-size: 14px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-left: 5px;
+`;
+
+const RowDeleteOverlay = (props: any) => (
+  <TableOverlay>
+    <OverlayText>{props.prompt}</OverlayText>
+    <OverlayButtons>
+      <OverlayDelete onClick={props.deleteAction}>Delete</OverlayDelete>
+      <OverlayCancel secondary={true} onClick={props.cancelAction}>
+        Cancel
+      </OverlayCancel>
+    </OverlayButtons>
+  </TableOverlay>
+);
+
+export default RowDeleteOverlay;

--- a/common/v2/components/RowDeleteOverlay.tsx
+++ b/common/v2/components/RowDeleteOverlay.tsx
@@ -1,48 +1,62 @@
 import React from 'react';
-import { Button, Typography } from '@mycrypto/ui';
 import styled from 'styled-components';
 
+import { COLORS, BREAK_POINTS } from 'v2/theme';
+import { Button } from 'v2/components';
+
+/*
+  Passed to CollapisableTable and Table by AccountList and AddressBook
+  It handles its own display to adapt to overlay on table row or over
+  StackCard. 
+*/
+
 const TableOverlay = styled.div`
-  height: 67px;
+  height: 100%;
+  max-height: 69px;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
   align-items: center;
-  background-color: #b5bfc7;
-  color: #fff;
+  background-color: ${COLORS.CLOUDY_BLUE};
+  color: ${COLORS.WHITE};
   padding: 1em;
+  @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+    max-height: 100%;
+    flex-direction: column;
+    justify-content: start;
+    align-items: space-between;
+  }
 `;
 
-const OverlayText = styled(Typography)`
-  color: #fff;
+const OverlayText = styled('span')`
+  color: ${COLORS.WHITE};
   flex-grow: 1;
-  text-overflow: hidden;
-  width: 50%;
+  overflow-wrap: break-word;
+  max-width: 70%;
+  @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+    max-width: 100%;
+  }
 `;
 
 const OverlayButtons = styled.div`
-  align-self: flex-end;
-`;
-
-const OverlayDelete = styled(Button)`
-  font-size: 14px;
-  margin-left: 5px;
-`;
-
-const OverlayCancel = styled(Button)`
-  font-size: 14px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin-left: 5px;
+  padding: 8px 0px;
+  & > * {
+    margin-left: 2ch;
+    font-size: 0.9em;
+  }
+  @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+    align-self: flex-end;
+  }
 `;
 
 const RowDeleteOverlay = (props: any) => (
   <TableOverlay>
     <OverlayText>{props.prompt}</OverlayText>
     <OverlayButtons>
-      <OverlayDelete onClick={props.deleteAction}>Delete</OverlayDelete>
-      <OverlayCancel secondary={true} onClick={props.cancelAction}>
+      <Button onClick={props.deleteAction}>Delete</Button>
+      <Button secondary={true} onClick={props.cancelAction}>
         Cancel
-      </OverlayCancel>
+      </Button>
     </OverlayButtons>
   </TableOverlay>
 );

--- a/common/v2/components/Table.tsx
+++ b/common/v2/components/Table.tsx
@@ -37,6 +37,8 @@ export interface TableContent {
 
 export interface TableData extends TableContent {
   head: (string | JSX.Element)[];
+  overlay?: ReactNode;
+  overlayRows?: number[];
   config?: TableConfig;
 }
 
@@ -201,7 +203,7 @@ class AbstractTable extends Component<Props, State> {
   }
 
   public render() {
-    const { head, config, ...rest } = this.props;
+    const { head, config, overlay, overlayRows, ...rest } = this.props;
     const { collapsedGroups, sortedColumnDirection } = this.state;
     const { body, groups } = this.getSortedLayout();
 
@@ -243,15 +245,44 @@ class AbstractTable extends Component<Props, State> {
           {/* Ungrouped rows are placed on top of grouped rows. */}
           {body.map((row, rowIndex) => (
             <TableRow key={rowIndex}>
-              {row.map((cell, cellIndex) => (
-                <TableCell
-                  key={cellIndex}
-                  isReversed={isReversedColumn(head[cellIndex])}
-                  data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
-                >
-                  {cell}
-                </TableCell>
-              ))}
+              {overlay ? (
+                overlayRows ? (
+                  // Render overlay component for any row in the overlay list
+                  overlayRows.includes(rowIndex) ? (
+                    <td colSpan={head.length}>{overlay}</td>
+                  ) : (
+                    row.map((cell, cellIndex) => (
+                      <TableCell
+                        key={cellIndex}
+                        isReversed={isReversedColumn(head[cellIndex])}
+                        data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
+                      >
+                        {cell}
+                      </TableCell>
+                    ))
+                  )
+                ) : (
+                  row.map((cell, cellIndex) => (
+                    <TableCell
+                      key={cellIndex}
+                      isReversed={isReversedColumn(head[cellIndex])}
+                      data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
+                    >
+                      {cell}
+                    </TableCell>
+                  ))
+                )
+              ) : (
+                row.map((cell, cellIndex) => (
+                  <TableCell
+                    key={cellIndex}
+                    isReversed={isReversedColumn(head[cellIndex])}
+                    data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
+                  >
+                    {cell}
+                  </TableCell>
+                ))
+              )}
             </TableRow>
           ))}
           {groups!.map(({ title, entries, offset = 0 }) => (

--- a/common/v2/components/Table.tsx
+++ b/common/v2/components/Table.tsx
@@ -245,33 +245,9 @@ class AbstractTable extends Component<Props, State> {
           {/* Ungrouped rows are placed on top of grouped rows. */}
           {body.map((row, rowIndex) => (
             <TableRow key={rowIndex}>
-              {overlay ? (
-                overlayRows ? (
-                  // Render overlay component for any row in the overlay list
-                  overlayRows.includes(rowIndex) ? (
-                    <td colSpan={head.length}>{overlay}</td>
-                  ) : (
-                    row.map((cell, cellIndex) => (
-                      <TableCell
-                        key={cellIndex}
-                        isReversed={isReversedColumn(head[cellIndex])}
-                        data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
-                      >
-                        {cell}
-                      </TableCell>
-                    ))
-                  )
-                ) : (
-                  row.map((cell, cellIndex) => (
-                    <TableCell
-                      key={cellIndex}
-                      isReversed={isReversedColumn(head[cellIndex])}
-                      data-testid={`ungrouped-${rowIndex}-${cellIndex}`}
-                    >
-                      {cell}
-                    </TableCell>
-                  ))
-                )
+              {overlay && overlayRows!.includes(rowIndex) ? (
+                // TODO: Solve jump in th width when the overlay is toggled.
+                <td colSpan={head.length}>{overlay}</td>
               ) : (
                 row.map((cell, cellIndex) => (
                   <TableCell

--- a/common/v2/components/index.ts
+++ b/common/v2/components/index.ts
@@ -14,6 +14,7 @@ export { default as Checkbox } from './Checkbox';
 export { default as CopyableCodeBlock } from './CopyableCodeBlock';
 export { default as ContentPanel } from './ContentPanel';
 export { default as Currency } from './Currency';
+export { default as RowDeleteOverlay } from './RowDeleteOverlay';
 export { default as Divider } from './Divider';
 export { default as Dropdown } from './Dropdown';
 export { default as ExtendedContentPanel } from './ExtendedContentPanel';

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -23,6 +23,8 @@ const SettingsHeadingIcon = styled.img`
 `;
 
 const StyledLayout = styled.div`
+  width: 100%;
+  max-width: 700px;
   .Layout-content {
     padding: 0;
     @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -24,7 +24,7 @@ const SettingsHeadingIcon = styled.img`
 
 const StyledLayout = styled.div`
   width: 100%;
-  max-width: 700px;
+  max-width: 1000px;
   .Layout-content {
     padding: 0;
     @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -23,11 +23,15 @@ const SettingsHeadingIcon = styled.img`
 `;
 
 const StyledLayout = styled.div`
-  width: 100%;
-  max-width: 1000px;
+  width: 960px;
+  @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+    width: 100%;
+  }
   .Layout-content {
     padding: 0;
-    @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+  }
+  @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
+    .Layout-content {
       margin-top: ${IS_MOBILE && '73px'};
     }
   }

--- a/common/v2/features/Settings/components/AddressBook.tsx
+++ b/common/v2/features/Settings/components/AddressBook.tsx
@@ -54,7 +54,6 @@ const STypography = styled(Typography)`
 `;
 
 const TableOverlay = styled.div`
-  max-width: 674px;
   height: 67px;
   display: flex;
   flex-direction: row;

--- a/common/v2/features/Settings/components/AddressBook.tsx
+++ b/common/v2/features/Settings/components/AddressBook.tsx
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Icon, Copyable, Identicon, Button } from '@mycrypto/ui';
 
-import { DashboardPanel, CollapsibleTable, Typography, Network } from 'v2/components';
+import {
+  DashboardPanel,
+  CollapsibleTable,
+  RowDeleteOverlay,
+  Network,
+  Typography
+} from 'v2/components';
 import { ExtendedAddressBook } from 'v2/types';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, breakpointToNumber } from 'v2/theme';
@@ -53,39 +59,6 @@ const STypography = styled(Typography)`
   }
 `;
 
-const TableOverlay = styled.div`
-  height: 67px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  background-color: #b5bfc7;
-  color: #fff;
-  padding: 1em;
-`;
-
-const OverlayText = styled(Typography)`
-  color: #fff;
-  flex-grow: 1;
-  text-overflow: hidden;
-  width: 50%;
-`;
-
-const OverlayButtons = styled.div`
-  align-self: flex-end;
-`;
-
-const OverlayDelete = styled(Button)`
-  font-size: 14px;
-  margin-left: 5px;
-`;
-
-const OverlayCancel = styled(Button)`
-  font-size: 14px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin-left: 5px;
-`;
-
 export const screenIsMobileSized = (breakpoint: number): boolean =>
   window.matchMedia(`(max-width: ${breakpoint}px)`).matches;
 
@@ -98,25 +71,15 @@ export default function AddressBook({ addressBook, toggleFlipped, deleteAddressB
     head: ['Favorite', 'Label', 'Address', 'Network', 'Notes', 'Delete'],
     overlay:
       overlayRows && overlayRows[0] !== undefined ? (
-        <TableOverlay>
-          <OverlayText>
-            Are you sure you want to delete {addressBook[overlayRows[0]].label} address with
-            address: {truncate(addressBook[overlayRows[0]].address)}?
-          </OverlayText>
-          <OverlayButtons>
-            <OverlayDelete
-              onClick={() => {
-                deleteAddressBooks(addressBook[overlayRows[0]].uuid);
-                setDeletingIndex(undefined);
-              }}
-            >
-              Delete
-            </OverlayDelete>
-            <OverlayCancel secondary={true} onClick={() => setDeletingIndex(undefined)}>
-              Cancel
-            </OverlayCancel>
-          </OverlayButtons>
-        </TableOverlay>
+        <RowDeleteOverlay
+          prompt={`Are you sure you want to delete ${addressBook[overlayRows[0]].label} address with
+             address: ${truncate(addressBook[overlayRows[0]].address)}?`}
+          deleteAction={() => {
+            deleteAddressBooks(addressBook[overlayRows[0]].uuid);
+            setDeletingIndex(undefined);
+          }}
+          cancelAction={() => setDeletingIndex(undefined)}
+        />
       ) : (
         <></>
       ),

--- a/common/v2/features/Settings/components/AddressBook.tsx
+++ b/common/v2/features/Settings/components/AddressBook.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Icon, Copyable, Identicon, Button } from '@mycrypto/ui';
 
 import { DashboardPanel, CollapsibleTable, Typography, Network } from 'v2/components';
 import { ExtendedAddressBook } from 'v2/types';
 import { truncate } from 'v2/utils';
-import { BREAK_POINTS } from 'v2/theme';
+import { BREAK_POINTS, breakpointToNumber } from 'v2/theme';
 
 interface Props {
   addressBook: ExtendedAddressBook[];
@@ -53,22 +53,101 @@ const STypography = styled(Typography)`
   }
 `;
 
+const TableOverlay = styled.div`
+  max-width: 674px;
+  height: 67px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background-color: #b5bfc7;
+  color: #fff;
+  padding: 1em;
+`;
+
+const OverlayText = styled(Typography)`
+  color: #fff;
+  flex-grow: 1;
+  text-overflow: hidden;
+  width: 50%;
+`;
+
+const OverlayButtons = styled.div`
+  align-self: flex-end;
+`;
+
+const OverlayDelete = styled(Button)`
+  font-size: 14px;
+  margin-left: 5px;
+`;
+
+const OverlayCancel = styled(Button)`
+  font-size: 14px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-left: 5px;
+`;
+
+export const screenIsMobileSized = (breakpoint: number): boolean =>
+  window.matchMedia(`(max-width: ${breakpoint}px)`).matches;
+
 export default function AddressBook({ addressBook, toggleFlipped, deleteAddressBooks }: Props) {
+  const [deletingIndex, setDeletingIndex] = useState();
+
+  const overlayRows = [deletingIndex];
+
   const addressBookTable = {
     head: ['Favorite', 'Label', 'Address', 'Network', 'Notes', 'Delete'],
-    body: addressBook.map(({ address, label, network, notes, uuid }: ExtendedAddressBook) => [
-      <Icon key={0} icon="star" />,
-      <Label key={1}>
-        <SIdenticon address={address} />
-        <STypography bold={true} value={label} />
-      </Label>,
-      <Copyable key={2} text={address} truncate={truncate} isCopyable={true} />,
-      <Network key={3} color="#a682ff">
-        {network}
-      </Network>,
-      <Typography key={4} value={notes} />,
-      <DeleteButton key={5} onClick={() => deleteAddressBooks(uuid)} icon="exit" />
-    ]),
+    overlay:
+      overlayRows && overlayRows[0] !== undefined ? (
+        <TableOverlay>
+          <OverlayText>
+            Are you sure you want to delete {addressBook[overlayRows[0]].label} address with
+            address: {truncate(addressBook[overlayRows[0]].address)}?
+          </OverlayText>
+          <OverlayButtons>
+            <OverlayDelete
+              onClick={() => {
+                deleteAddressBooks(addressBook[overlayRows[0]].uuid);
+                setDeletingIndex(undefined);
+              }}
+            >
+              Delete
+            </OverlayDelete>
+            <OverlayCancel secondary={true} onClick={() => setDeletingIndex(undefined)}>
+              Cancel
+            </OverlayCancel>
+          </OverlayButtons>
+        </TableOverlay>
+      ) : (
+        <></>
+      ),
+    overlayRows,
+    body: addressBook.map(
+      ({ address, label, network, notes, uuid }: ExtendedAddressBook, index) => [
+        <Icon key={0} icon="star" />,
+        <Label key={1}>
+          <SIdenticon address={address} />
+          <STypography bold={true} value={label} />
+        </Label>,
+        <Copyable key={2} text={address} truncate={truncate} isCopyable={true} />,
+        <Network key={3} color="#a682ff">
+          {network}
+        </Network>,
+        <Typography key={4} value={notes} />,
+        <DeleteButton
+          key={5}
+          onClick={() => {
+            if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === false) {
+              setDeletingIndex(index);
+            }
+            if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === true) {
+              deleteAddressBooks(uuid);
+            }
+          }}
+          icon="exit"
+        />
+      ]
+    ),
     config: {
       primaryColumn: 'Label',
       sortableColumn: 'Label',

--- a/common/v2/features/Settings/components/AddressBook.tsx
+++ b/common/v2/features/Settings/components/AddressBook.tsx
@@ -11,7 +11,7 @@ import {
 } from 'v2/components';
 import { ExtendedAddressBook } from 'v2/types';
 import { truncate } from 'v2/utils';
-import { BREAK_POINTS, breakpointToNumber } from 'v2/theme';
+import { BREAK_POINTS } from 'v2/theme';
 
 interface Props {
   addressBook: ExtendedAddressBook[];
@@ -84,32 +84,19 @@ export default function AddressBook({ addressBook, toggleFlipped, deleteAddressB
         <></>
       ),
     overlayRows,
-    body: addressBook.map(
-      ({ address, label, network, notes, uuid }: ExtendedAddressBook, index) => [
-        <Icon key={0} icon="star" />,
-        <Label key={1}>
-          <SIdenticon address={address} />
-          <STypography bold={true} value={label} />
-        </Label>,
-        <Copyable key={2} text={address} truncate={truncate} isCopyable={true} />,
-        <Network key={3} color="#a682ff">
-          {network}
-        </Network>,
-        <Typography key={4} value={notes} />,
-        <DeleteButton
-          key={5}
-          onClick={() => {
-            if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === false) {
-              setDeletingIndex(index);
-            }
-            if (screenIsMobileSized(breakpointToNumber(BREAK_POINTS.SCREEN_XS)) === true) {
-              deleteAddressBooks(uuid);
-            }
-          }}
-          icon="exit"
-        />
-      ]
-    ),
+    body: addressBook.map(({ address, label, network, notes }: ExtendedAddressBook, index) => [
+      <Icon key={0} icon="star" />,
+      <Label key={1}>
+        <SIdenticon address={address} />
+        <STypography bold={true} value={label} />
+      </Label>,
+      <Copyable key={2} text={address} truncate={truncate} isCopyable={true} />,
+      <Network key={3} color="#a682ff">
+        {network}
+      </Network>,
+      <Typography key={4} value={notes} />,
+      <DeleteButton key={5} onClick={() => setDeletingIndex(index)} icon="exit" />
+    ]),
     config: {
       primaryColumn: 'Label',
       sortableColumn: 'Label',


### PR DESCRIPTION
## Description

* Added a table row overlay for account deletion confirmation step

~Will prob need to be cleaned up a bit later~

[ch2593]

### Mobile Overlay
<img width="347" alt="Screenshot 2019-11-14 at 20 41 17" src="https://user-images.githubusercontent.com/2429708/68890813-fc824d80-071f-11ea-9b82-16ab3de778f4.png">

### Desktop Overlay
<img width="965" alt="Screenshot 2019-11-14 at 20 47 02" src="https://user-images.githubusercontent.com/2429708/68890817-fc824d80-071f-11ea-80d3-9415f1dea9b5.png">


