### PR TITLE
Strip Redux/Shepherd out of HD wallet types in Add Account

### DIFF
--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -943,7 +943,7 @@
     "NOTIFICATIONS_ONBOARDING_RESPONSIBLE_MYCRYPTO": "Reducing risk by using the [MyCrypto Desktop App]($link)",
     "WEB3_ONUNLOCK_NOT_FOUND_ERROR": "Please unlock your $walletId before continuing.",
     "YOUR_PRIVATE_KEY": "Your Private Key",
-    "INPUT_PUBLIC_ADDRESS_LABEL": "Select or Input Your Address",
+    "INPUT_PUBLIC_ADDRESS_LABEL": "Add a view-only Address or ENS Name",
     "COINBASE_APP_LABEL": "Coinbase App",
     "TRUST_APP_LABEL": "Trust Wallet App",
     "RECEIVE_FORM_ERROR_TYPE": "Please enter a valid number",

--- a/common/v2/components/AddressField.tsx
+++ b/common/v2/components/AddressField.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Input } from '@mycrypto/ui';
+import { FieldProps, Field, FormikTouched } from 'formik';
+
+import { translateRaw } from 'translations';
+import {
+  isValidETHAddress,
+  getENSTLDForChain,
+  getIsValidENSAddressFunction
+} from 'v2/services/EthService';
+import { InlineErrorMsg, ENSStatus, IViewOnlyFormikValues } from 'v2/components';
+import { Network } from 'v2/types';
+
+/*
+  Eth address field to be used within a Formik Form
+  - the 'fieldname' must exist wihtin the Formik default fields
+  - validation of the field is handled here.
+*/
+
+interface Props {
+  error?: string;
+  fieldName: string;
+  touched?: FormikTouched<IViewOnlyFormikValues>;
+  placeholder?: string;
+  network?: Network;
+  isLoading: boolean;
+  handleENSResolve?(name: string): Promise<void>;
+}
+
+function ETHAddressField({
+  fieldName,
+  touched,
+  error,
+  network,
+  placeholder = 'ETH Address or ENS Name',
+  isLoading,
+  handleENSResolve
+}: Props) {
+  const validateEthAddress = (value: any) => {
+    let errorMsg;
+    if (!value) {
+      errorMsg = translateRaw('REQUIRED');
+    } else if (!isValidETHAddress(value)) {
+      const networkId = network && network.chainId ? network.chainId : 1;
+      const isValidENSName = getIsValidENSAddressFunction(networkId);
+      if (!isValidENSName(value)) {
+        errorMsg = translateRaw('TO_FIELD_ERROR');
+      }
+    }
+    return errorMsg;
+  };
+  // By destructuring 'field' in the rendered component we are mapping
+  // the Inputs 'value' and 'onChange' props to Formiks handlers.
+  return (
+    <>
+      <Field
+        name={fieldName}
+        validate={validateEthAddress}
+        validateOnChange={false}
+        render={({ field, form }: FieldProps) => (
+          <>
+            <Input
+              {...field}
+              value={field.value.display}
+              placeholder={placeholder}
+              onChange={e => {
+                form.setFieldValue(fieldName, {
+                  display: e.currentTarget.value,
+                  value: e.currentTarget.value
+                });
+              }}
+              onBlur={async e => {
+                if (!network || !network.chainId) {
+                  return;
+                }
+                const ensTLD = getENSTLDForChain(network.chainId);
+                const isENSAddress = e.currentTarget.value.endsWith(`.${ensTLD}`);
+                const action =
+                  isENSAddress && handleENSResolve
+                    ? (ensName: string) => handleENSResolve(ensName)
+                    : (address: string) =>
+                        form.setFieldValue(fieldName, { display: address, value: address });
+                await action(e.currentTarget.value);
+                form.setFieldTouched(fieldName);
+              }}
+            />
+            <ENSStatus
+              ensName={form.values.addressObject.display}
+              rawAddress={form.values.addressObject.value}
+              chainId={network ? network.chainId : 1}
+              isLoading={isLoading}
+            />
+            {error && touched && touched.addressObject ? (
+              <InlineErrorMsg className="ViewOnlyForm-errors">{error}</InlineErrorMsg>
+            ) : null}
+          </>
+        )}
+      />
+    </>
+  );
+}
+
+export default ETHAddressField;

