### PR TITLE
Fixed currency formatting

### DIFF
--- a/common/v2/components/Currency.tsx
+++ b/common/v2/components/Currency.tsx
@@ -31,7 +31,10 @@ function Currency({
 }: Props) {
   const format = (value: string, decimalPlaces: number) => {
     const v = parseFloat(value);
-    return Number(v).toLocaleString(undefined, { maximumFractionDigits: decimalPlaces });
+    return Number(v).toLocaleString(undefined, {
+      minimumFractionDigits: decimalPlaces,
+      maximumFractionDigits: decimalPlaces
+    });
     // const multiplier = Math.pow(10, decimalPlaces);
     // return Math.round(v * multiplier + Number.EPSILON) / multiplier;
   };


### PR DESCRIPTION
Description

Fixed currency formatting issue where `1.50` would read as `1.5`