### PR TITLE
Fix a bug with view-only accounts in add-account flow

### DIFF
--- a/common/v2/components/WalletUnlock/ViewOnly.tsx
+++ b/common/v2/components/WalletUnlock/ViewOnly.tsx
@@ -98,7 +98,7 @@ class ViewOnlyDecryptClass extends PureComponent<OwnProps & StateProps, State> {
     if (wallet) {
       e.preventDefault();
       e.stopPropagation();
-      this.props.onUnlock(new WalletService.init(wallet));
+      this.props.onUnlock(WalletService.init(wallet));
     }
   };
 }


### PR DESCRIPTION
### Description
Previously, the app couldn't pass through the add-account flow and would through an 'm.init is not a constructor error` instead. This is now fixed.