### PR TITLE
Mock http call for analytics spec

### DIFF
--- a/common/v2/services/ApiService/Analytics/Analytics.spec.ts
+++ b/common/v2/services/ApiService/Analytics/Analytics.spec.ts
@@ -1,39 +1,56 @@
+import nock from 'nock';
 import AnalyticsService from './Analytics';
+import { ANALYTICS_API_URL } from './constants';
 
-const category: string = 'Test';
-const eventName: string = 'Test event';
-const testUrl: string = 'test_url';
+let category: string;
+let eventAction: string;
+let appUrl: string;
 
 describe('AnalyticsService', () => {
-  it('should send event to analytics endpoint', async () => {
+  nock.back.setMode('record');
+
+  beforeEach(() => {
+    category = 'Category';
+    eventAction = 'Name of Event';
+    appUrl = 'App route url';
+
+    nock(ANALYTICS_API_URL)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get(/.*/)
+      .reply(200, {}); // responses are handled by nock.
+  });
+
+  it('should send an action name', async () => {
     const {
       status,
       config: { params }
-    } = await AnalyticsService.instance.track(category, eventName);
+    } = await AnalyticsService.instance.track(category, eventAction);
 
     expect(status).toBe(200);
     expect(params.e_c).toBe(category);
-    expect(params.action_name).toBe(eventName);
+    expect(params.action_name).toBe(eventAction);
   });
 
   it('should add Legacy_ prefix to legacy event', async () => {
     const {
       status,
       config: { params }
-    } = await AnalyticsService.instance.trackLegacy(category, eventName);
+    } = await AnalyticsService.instance.trackLegacy(category, eventAction);
 
     expect(status).toBe(200);
     expect(params.e_c).toBe(category);
-    expect(params.action_name).toBe(`Legacy_${eventName}`);
+    expect(params.action_name).toBe(`Legacy_${eventAction}`);
   });
 
   it('should add page url param to page visit event', async () => {
     const {
       status,
       config: { params }
-    } = await AnalyticsService.instance.trackPageVisit(testUrl);
+    } = await AnalyticsService.instance.trackPageVisit(appUrl);
 
     expect(status).toBe(200);
-    expect(params.url).toBe(testUrl);
+    expect(params.url).toBe(appUrl);
   });
+
+  nock.back.setMode('wild');
 });

--- a/jest_config/jest.config.json
+++ b/jest_config/jest.config.json
@@ -1,20 +1,20 @@
 {
   "rootDir": "../",
+  "verbose": true,
   "transform": {
-    "^.+\\.tsx?$": "ts-jest"
+    "\\.tsx?$": "ts-jest"
   },
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleDirectories": ["node_modules", "common"],
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "worker.ts", "worker.tsx"],
   "moduleNameMapper": {
     "shared/(.*)": "<rootDir>/shared/$1",
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-      "<rootDir>/jest_config/__mocks__/fileMock.ts",
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/jest_config/__mocks__/fileMock.ts",
     "\\.(css|scss)$": "<rootDir>/jest_config/__mocks__/styleMock.ts",
     "\\.worker.(ts|tsx)": "<rootDir>/jest_config/__mocks__/workerMock.js"
   },
-  "testPathIgnorePatterns": ["dist"],
-  "coveragePathIgnorePatterns": ["components", "containers", "vendor", "spec"],
+  "testPathIgnorePatterns": ["node_modules", "dist"],
+  "coveragePathIgnorePatterns": ["node_modules", "components", "containers", "vendor", "spec"],
   "setupFiles": [
     "<rootDir>/jest_config/setupJest.js",
     "<rootDir>/jest_config/__mocks__/localStorage.ts"

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "mini-css-extract-plugin": "0.8.0",
     "minimist": "1.2.0",
     "mycrypto-nano-result": "0.0.1",
+    "nock": "11.7.0",
     "node-sass": "4.12.0",
     "nodemon": "1.17.3",
     "parse-eth-tokens": "0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2585,6 +2585,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3757,6 +3762,18 @@ caw@^2.0.0:
     tunnel-agent "^0.6.0"
     url-to-options "^1.0.1"
 
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3796,6 +3813,11 @@ character-reference-invalid@^1.0.0:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 check-node-version@3.2.0:
   version "3.2.0"
@@ -5076,6 +5098,13 @@ deep-diff@^0.3.5:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
   integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.1:
   version "1.1.0"
@@ -7086,6 +7115,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.1"
@@ -9439,7 +9473,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@5, json-stringify-safe@~5.0.1:
+json-stringify-safe@5, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -11106,6 +11140,18 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+nock@11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-11.7.0.tgz#5eaae8b8a55c0dfc014d05692c8cf3d31d61a342"
+  integrity sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    mkdirp "^0.5.0"
+    propagate "^2.0.0"
+
 node-abi@^2.7.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.11.0.tgz#b7dce18815057544a049be5ae75cd1fdc2e9ea59"
@@ -12201,6 +12247,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -12570,6 +12621,11 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, pr
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-expr@^1.5.0:
   version "1.5.1"
@@ -15849,6 +15905,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
[[ch3434]](https://app.clubhouse.io/mycrypto/story/3434/webpack-improve-dev-server)

From time to time `Analytics.spec.ts` would timeout.
To avoid it we use `nock` to mock the api call and return a response.