--- a/common/v2/components/WalletUnlock/DeterministicWallets.tsx
+++ b/common/v2/components/WalletUnlock/DeterministicWallets.tsx
@@ -1,25 +1,27 @@
 import React, { useState, useEffect, useContext } from 'react';
 import Select, { Option } from 'react-select';
 import { Table, Address, Button } from '@mycrypto/ui';
+import BN from 'bn.js';
 
 import translate, { translateRaw } from 'translations';
-import { isValidPath } from 'v2/services/EthService/';
 import { UnitDisplay, Input } from 'components/ui';
-import './DeterministicWallets.scss';
+
 import { truncate } from 'v2/utils';
+import { Network } from 'v2/types';
+import {
+  getBaseAssetSymbolByNetwork,
+  AddressBookContext,
+  getLabelByAddressAndNetwork,
+  isValidPath
+} from 'v2/services';
 import nextIcon from 'assets/images/next-page-button.svg';
 import prevIcon from 'assets/images/previous-page-button.svg';
 import radio from 'assets/images/radio.svg';
 import radioChecked from 'assets/images/radio-checked.svg';
-import { Network } from 'v2/types';
-import { getBaseAssetSymbolByNetwork, AddressBookContext } from 'v2/services';
-import {
-  getDeterministicWallets,
-  DeterministicWalletData
-} from 'v2/services/WalletService/deterministic/deterministic';
-import { getLabelByAddressAndNetwork } from 'v2/services/Store/AddressBook/helpers';
+
+import './DeterministicWallets.scss';
+import { DeterministicWalletData, getDeterministicWallets } from 'v2/services/WalletService';
 import { getBaseAssetBalances, BalanceMap } from 'v2/services/Store/BalanceService';
-import BN from 'bn.js';
 
 function Radio({ checked }: { checked: boolean }) {
   return <img className="clickable radio-image" src={checked ? radioChecked : radio} />;
@@ -36,17 +38,13 @@ interface OwnProps {
   seed?: string;
 }
 
-/*interface StateProps {
-  addressLabels: ReturnType<typeof addressBookSelectors.getAddressLabels>;
-}*/
-
 interface DispatchProps {
   onCancel(): void;
   onConfirmAddress(address: string, addressIndex: number): void;
   onPathChange(dPath: DPath): void;
 }
 
-type Props = OwnProps /*& StateProps*/ & DispatchProps;
+type Props = OwnProps & DispatchProps;
 
 const customDPath: DPath = {
   label: 'custom',
@@ -145,10 +143,8 @@ export function DeterministicWalletsClass({
 
   const handleChangePath = (newPath: DPath) => {
     if (newPath.value === customDPath.value) {
-      //setIsCustomPath(true);
       setCurrentDPath(newPath);
     } else {
-      //setIsCustomPath(false);
       setCurrentDPath(newPath);
       onPathChange(newPath);
     }

--- a/common/v2/components/index.ts
+++ b/common/v2/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Amount } from './Amount';
+export { default as AddressField } from './AddressField';
 export { default as AccountDropdown } from './AccountDropdown';
 export { default as AccountOption } from './AccountOption';
 export { default as AccountSummary } from './AccountSummary';

--- a/common/v2/services/Store/AddressBook/helpers.ts
+++ b/common/v2/services/Store/AddressBook/helpers.ts
@@ -1,5 +1,5 @@
 import { getCache } from '../LocalCache';
-import { Account, AddressBook } from 'v2/types';
+import { Account, AddressBook, Network } from 'v2/types';
 
 export const getAllAddressLabels = (): AddressBook[] => {
   return Object.values(getCache().addressBook);
@@ -18,6 +18,18 @@ export const getLabelByAccount = (
     label =>
       account.address.toLowerCase() === label.address.toLowerCase() &&
       account.networkId === label.network
+  );
+};
+
+export const getLabelByAddressAndNetwork = (
+  address: string,
+  addressLabels: AddressBook[],
+  network: Network | undefined
+): AddressBook | undefined => {
+  return addressLabels.find(
+    label =>
+      address.toLowerCase() === label.address.toLowerCase() &&
+      (network ? network.id === label.network : true)
   );
 };
 

--- a/common/v2/services/Store/AddressBook/index.ts
+++ b/common/v2/services/Store/AddressBook/index.ts
@@ -4,5 +4,6 @@ export {
   getAllAddressLabels,
   getLabelByAddress,
   getLabelByAccount,
+  getLabelByAddressAndNetwork,
   findNextUnusedDefaultLabel
 } from './helpers';

--- a/common/v2/services/WalletService/deterministic/deterministic.ts
+++ b/common/v2/services/WalletService/deterministic/deterministic.ts
@@ -1,3 +1,7 @@
+import HDKey from 'hdkey';
+import { publicToAddress, toChecksumAddress } from 'ethereumjs-util';
+import { TokenValue } from 'v2/services/EthService';
+
 export class DeterministicWallet {
   protected address: string;
   protected dPath: string;
@@ -17,3 +21,59 @@ export class DeterministicWallet {
     return `${this.dPath}/${this.index}`;
   }
 }
+export interface GetDeterministicWalletsArgs {
+  seed?: string;
+  dPath: string;
+  publicKey?: string;
+  chainCode?: string;
+  limit: number;
+  offset: number;
+}
+
+export interface DeterministicWalletData {
+  index: number;
+  address: string;
+  value?: TokenValue;
+}
+
+export interface ITokenData {
+  value: TokenValue;
+  decimal: number;
+}
+
+export interface ITokenValues {
+  [key: string]: ITokenData | null;
+}
+
+export const getDeterministicWallets = (
+  args: GetDeterministicWalletsArgs
+): DeterministicWalletData[] => {
+  const { seed, dPath, publicKey, chainCode, limit, offset } = args;
+  let pathBase;
+  let hdk;
+
+  // if seed present, treat as mnemonic
+  // if pubKey & chainCode present, treat as HW wallet
+  if (seed) {
+    hdk = HDKey.fromMasterSeed(new Buffer(seed, 'hex'));
+    pathBase = dPath;
+  } else if (publicKey && chainCode) {
+    hdk = new HDKey();
+    hdk.publicKey = new Buffer(publicKey, 'hex');
+    hdk.chainCode = new Buffer(chainCode, 'hex');
+    pathBase = 'm';
+  } else {
+    return [];
+  }
+  const wallets: DeterministicWalletData[] = [];
+  for (let i = 0; i < limit; i++) {
+    const index = i + offset;
+    const dkey = hdk.derive(`${pathBase}/${index}`);
+    const address = publicToAddress(dkey.publicKey, true).toString('hex');
+    wallets.push({
+      index,
+      address: toChecksumAddress(address)
+    });
+  }
+  return wallets;
+};

--- a/common/v2/services/WalletService/deterministic/index.ts
+++ b/common/v2/services/WalletService/deterministic/index.ts
@@ -19,6 +19,7 @@ function enclaveOrWallet<T>(type: HardwareWalletId, lib: T) {
 
 export * from './mnemonic';
 export * from './hardware';
+export * from './deterministic';
 export const LedgerWallet = enclaveOrWallet(WalletId.LEDGER_NANO_S, LedgerWalletWeb);
 export const TrezorWallet = enclaveOrWallet(WalletId.TREZOR, TrezorWalletWeb);
 export const SafeTWallet = enclaveOrWallet(WalletId.SAFE_T_MINI, SafeTWalletWeb);


### PR DESCRIPTION
### Description

The goal of this PR is to extract out the redux and shepherd stuff being used in the Add-Account flow.
This is needed so that we can for prep for migrating `gau` to `master` and strip out legacy sections of the codebase.