### PR TITLE
Migrate to coingecko from cryptocompare

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -153,7 +153,7 @@ function buildAccountTable(
   setDeletingIndex?: any
 ) {
   const { totalFiat } = useContext(StoreContext);
-  const { getRate } = useContext(RatesContext);
+  const { getRateFromAsset } = useContext(RatesContext);
   const { settings } = useContext(SettingsContext);
   const { addressBook } = useContext(AddressBookContext);
   const columns = [
@@ -188,7 +188,7 @@ function buildAccountTable(
     overlayRows,
     body: accounts.map((account, index) => {
       const addressCard: AddressBook | undefined = getLabelByAccount(account, addressBook);
-      const total = totalFiat([account])(getRate);
+      const total = totalFiat([account])(getRateFromAsset);
       const label = addressCard ? addressCard.label : 'Unknown Account';
       const bodyContent = [
         <Label key={index}>

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -153,7 +153,7 @@ function buildAccountTable(
   setDeletingIndex?: any
 ) {
   const { totalFiat } = useContext(StoreContext);
-  const { getRateFromAsset } = useContext(RatesContext);
+  const { getAssetRate } = useContext(RatesContext);
   const { settings } = useContext(SettingsContext);
   const { addressBook } = useContext(AddressBookContext);
   const columns = [
@@ -188,7 +188,7 @@ function buildAccountTable(
     overlayRows,
     body: accounts.map((account, index) => {
       const addressCard: AddressBook | undefined = getLabelByAccount(account, addressBook);
-      const total = totalFiat([account])(getRateFromAsset);
+      const total = totalFiat([account])(getAssetRate);
       const label = addressCard ? addressCard.label : 'Unknown Account';
       const bodyContent = [
         <Label key={index}>

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -8,7 +8,7 @@ import { AddressBookContext } from 'v2/services/Store';
 import { Amount } from 'v2/components';
 import { fromWei, Wei, totalTxFeeToString, totalTxFeeToWei } from 'v2/services/EthService';
 import { RatesContext } from 'v2/services/RatesProvider';
-import { TTicker, IStepComponentProps } from 'v2/types';
+import { IStepComponentProps } from 'v2/types';
 
 import './ConfirmTransaction.scss';
 import TransactionDetailsDisplay from './displays/TransactionDetailsDisplay';
@@ -28,7 +28,7 @@ export default function ConfirmTransaction({
     onComplete(null);
   };
 
-  const { getRate } = useContext(RatesContext);
+  const { getRateFromAsset } = useContext(RatesContext);
   const recipientContact = getContactByAddressAndNetwork(
     txConfig.receiverAddress,
     txConfig.network
@@ -98,10 +98,7 @@ export default function ConfirmTransaction({
         <div className="ConfirmTransaction-row-column">
           <Amount
             assetValue={`${parseFloat(amount).toFixed(6)} ${asset.ticker}`}
-            fiatValue={`$${convertToFiat(
-              parseFloat(amount),
-              getRate(asset.ticker as TTicker)
-            ).toFixed(2)}
+            fiatValue={`$${convertToFiat(parseFloat(amount), getRateFromAsset(asset)).toFixed(2)}
           `}
           />
         </div>
@@ -115,7 +112,7 @@ export default function ConfirmTransaction({
             assetValue={`${maxTransactionFeeBase} ${baseAsset.ticker}`}
             fiatValue={`$${convertToFiat(
               parseFloat(maxTransactionFeeBase),
-              getRate(baseAsset.ticker as TTicker)
+              getRateFromAsset(baseAsset)
             ).toFixed(2)}`}
           />
         </div>
@@ -131,7 +128,7 @@ export default function ConfirmTransaction({
               assetValue={`${totalEtherEgress} ${asset.ticker}`}
               fiatValue={`$${convertToFiat(
                 parseFloat(totalEtherEgress),
-                getRate(asset.ticker as TTicker)
+                getRateFromAsset(asset)
               ).toFixed(2)}`}
             />
           ) : (
@@ -139,8 +136,8 @@ export default function ConfirmTransaction({
               assetValue={`${amount} ${asset.ticker}`}
               baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
               fiatValue={`$${(
-                convertToFiat(parseFloat(amount), getRate(asset.ticker as TTicker)) +
-                convertToFiat(parseFloat(totalEtherEgress), getRate(baseAsset.ticker as TTicker))
+                convertToFiat(parseFloat(amount), getRateFromAsset(asset)) +
+                convertToFiat(parseFloat(totalEtherEgress), getRateFromAsset(baseAsset))
               ).toFixed(2)}`}
             />
           )}

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -28,7 +28,7 @@ export default function ConfirmTransaction({
     onComplete(null);
   };
 
-  const { getRateFromAsset } = useContext(RatesContext);
+  const { getAssetRate } = useContext(RatesContext);
   const recipientContact = getContactByAddressAndNetwork(
     txConfig.receiverAddress,
     txConfig.network
@@ -98,7 +98,7 @@ export default function ConfirmTransaction({
         <div className="ConfirmTransaction-row-column">
           <Amount
             assetValue={`${parseFloat(amount).toFixed(6)} ${asset.ticker}`}
-            fiatValue={`$${convertToFiat(parseFloat(amount), getRateFromAsset(asset)).toFixed(2)}
+            fiatValue={`$${convertToFiat(parseFloat(amount), getAssetRate(asset)).toFixed(2)}
           `}
           />
         </div>
@@ -112,7 +112,7 @@ export default function ConfirmTransaction({
             assetValue={`${maxTransactionFeeBase} ${baseAsset.ticker}`}
             fiatValue={`$${convertToFiat(
               parseFloat(maxTransactionFeeBase),
-              getRateFromAsset(baseAsset)
+              getAssetRate(baseAsset)
             ).toFixed(2)}`}
           />
         </div>
@@ -128,7 +128,7 @@ export default function ConfirmTransaction({
               assetValue={`${totalEtherEgress} ${asset.ticker}`}
               fiatValue={`$${convertToFiat(
                 parseFloat(totalEtherEgress),
-                getRateFromAsset(asset)
+                getAssetRate(asset)
               ).toFixed(2)}`}
             />
           ) : (
@@ -136,8 +136,8 @@ export default function ConfirmTransaction({
               assetValue={`${amount} ${asset.ticker}`}
               baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
               fiatValue={`$${(
-                convertToFiat(parseFloat(amount), getRateFromAsset(asset)) +
-                convertToFiat(parseFloat(totalEtherEgress), getRateFromAsset(baseAsset))
+                convertToFiat(parseFloat(amount), getAssetRate(asset)) +
+                convertToFiat(parseFloat(totalEtherEgress), getAssetRate(baseAsset))
               ).toFixed(2)}`}
             />
           )}

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -62,6 +62,10 @@ export default function ConfirmTransaction({
   const senderContact = getContactByAccount(senderAccount);
   const senderAccountLabel = senderContact ? senderContact.label : 'Unknown Account';
 
+  /* Get Rates */
+  const assetRate = getAssetRate(asset);
+  const baseAssetRate = getAssetRate(baseAsset);
+
   return (
     <div className="ConfirmTransaction">
       <div className="ConfirmTransaction-row">
@@ -98,7 +102,7 @@ export default function ConfirmTransaction({
         <div className="ConfirmTransaction-row-column">
           <Amount
             assetValue={`${parseFloat(amount).toFixed(6)} ${asset.ticker}`}
-            fiatValue={`$${convertToFiat(parseFloat(amount), getAssetRate(asset)).toFixed(2)}
+            fiatValue={`$${convertToFiat(parseFloat(amount), assetRate).toFixed(2)}
           `}
           />
         </div>
@@ -110,10 +114,9 @@ export default function ConfirmTransaction({
         <div className="ConfirmTransaction-row-column">
           <Amount
             assetValue={`${maxTransactionFeeBase} ${baseAsset.ticker}`}
-            fiatValue={`$${convertToFiat(
-              parseFloat(maxTransactionFeeBase),
-              getAssetRate(baseAsset)
-            ).toFixed(2)}`}
+            fiatValue={`$${convertToFiat(parseFloat(maxTransactionFeeBase), baseAssetRate).toFixed(
+              2
+            )}`}
           />
         </div>
       </div>
@@ -126,18 +129,15 @@ export default function ConfirmTransaction({
           {assetType === 'base' ? (
             <Amount
               assetValue={`${totalEtherEgress} ${asset.ticker}`}
-              fiatValue={`$${convertToFiat(
-                parseFloat(totalEtherEgress),
-                getAssetRate(asset)
-              ).toFixed(2)}`}
+              fiatValue={`$${convertToFiat(parseFloat(totalEtherEgress), assetRate).toFixed(2)}`}
             />
           ) : (
             <Amount
               assetValue={`${amount} ${asset.ticker}`}
               baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
               fiatValue={`$${(
-                convertToFiat(parseFloat(amount), getAssetRate(asset)) +
-                convertToFiat(parseFloat(totalEtherEgress), getAssetRate(baseAsset))
+                convertToFiat(parseFloat(amount), assetRate) +
+                convertToFiat(parseFloat(totalEtherEgress), baseAssetRate)
               ).toFixed(2)}`}
             />
           )}

--- a/common/v2/components/TransactionFlow/TransactionReceipt.tsx
+++ b/common/v2/components/TransactionFlow/TransactionReceipt.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Address, Button, Copyable } from '@mycrypto/ui';
 
-import { ITxReceipt, ITxStatus, IStepComponentProps, TTicker } from 'v2/types';
+import { ITxReceipt, ITxStatus, IStepComponentProps } from 'v2/types';
 import { Amount, TimeElapsedCounter } from 'v2/components';
 import { AddressBookContext, AccountContext } from 'v2/services/Store';
 import { RatesContext } from 'v2/services/RatesProvider';
@@ -30,7 +30,7 @@ export default function TransactionReceipt({
   resetFlow,
   completeButtonText
 }: IStepComponentProps & Props) {
-  const { getRate } = useContext(RatesContext);
+  const { getRateFromAsset } = useContext(RatesContext);
   const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
   const { addNewTransactionToAccount } = useContext(AccountContext);
   const [txStatus, setTxStatus] = useState(ITxStatus.PENDING);
@@ -93,6 +93,7 @@ export default function TransactionReceipt({
   const localTimestamp = new Date(Math.floor(timestamp * 1000)).toLocaleString();
   const assetAmount = displayTxReceipt.amount || txConfig.amount;
   const assetTicker = 'asset' in displayTxReceipt ? displayTxReceipt.asset.ticker : 'ETH';
+  const assetForRateFetch = 'asset' in displayTxReceipt ? displayTxReceipt.asset : undefined;
   return (
     <div className="TransactionReceipt">
       <div className="TransactionReceipt-row">
@@ -126,7 +127,7 @@ export default function TransactionReceipt({
             assetValue={`${parseFloat(assetAmount).toFixed(6)} ${assetTicker}`}
             fiatValue={`$${convertToFiat(
               parseFloat(assetAmount),
-              getRate(assetTicker as TTicker)
+              getRateFromAsset(assetForRateFetch)
             ).toFixed(2)}
             `}
           />

--- a/common/v2/components/TransactionFlow/TransactionReceipt.tsx
+++ b/common/v2/components/TransactionFlow/TransactionReceipt.tsx
@@ -30,7 +30,7 @@ export default function TransactionReceipt({
   resetFlow,
   completeButtonText
 }: IStepComponentProps & Props) {
-  const { getRateFromAsset } = useContext(RatesContext);
+  const { getAssetRate } = useContext(RatesContext);
   const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
   const { addNewTransactionToAccount } = useContext(AccountContext);
   const [txStatus, setTxStatus] = useState(ITxStatus.PENDING);
@@ -127,7 +127,7 @@ export default function TransactionReceipt({
             assetValue={`${parseFloat(assetAmount).toFixed(6)} ${assetTicker}`}
             fiatValue={`$${convertToFiat(
               parseFloat(assetAmount),
-              getRateFromAsset(assetForRateFetch)
+              getAssetRate(assetForRateFetch)
             ).toFixed(2)}
             `}
           />

--- a/common/v2/components/TransactionFlow/displays/TransactionFeeDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionFeeDisplay.tsx
@@ -7,14 +7,14 @@ interface Props {
   baseAsset: Asset;
   gasLimitToUse: string;
   gasPriceToUse: string;
-  fiatAsset: { fiat: string; value: string; symbol: string };
+  fiatAsset: { fiat: string; rate: string; symbol: string };
 }
 
 function TransactionFeeDisplay({ baseAsset, gasLimitToUse, gasPriceToUse, fiatAsset }: Props) {
   const transactionFeeETH: number = gasStringsToMaxGasNumber(gasPriceToUse, gasLimitToUse);
   const baseAssetSymbol: string = baseAsset.ticker || 'ETH';
 
-  const fiatValue: string = (parseFloat(fiatAsset.value) * transactionFeeETH).toFixed(4);
+  const fiatValue: string = (parseFloat(fiatAsset.rate) * transactionFeeETH).toFixed(4);
 
   return (
     <React.Fragment>

--- a/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
+++ b/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 
 import { StoreContext, RatesContext, TokenInfoService } from 'v2/services';
-import { TTicker, AssetWithDetails, ExtendedAsset } from 'v2/types';
+import { AssetWithDetails, ExtendedAsset } from 'v2/types';
 import { TokenList } from './TokenList';
 import { TokenDetails } from './TokenDetails';
 import { AddToken } from './AddToken';
@@ -14,7 +14,7 @@ export function TokenPanel() {
   const [isScanning, setIsScanning] = useState(false);
 
   const { accounts, totals, currentAccounts, scanTokens } = useContext(StoreContext);
-  const { getRate, rates } = useContext(RatesContext);
+  const { getRateFromAsset, rates } = useContext(RatesContext);
 
   const handleScanTokens = async (asset?: ExtendedAsset) => {
     try {
@@ -43,7 +43,7 @@ export function TokenPanel() {
           : [
               ...tokens,
               Object.assign(asset, {
-                rate: getRate(asset.ticker as TTicker) || 0,
+                rate: getRateFromAsset(asset) || 0,
                 details:
                   tokensDetails.find(details => details.address === asset.contractAddress) || {}
               })

--- a/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
+++ b/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
@@ -28,6 +28,7 @@ export function TokenPanel() {
   };
 
   useEffect(() => {
+    // Fetches token details by contract address
     const fetchTokenDetails = async () => {
       const selectedAccounts = currentAccounts();
       const tokenTotals = totals(selectedAccounts);
@@ -40,26 +41,22 @@ export function TokenPanel() {
   }, [accounts]);
 
   useEffect(() => {
-    const getTokensWithDetails = async () => {
-      const selectedAccounts = currentAccounts();
+    const selectedAccounts = currentAccounts();
 
-      // Add token details and token rate info to all assets that have  a contractAddress
-      const tempTokens = totals(selectedAccounts).reduce((tokens: AssetWithDetails[], asset) => {
-        return !asset.contractAddress
-          ? tokens
-          : [
-              ...tokens,
-              Object.assign(asset, {
-                rate: getRateFromAsset(asset) || 0,
-                details: tokenData.find(details => details.address === asset.contractAddress) || {}
-              })
-            ];
-      }, []);
+    // Add token details and token rate info to all assets that have a contractAddress
+    const tempTokens = totals(selectedAccounts).reduce((tokens: AssetWithDetails[], asset) => {
+      return !asset.contractAddress
+        ? tokens
+        : [
+            ...tokens,
+            Object.assign(asset, {
+              rate: getRateFromAsset(asset) || 0,
+              details: tokenData.find(details => details.address === asset.contractAddress) || {}
+            })
+          ];
+    }, []);
 
-      setAllTokens(tempTokens);
-    };
-
-    getTokensWithDetails();
+    setAllTokens(tempTokens);
   }, [accounts, rates]);
 
   return showDetailsView && currentToken ? (

--- a/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
+++ b/common/v2/features/Dashboard/components/TokenPanel/TokenPanel.tsx
@@ -15,7 +15,7 @@ export function TokenPanel() {
   const [tokenData, setTokenData] = useState([] as any[]);
 
   const { accounts, totals, currentAccounts, scanTokens } = useContext(StoreContext);
-  const { getRateFromAsset, rates } = useContext(RatesContext);
+  const { getAssetRate, rates } = useContext(RatesContext);
 
   const handleScanTokens = async (asset?: ExtendedAsset) => {
     try {
@@ -50,7 +50,7 @@ export function TokenPanel() {
         : [
             ...tokens,
             Object.assign(asset, {
-              rate: getRateFromAsset(asset) || 0,
+              rate: getAssetRate(asset) || 0,
               details: tokenData.find(details => details.address === asset.contractAddress) || {}
             })
           ];

--- a/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { translateRaw } from 'v2/translations';
 import { AnalyticsService, ANALYTICS_CATEGORIES, RatesContext } from 'v2/services';
 import { SettingsContext, StoreContext, AccountContext } from 'v2/services/Store';
-import { StoreAsset, TTicker } from 'v2/types';
+import { StoreAsset } from 'v2/types';
 import { weiToFloat, convertToFiatFromAsset } from 'v2/utils';
 import { BREAK_POINTS } from 'v2/theme';
 import { Fiats } from 'v2/config';
@@ -55,7 +55,7 @@ export function WalletBreakdown() {
   const { totals, currentAccounts } = useContext(StoreContext);
   const { accounts } = useContext(AccountContext);
   const { settings, updateSettingsAccounts } = useContext(SettingsContext);
-  const { getRate } = useContext(RatesContext);
+  const { getRateFromAsset } = useContext(RatesContext);
 
   // Track number of accounts that user has only once per session
   if (!wasNumOfAccountsTracked) {
@@ -73,7 +73,7 @@ export function WalletBreakdown() {
       name: asset.name || translateRaw('WALLET_BREAKDOWN_UNKNOWN'),
       ticker: asset.ticker,
       amount: weiToFloat(asset.balance, asset.decimal),
-      fiatValue: convertToFiatFromAsset(asset, getRate(asset.ticker as TTicker))
+      fiatValue: convertToFiatFromAsset(asset, getRateFromAsset(asset))
     }))
     .sort((a, b) => b.fiatValue - a.fiatValue);
 

--- a/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/WalletBreakdown.tsx
@@ -55,7 +55,7 @@ export function WalletBreakdown() {
   const { totals, currentAccounts } = useContext(StoreContext);
   const { accounts } = useContext(AccountContext);
   const { settings, updateSettingsAccounts } = useContext(SettingsContext);
-  const { getRateFromAsset } = useContext(RatesContext);
+  const { getAssetRate } = useContext(RatesContext);
 
   // Track number of accounts that user has only once per session
   if (!wasNumOfAccountsTracked) {
@@ -73,7 +73,7 @@ export function WalletBreakdown() {
       name: asset.name || translateRaw('WALLET_BREAKDOWN_UNKNOWN'),
       ticker: asset.ticker,
       amount: weiToFloat(asset.balance, asset.decimal),
-      fiatValue: convertToFiatFromAsset(asset, getRateFromAsset(asset))
+      fiatValue: convertToFiatFromAsset(asset, getAssetRate(asset))
     }))
     .sort((a, b) => b.fiatValue - a.fiatValue);
 

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -30,8 +30,7 @@ import {
   StoreAsset,
   WalletId,
   IFormikFields,
-  IStepComponentProps,
-  TTicker
+  IStepComponentProps
 } from 'v2/types';
 import {
   getNonce,
@@ -141,7 +140,7 @@ export default function SendAssetsForm({
   onComplete
 }: IStepComponentProps) {
   const { accounts, assets } = useContext(StoreContext);
-  const { getRate } = useContext(RatesContext);
+  const { getRateFromAsset } = useContext(RatesContext);
   const [isEstimatingGasLimit, setIsEstimatingGasLimit] = useState(false); // Used to indicate that interface is currently estimating gas.
   const [isEstimatingNonce, setIsEstimatingNonce] = useState(false); // Used to indicate that interface is currently estimating gas.
   const [isResolvingENSName, setIsResolvingENSName] = useState(false); // Used to indicate recipient-address is ENS name that is currently attempting to be resolved.
@@ -385,9 +384,7 @@ export default function SendAssetsForm({
                     }
                     fiatAsset={{
                       fiat: 'USD',
-                      value: (
-                        getRate((baseAsset.ticker as TTicker) || ('ETH' as TTicker)) || 0
-                      ).toString(),
+                      value: (getRateFromAsset(baseAsset || undefined) || 0).toString(),
                       symbol: '$'
                     }}
                   />

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -384,7 +384,7 @@ export default function SendAssetsForm({
                     }
                     fiatAsset={{
                       fiat: 'USD',
-                      value: (getAssetRate(baseAsset || undefined) || 0).toString(),
+                      rate: (getAssetRate(baseAsset || undefined) || 0).toString(),
                       symbol: '$'
                     }}
                   />

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -140,7 +140,7 @@ export default function SendAssetsForm({
   onComplete
 }: IStepComponentProps) {
   const { accounts, assets } = useContext(StoreContext);
-  const { getRateFromAsset } = useContext(RatesContext);
+  const { getAssetRate } = useContext(RatesContext);
   const [isEstimatingGasLimit, setIsEstimatingGasLimit] = useState(false); // Used to indicate that interface is currently estimating gas.
   const [isEstimatingNonce, setIsEstimatingNonce] = useState(false); // Used to indicate that interface is currently estimating gas.
   const [isResolvingENSName, setIsResolvingENSName] = useState(false); // Used to indicate recipient-address is ENS name that is currently attempting to be resolved.
@@ -384,7 +384,7 @@ export default function SendAssetsForm({
                     }
                     fiatAsset={{
                       fiat: 'USD',
-                      value: (getRateFromAsset(baseAsset || undefined) || 0).toString(),
+                      value: (getAssetRate(baseAsset || undefined) || 0).toString(),
                       symbol: '$'
                     }}
                   />

--- a/common/v2/services/ApiService/AssetMap/AssetMap.ts
+++ b/common/v2/services/ApiService/AssetMap/AssetMap.ts
@@ -1,0 +1,30 @@
+import { AxiosInstance } from 'axios';
+import { default as ApiService } from '../ApiService';
+
+let instantiated: boolean = false;
+
+const ASSET_ID_MAPPING_URL = 'https://price.mycryptoapi.com';
+
+export default class AssetMapService {
+  public static instance = new AssetMapService();
+
+  private service: AxiosInstance = ApiService.generateInstance({
+    baseURL: ASSET_ID_MAPPING_URL
+  });
+
+  constructor() {
+    if (instantiated) {
+      throw new Error(`AssetMapService has already been instantiated.`);
+    } else {
+      instantiated = true;
+    }
+  }
+
+  public getAssetMap = async () => {
+    try {
+      return this.service.get('').then(res => res.data);
+    } catch (e) {
+      throw e;
+    }
+  };
+}

--- a/common/v2/services/ApiService/AssetMap/index.ts
+++ b/common/v2/services/ApiService/AssetMap/index.ts
@@ -1,0 +1,1 @@
+export { default as AssetMapService } from './AssetMap';

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -51,7 +51,7 @@ const spliceContractAddresses = (contractAddresses: string[]): string[][] => {
   return splicedContractAddressArrays;
 };
 
-export const createParams = (contractAddresses: string[]) => {
+const createParams = (contractAddresses: string[]) => {
   const params = new URLSearchParams();
   contractAddresses.forEach(address => params.append('contractAddress', address));
   return params;

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -1,7 +1,8 @@
-import { AxiosInstance } from 'axios';
+import { AxiosInstance, AxiosResponse } from 'axios';
 
 import { default as ApiService } from '../ApiService';
 import { TOKEN_INFO_URL } from 'v2/config';
+import _ from 'lodash';
 
 let instantiated: boolean = false;
 
@@ -21,14 +22,37 @@ export default class TokenInfoService {
   }
 
   public getTokensInfo = async (contractAddresses: string[]) => {
-    const params = new URLSearchParams();
-    contractAddresses.forEach(address => params.append('contractAddress', address));
+    // Splices contract addresses for large sets of contracts to break up the calls into manageable chunks
+    const splicedContractAddressArrays = spliceContractAddresses(contractAddresses);
+    const paramsArray = splicedContractAddressArrays.map(contractAddressArray =>
+      createParams(contractAddressArray)
+    );
 
     try {
-      const response = await this.service.get('', { params });
-      return response.data;
+      return await Promise.all(
+        paramsArray.map(async (params: any) => this.service.get('', { params }))
+      ).then((returnedArray: AxiosResponse[]) =>
+        _.union(...returnedArray.map(returnObject => returnObject.data))
+      );
     } catch (e) {
       throw e;
     }
   };
 }
+
+const spliceContractAddresses = (contractAddresses: string[]): string[][] => {
+  const lengthToSplitOn = 20;
+  const splicedContractAddressArrays = [];
+  do {
+    splicedContractAddressArrays.push([...contractAddresses.splice(0, lengthToSplitOn)]);
+  } while (contractAddresses.length >= lengthToSplitOn);
+
+  splicedContractAddressArrays.push([...contractAddresses]);
+  return splicedContractAddressArrays;
+};
+
+export const createParams = (contractAddresses: string[]) => {
+  const params = new URLSearchParams();
+  contractAddresses.forEach(address => params.append('contractAddress', address));
+  return params;
+};

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -23,8 +23,7 @@ export default class TokenInfoService {
 
   public getTokensInfo = async (contractAddresses: string[]) => {
     // Splices contract addresses for large sets of contracts to break up the calls into manageable chunks
-    const splicedContractAddressArrays = spliceContractAddresses(contractAddresses);
-    const paramsArray = splicedContractAddressArrays.map(contractAddressArray =>
+    const paramsArray = _.chunk(contractAddresses, 20).map(contractAddressArray =>
       createParams(contractAddressArray)
     );
 
@@ -39,17 +38,6 @@ export default class TokenInfoService {
     }
   };
 }
-
-const spliceContractAddresses = (contractAddresses: string[]): string[][] => {
-  const lengthToSplitOn = 20;
-  const splicedContractAddressArrays = [];
-  do {
-    splicedContractAddressArrays.push([...contractAddresses.splice(0, lengthToSplitOn)]);
-  } while (contractAddresses.length >= lengthToSplitOn);
-
-  splicedContractAddressArrays.push([...contractAddresses]);
-  return splicedContractAddressArrays;
-};
 
 const createParams = (contractAddresses: string[]) => {
   const params = new URLSearchParams();

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -23,16 +23,14 @@ export default class TokenInfoService {
 
   public getTokensInfo = async (contractAddresses: string[]) => {
     // Splices contract addresses for large sets of contracts to break up the calls into manageable chunks
-    const paramsArray = _.chunk(contractAddresses, 20).map(contractAddressArray =>
+    const queryParams = _.chunk(contractAddresses, 20).map(contractAddressArray =>
       createParams(contractAddressArray)
     );
 
     try {
       return Promise.all(
-        paramsArray.map(async (params: any) => this.service.get('', { params }))
-      ).then((returnedArray: AxiosResponse[]) =>
-        _.union(...returnedArray.map(returnObject => returnObject.data))
-      );
+        queryParams.map(async (params: any) => this.service.get('', { params }))
+      ).then((res: AxiosResponse[]) => _.union(...res.map(r => r.data)));
     } catch (e) {
       throw e;
     }

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -28,7 +28,7 @@ export default class TokenInfoService {
     );
 
     try {
-      return Promise.all(
+      return await Promise.all(
         queryParams.map(async (params: any) => this.service.get('', { params }))
       ).then((res: AxiosResponse[]) => _.union(...res.map(r => r.data)));
     } catch (e) {

--- a/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
+++ b/common/v2/services/ApiService/TokenInfo/TokenInfo.ts
@@ -29,7 +29,7 @@ export default class TokenInfoService {
     );
 
     try {
-      return await Promise.all(
+      return Promise.all(
         paramsArray.map(async (params: any) => this.service.get('', { params }))
       ).then((returnedArray: AxiosResponse[]) =>
         _.union(...returnedArray.map(returnObject => returnObject.data))

--- a/common/v2/services/ApiService/index.ts
+++ b/common/v2/services/ApiService/index.ts
@@ -2,6 +2,7 @@ export { default as ApiService } from './ApiService';
 export { AnalyticsService, ANALYTICS_CATEGORIES, Params, CvarEntry } from './Analytics';
 export { subscribeToMailingList } from './emails';
 export { getDefaultEstimates, fetchGasPriceEstimates, getGasEstimate } from './Gas';
+export { AssetMapService } from './AssetMap';
 export { GithubService } from './Github';
 export { TokenInfoService } from './TokenInfo';
 export { DexService } from './Dex';

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -26,7 +26,8 @@ interface AssetMappingListObject {
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
-const ASSET_ID_MAPPING_URL = 'https://price.mycryptoapi.com/';
+const ASSET_ID_MAPPING_URL =
+  'https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json';
 const TOKEN_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
 const buildTokenQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
   ${TOKEN_RATES_URL}/?ids=${assets.join('%2C')}&vs_currencies=${currencies.join('%2c')}

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -1,26 +1,34 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { isEmpty } from 'lodash';
 
-import { StoreContext, AccountContext, SettingsContext } from 'v2/services/Store';
+import { StoreContext, AccountContext, SettingsContext, NetworkContext } from 'v2/services/Store';
 import { PollingService } from 'v2/workers';
-import { IRates, TTicker } from 'v2/types';
+import { IRates, TTicker, Asset } from 'v2/types';
+import { notUndefined, getUUIDForAsset } from 'v2/utils';
+import { checkHttpStatus, parseJSON } from './ApiService/utils';
 
 interface State {
   rates: IRates;
   getRate(ticker: TTicker): number | undefined;
+  getRateFromAsset(asset: Asset): number | undefined;
 }
 
-interface CoinGeckoListObject {
-  id: string;
-  symbol: string;
-  name: string;
+interface AssetMappingObject {
+  coinGeckoId?: string;
+  cryptoCompareId?: string;
+  coinCapId?: string;
+}
+
+interface AssetMappingListObject {
+  [key: string]: AssetMappingObject;
 }
 
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
 //const RATES_URL = 'https://proxy.mycryptoapi.com/cc/multi'
-const ASSET_ID_LIST_URL = 'https://api.coingecko.com/api/v3/coins/list';
+const ASSET_ID_MAPPING_URL =
+  'https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json';
 const TOKEN_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
 /*const buildQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
   ${RATES_URL}/?fsyms=${assets.join(',')}tsyms=${currencies.join(',')}
@@ -29,44 +37,41 @@ const buildTokenQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
   ${TOKEN_RATES_URL}/?ids=${assets.join('%2C')}&vs_currencies=${currencies.join('%2c')}
 `;
 
-const fetchCoinGeckoCoinlist = async () => {
-  const assetIdList = await fetch(ASSET_ID_LIST_URL);
-  return await assetIdList.json();
+const fetchAssetMappingList = async (): Promise<AssetMappingListObject | any> => {
+  return fetch(ASSET_ID_MAPPING_URL, {
+    mode: 'cors'
+  })
+    .then(checkHttpStatus)
+    .then(parseJSON);
 };
 
-const structureCoinGeckoTickers = (coinGeckoCoinlist: CoinGeckoListObject[], tickers: string[]) => {
-  return tickers.map(ticker => {
-    const detectedCoinListObject = coinGeckoCoinlist.find(
-      (coinListObj: CoinGeckoListObject) =>
-        coinListObj.symbol.toLowerCase() === ticker.toLowerCase()
-    );
-    return detectedCoinListObject ? detectedCoinListObject.id : ticker;
-  });
-};
-
-const destructureCoinGeckoTickers = (rates: IRates, coinGeckoCoinlist: CoinGeckoListObject[]) => {
-  Object.keys(rates).forEach(rateID => {
-    const coinGeckoObj = coinGeckoCoinlist.find(
-      (coinListObj: CoinGeckoListObject) => coinListObj.id.toLowerCase() === rateID.toLowerCase()
-    );
-    if (coinGeckoObj) {
-      rates[coinGeckoObj.symbol.toUpperCase()] = rates[coinGeckoObj.id];
-      delete rates[coinGeckoObj.id];
+const destructureCoinGeckoIds = (rates: IRates, assetMap: AssetMappingListObject): IRates => {
+  Object.keys(rates).forEach(rateKey => {
+    const rateObject = rates[rateKey];
+    delete rates[rateKey];
+    const detectedAssetUUID = Object.keys(assetMap)
+      .filter(assetMapKey => assetMap[assetMapKey].coinGeckoId)
+      .find(assetMapKey => assetMap[assetMapKey].coinGeckoId === rateKey);
+    if (detectedAssetUUID) {
+      rates[detectedAssetUUID] = rateObject;
     }
   });
   return rates;
 };
 
+const pullCoinGeckoIDs = (assetMap: AssetMappingListObject, uuids: string[]): string[] =>
+  uuids
+    .map((uuid: string) => (!assetMap || !assetMap[uuid] ? undefined : assetMap[uuid].coinGeckoId))
+    .filter(notUndefined);
+
 export const RatesContext = createContext({} as State);
 export function RatesProvider({ children }: { children: React.ReactNode }) {
   const { accounts: rawAccounts } = useContext(AccountContext);
-  const { assetTickers } = useContext(StoreContext);
+  const { assetIDs } = useContext(StoreContext);
   const { settings, updateSettingsRates } = useContext(SettingsContext);
+  const { getNetworkByName } = useContext(NetworkContext);
   const [rates, setRates] = useState(settings.rates || {});
   const [isSettingsInitialized, setIsSettingsInitialized] = useState(false);
-  /*
-
-  */
   useEffect(() => {
     if (isEmpty(rates) || isSettingsInitialized) return;
     updateSettingsRates(rates);
@@ -77,16 +82,16 @@ export function RatesProvider({ children }: { children: React.ReactNode }) {
     // Save settings rates again when the assets change.
     setIsSettingsInitialized(false);
   }, [Object.keys(rates)]);
-  const currentTickers = assetTickers();
+  const currentAssetIDs = assetIDs();
   useEffect(() => {
     // The cryptocompare api that our proxie uses fails gracefully and will return a conversion rate
     // even if some are tickers are invalid (e.g WETH, GoerliETH etc.)
-    fetchCoinGeckoCoinlist().then((coinListObjs: CoinGeckoListObject[]) => {
-      const formattedTickers = structureCoinGeckoTickers(coinListObjs, currentTickers as string[]);
+    fetchAssetMappingList().then((coinMappingObj: AssetMappingListObject) => {
+      const formattedCoinGeckoIds = pullCoinGeckoIDs(coinMappingObj, currentAssetIDs as string[]);
       const worker = new PollingService(
-        buildTokenQueryUrl(formattedTickers, DEFAULT_FIAT_PAIRS), // @TODO: figure out how to handle the conversion more elegantly then `DEFAULT_FIAT_RATE`
+        buildTokenQueryUrl(formattedCoinGeckoIds, DEFAULT_FIAT_PAIRS), // @TODO: figure out how to handle the conversion more elegantly then `DEFAULT_FIAT_RATE`
         POLLING_INTERRVAL,
-        (data: IRates) => setRates({ rates, ...destructureCoinGeckoTickers(data, coinListObjs) }),
+        (data: IRates) => setRates({ ...rates, ...destructureCoinGeckoIds(data, coinMappingObj) }),
         err => console.debug('[RatesProvider]', err)
       );
 
@@ -105,6 +110,12 @@ export function RatesProvider({ children }: { children: React.ReactNode }) {
     getRate: (ticker: TTicker) => {
       // @ts-ignore until we find a solution for TS7053 error
       return rates[ticker] ? rates[ticker].usd : DEFAULT_FIAT_RATE;
+    },
+    getRateFromAsset: (asset: Asset) => {
+      const network = getNetworkByName(asset.networkId || '');
+      const chainId = network ? network.chainId : 1;
+      const uuid = getUUIDForAsset(chainId, asset.contractAddress);
+      return rates[uuid] ? rates[uuid].usd : DEFAULT_FIAT_RATE;
     }
   };
 

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -26,13 +26,8 @@ interface AssetMappingListObject {
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
-//const RATES_URL = 'https://proxy.mycryptoapi.com/cc/multi'
-const ASSET_ID_MAPPING_URL =
-  'https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json';
+const ASSET_ID_MAPPING_URL = 'https://price.mycryptoapi.com/';
 const TOKEN_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
-/*const buildQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
-  ${RATES_URL}/?fsyms=${assets.join(',')}tsyms=${currencies.join(',')}
-`;*/
 const buildTokenQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
   ${TOKEN_RATES_URL}/?ids=${assets.join('%2C')}&vs_currencies=${currencies.join('%2c')}
 `;
@@ -103,7 +98,7 @@ export function RatesProvider({ children }: { children: React.ReactNode }) {
       worker.start();
       return terminateWorker; // make sure we terminate the previous worker on teardown.
     });
-  }, [rawAccounts]); // only update if an account has been added or removed from LocalStorage.
+  }, [rawAccounts, currentAssetIDs.length]); // only update if an account has been added or removed from LocalStorage.
 
   const state: State = {
     rates: {},

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -42,17 +42,18 @@ const fetchAssetMappingList = async (): Promise<AssetMappingListObject | any> =>
 };
 
 const destructureCoinGeckoIds = (rates: IRates, assetMap: AssetMappingListObject): IRates => {
-  Object.keys(rates).forEach(rateKey => {
-    const rateObject = rates[rateKey];
-    delete rates[rateKey];
-    const detectedAssetUUID = Object.keys(assetMap)
-      .filter(assetMapKey => assetMap[assetMapKey].coinGeckoId)
-      .find(assetMapKey => assetMap[assetMapKey].coinGeckoId === rateKey);
-    if (detectedAssetUUID) {
-      rates[detectedAssetUUID] = rateObject;
-    }
-  });
-  return rates;
+  /* {
+    "ETH":{ "usd": 123.45,"eur": 234.56 }
+  } => {
+    [uuid for coinGeckoId: = "ETH"]: { "usd": 123.45, "eur": 234.56 }
+  } */
+  const updateRateObj = (acc: any, curValue: any): IRates => {
+    const data: any = Object.keys(assetMap).find(uuid => assetMap[uuid].coinGeckoId === curValue);
+    acc[data] = rates[curValue];
+    return acc;
+  };
+
+  return Object.keys(rates).reduce(updateRateObj, {} as IRates);
 };
 
 const pullCoinGeckoIDs = (assetMap: AssetMappingListObject, uuids: string[]): string[] =>

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -10,13 +10,52 @@ interface State {
   getRate(ticker: TTicker): number | undefined;
 }
 
+interface CoinGeckoListObject {
+  id: string;
+  symbol: string;
+  name: string;
+}
+
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
-const RATES_URL = 'https://proxy.mycryptoapi.com/cc/multi';
-const buildQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
-  ${RATES_URL}/?fsyms=${assets.join(',')}&tsyms=${currencies.join(',')}
+//const RATES_URL = 'https://proxy.mycryptoapi.com/cc/multi'
+const ASSET_ID_LIST_URL = 'https://api.coingecko.com/api/v3/coins/list';
+const TOKEN_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
+/*const buildQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
+  ${RATES_URL}/?fsyms=${assets.join(',')}tsyms=${currencies.join(',')}
+`;*/
+const buildTokenQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
+  ${TOKEN_RATES_URL}/?ids=${assets.join('%2C')}&vs_currencies=${currencies.join('%2c')}
 `;
+
+const fetchCoinGeckoCoinlist = async () => {
+  const assetIdList = await fetch(ASSET_ID_LIST_URL);
+  return await assetIdList.json();
+};
+
+const structureCoinGeckoTickers = (coinGeckoCoinlist: CoinGeckoListObject[], tickers: string[]) => {
+  return tickers.map(ticker => {
+    const detectedCoinListObject = coinGeckoCoinlist.find(
+      (coinListObj: CoinGeckoListObject) =>
+        coinListObj.symbol.toLowerCase() === ticker.toLowerCase()
+    );
+    return detectedCoinListObject ? detectedCoinListObject.id : ticker;
+  });
+};
+
+const destructureCoinGeckoTickers = (rates: IRates, coinGeckoCoinlist: CoinGeckoListObject[]) => {
+  Object.keys(rates).forEach(rateID => {
+    const coinGeckoObj = coinGeckoCoinlist.find(
+      (coinListObj: CoinGeckoListObject) => coinListObj.id.toLowerCase() === rateID.toLowerCase()
+    );
+    if (coinGeckoObj) {
+      rates[coinGeckoObj.symbol.toUpperCase()] = rates[coinGeckoObj.id];
+      delete rates[coinGeckoObj.id];
+    }
+  });
+  return rates;
+};
 
 export const RatesContext = createContext({} as State);
 export function RatesProvider({ children }: { children: React.ReactNode }) {
@@ -25,7 +64,9 @@ export function RatesProvider({ children }: { children: React.ReactNode }) {
   const { settings, updateSettingsRates } = useContext(SettingsContext);
   const [rates, setRates] = useState(settings.rates || {});
   const [isSettingsInitialized, setIsSettingsInitialized] = useState(false);
+  /*
 
+  */
   useEffect(() => {
     if (isEmpty(rates) || isSettingsInitialized) return;
     updateSettingsRates(rates);
@@ -40,28 +81,30 @@ export function RatesProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     // The cryptocompare api that our proxie uses fails gracefully and will return a conversion rate
     // even if some are tickers are invalid (e.g WETH, GoerliETH etc.)
+    fetchCoinGeckoCoinlist().then((coinListObjs: CoinGeckoListObject[]) => {
+      const formattedTickers = structureCoinGeckoTickers(coinListObjs, currentTickers as string[]);
+      const worker = new PollingService(
+        buildTokenQueryUrl(formattedTickers, DEFAULT_FIAT_PAIRS), // @TODO: figure out how to handle the conversion more elegantly then `DEFAULT_FIAT_RATE`
+        POLLING_INTERRVAL,
+        (data: IRates) => setRates({ rates, ...destructureCoinGeckoTickers(data, coinListObjs) }),
+        err => console.debug('[RatesProvider]', err)
+      );
 
-    const worker = new PollingService(
-      buildQueryUrl(currentTickers, DEFAULT_FIAT_PAIRS), // @TODO: figure out how to handle the conversion more elegantly then `DEFAULT_FIAT_RATE`
-      POLLING_INTERRVAL,
-      (data: IRates) => setRates(data),
-      err => console.debug('[RatesProvider]', err)
-    );
+      const terminateWorker = () => {
+        worker.stop();
+        worker.close();
+      };
 
-    const terminateWorker = () => {
-      worker.stop();
-      worker.close();
-    };
-
-    worker.start();
-    return terminateWorker; // make sure we terminate the previous worker on teardown.
-  }, [rawAccounts, currentTickers.length]); // only update if an account has been added or removed from LocalStorage or if assets have been updated.
+      worker.start();
+      return terminateWorker; // make sure we terminate the previous worker on teardown.
+    });
+  }, [rawAccounts]); // only update if an account has been added or removed from LocalStorage.
 
   const state: State = {
     rates: {},
     getRate: (ticker: TTicker) => {
       // @ts-ignore until we find a solution for TS7053 error
-      return rates[ticker] ? rates[ticker].USD : DEFAULT_FIAT_RATE;
+      return rates[ticker] ? rates[ticker].usd : DEFAULT_FIAT_RATE;
     }
   };
 

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -26,8 +26,7 @@ interface AssetMappingListObject {
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
-const ASSET_ID_MAPPING_URL =
-  'https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json';
+const ASSET_ID_MAPPING_URL = 'https://price.mycryptoapi.com/';
 const TOKEN_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
 const buildTokenQueryUrl = (assets: TTicker[], currencies: TTicker[]) => `
   ${TOKEN_RATES_URL}/?ids=${assets.join('%2C')}&vs_currencies=${currencies.join('%2c')}

--- a/common/v2/services/RatesProvider.tsx
+++ b/common/v2/services/RatesProvider.tsx
@@ -5,7 +5,7 @@ import { StoreContext, SettingsContext } from 'v2/services/Store';
 import { PollingService } from 'v2/workers';
 import { IRates, TTicker, Asset } from 'v2/types';
 import { notUndefined } from 'v2/utils';
-import { checkHttpStatus, parseJSON } from './ApiService/utils';
+import { AssetMapService } from './ApiService';
 
 interface State {
   rates: IRates;
@@ -26,20 +26,14 @@ interface AssetMappingListObject {
 const DEFAULT_FIAT_PAIRS = ['USD', 'EUR'] as TTicker[];
 const DEFAULT_FIAT_RATE = 0;
 const POLLING_INTERRVAL = 60000;
-const ASSET_ID_MAPPING_URL =
-  'https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json';
+
 const ASSET_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
 const buildAssetQueryUrl = (assets: string[], currencies: string[]) => `
   ${ASSET_RATES_URL}/?ids=${assets}&vs_currencies=${currencies}
 `;
 
-const fetchAssetMappingList = async (): Promise<AssetMappingListObject | any> => {
-  return fetch(ASSET_ID_MAPPING_URL, {
-    mode: 'cors'
-  })
-    .then(checkHttpStatus)
-    .then(parseJSON);
-};
+const fetchAssetMappingList = async (): Promise<AssetMappingListObject | any> =>
+  AssetMapService.instance.getAssetMap();
 
 const destructureCoinGeckoIds = (rates: IRates, assetMap: AssetMappingListObject): IRates => {
   /* {

--- a/common/v2/services/Store/BalanceService.tsx
+++ b/common/v2/services/Store/BalanceService.tsx
@@ -5,7 +5,7 @@ import { FallbackProvider } from 'ethers/providers';
 import { default as BN } from 'bignumber.js';
 
 import { ETHSCAN_NETWORKS, MYCRYPTO_UNLOCK_CONTRACT_ADDRESS } from 'v2/config';
-import { TAddress, StoreAccount, StoreAsset, Asset, NodeConfig } from 'v2/types';
+import { TAddress, StoreAccount, StoreAsset, Asset, NodeConfig, Network } from 'v2/types';
 import { ProviderHandler } from 'v2/services/EthService';
 
 export interface BalanceMap {
@@ -62,7 +62,22 @@ const getAccountAssetsBalancesWithEthScan = async (account: StoreAccount) => {
   ])
     .then(addBalancesToAccount(account))
     .catch(_ => account);
-}; /*
+};
+
+export const getBaseAssetBalances = async (addresses: string[], network: Network | undefined) => {
+  if (!network) {
+    return ([] as unknown) as BalanceMap;
+  }
+  const scanner = getScannerWithProvider(new ProviderHandler(network).client);
+  return scanner
+    .getEtherBalances(addresses)
+    .then(data => {
+      return data;
+    })
+    .catch(_ => ([] as unknown) as BalanceMap);
+}; // Return an object containing the balance of the different tokens
+
+/*
 interface shitObject {
   obj: {
     networkId: string;
@@ -98,8 +113,7 @@ const groupByNetwork = (accounts: StoreAccount[]) => {
   ])
     .then(addBalancesToAccount(account))
     .catch(_ => account);
-};*/ // Return an object containing the balance of the different tokens
-// e.g { TOKEN_CONTRACT_ADDRESS: <balance> }
+};*/ // e.g { TOKEN_CONTRACT_ADDRESS: <balance> }
 const getTokenBalances = (
   provider: ProviderHandler,
   address: TAddress,

--- a/common/v2/services/Store/BalanceService.tsx
+++ b/common/v2/services/Store/BalanceService.tsx
@@ -77,43 +77,6 @@ export const getBaseAssetBalances = async (addresses: string[], network: Network
     .catch(_ => ([] as unknown) as BalanceMap);
 }; // Return an object containing the balance of the different tokens
 
-/*
-interface shitObject {
-  obj: {
-    networkId: string;
-    addresses: string[];
-  };
-  account: StoreAccount;
-}
-const groupByNetwork = (accounts: StoreAccount[]) => {
-  /*const accountNetworkIDs = accounts.map(account => account.networkId)
-  const accountsByNetwork = accounts.map(account => )
-
-  const groupToValues = accounts.reduce(({obj, account}: shitObject) => {
-    obj[account.networkId] = obj[account.networkId] || [];
-    obj[account.networkId].push(account.address);
-    return obj;
-  }, {});
-
-  const groups = Object.keys(groupToValues).map(function (key) {
-    return { networkId: key, addresses: groupToValues[key] };
-  });
-}*/
-
-/*const getAccountsAssetsBalancesWithEthScan = async (
-  accounts: StoreAccount[]
-): Promise<StoreAccount> => {
-  Get list of accounts assets for each network 
-  const accountsAssets = accounts.flatMap(account => account.assets)
-  const list = getAssetAddresses(accountsAssets) as string[];
-  const scanner = getScannerWithProvider(new ProviderHandler(account.network).client);
-  return Promise.all([
-    scanner.getEtherBalances(accounts.map(account => account.address)),
-    () => scanner.getTokensBalance(account.address, list)
-  ])
-    .then(addBalancesToAccount(account))
-    .catch(_ => account);
-};*/ // e.g { TOKEN_CONTRACT_ADDRESS: <balance> }
 const getTokenBalances = (
   provider: ProviderHandler,
   address: TAddress,

--- a/common/v2/services/Store/BalanceService.tsx
+++ b/common/v2/services/Store/BalanceService.tsx
@@ -75,7 +75,7 @@ export const getBaseAssetBalances = async (addresses: string[], network: Network
       return data;
     })
     .catch(_ => ([] as unknown) as BalanceMap);
-}; // Return an object containing the balance of the different tokens
+};
 
 const getTokenBalances = (
   provider: ProviderHandler,

--- a/common/v2/services/Store/Cache/seedCache.ts
+++ b/common/v2/services/Store/Cache/seedCache.ts
@@ -1,4 +1,4 @@
-import { IS_DEV, generateUUID } from 'v2/utils';
+import { IS_DEV, generateUUID, generateAssetUUID } from 'v2/utils';
 import {
   Fiats,
   ContractsData,
@@ -81,8 +81,8 @@ export const initNetworks = () => {
       ([, asset]) => asset.networkId === networkId
     );
 
-    const baseAssetID = generateUUID();
     const network: NetworkLegacy = NETWORKS_CONFIG[networkId];
+    const baseAssetID = generateAssetUUID(network.chainId);
     const newLocalNetwork: Network = {
       contracts: Object.keys(newContracts),
       assets: Object.keys(newAssets),

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -10,7 +10,7 @@ import {
   Asset,
   ITxReceipt
 } from 'v2/types';
-import { isArrayEqual, useInterval, convertToFiatFromAsset, getUUIDForAsset, fromTxReceiptObj } from 'v2/utils';
+import { isArrayEqual, useInterval, convertToFiatFromAsset, fromTxReceiptObj } from 'v2/utils';
 import { ProviderHandler, getTxStatus, getTimestampFromBlockNum } from 'v2/services/EthService';
 
 import { getAccountsAssetsBalances, accountUnlockVIPDetected } from './BalanceService';
@@ -29,10 +29,10 @@ interface State {
   totals(selectedAccounts?: StoreAccount[]): StoreAsset[];
   totalFiat(
     selectedAccounts?: StoreAccount[]
-  ): (getRateFromAsset: (asset: Asset) => number | undefined) => number;
+  ): (getAssetRate: (asset: Asset) => number | undefined) => number;
   currentAccounts(): StoreAccount[];
   assetTickers(targetAssets?: StoreAsset[]): TTicker[];
-  assetIDs(targetAssets?: StoreAsset[]): any[];
+  assetUUIDs(targetAssets?: StoreAsset[]): any[];
   scanTokens(asset?: ExtendedAsset): Promise<void[]>;
   deleteAccountFromCache(uuid: string): void;
 }
@@ -50,7 +50,7 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
   } = useContext(AccountContext);
   const { assets } = useContext(AssetContext);
   const { settings, updateSettingsAccounts } = useContext(SettingsContext);
-  const { networks, getNetworkByName } = useContext(NetworkContext);
+  const { networks } = useContext(NetworkContext);
   const [pendingTransactions, setPendingTransactions] = useState([] as ITxReceipt[]);
   // We transform rawAccounts into StoreAccount. Since the operation is exponential to the number of
   // accounts, make sure it is done only when rawAccounts change.
@@ -144,27 +144,17 @@ export const StoreProvider = ({ children }: { children: React.ReactNode }) => {
     totals: (selectedAccounts = state.accounts) =>
       Object.values(getTotalByAsset(state.assets(selectedAccounts))),
     totalFiat: (selectedAccounts = state.accounts) => (
-      getRateFromAsset: (asset: Asset) => number | undefined
+      getAssetRate: (asset: Asset) => number | undefined
     ) =>
       state
         .totals(selectedAccounts)
-        .reduce((sum, asset) => (sum += convertToFiatFromAsset(asset, getRateFromAsset(asset))), 0),
+        .reduce((sum, asset) => (sum += convertToFiatFromAsset(asset, getAssetRate(asset))), 0),
     currentAccounts: () => getDashboardAccounts(state.accounts, settings.dashboardAccounts),
     assetTickers: (targetAssets = state.assets()) => [
       ...new Set(targetAssets.map(a => a.ticker as TTicker))
     ],
-    assetIDs: (targetAssets = state.assets()) => [
-      ...new Set(
-        targetAssets
-          .map((a: StoreAsset) => {
-            const network = getNetworkByName(a.networkId || '');
-            const chainId = network ? network.chainId : 1;
-            return { address: a.contractAddress, chainId };
-          })
-          .map(({ address, chainId }: { address: string; chainId: number }) =>
-            getUUIDForAsset(chainId, address)
-          )
-      )
+    assetUUIDs: (targetAssets = state.assets()) => [
+      ...new Set(targetAssets.map((a: StoreAsset) => a.uuid))
     ],
     scanTokens: async (asset?: ExtendedAsset) =>
       Promise.all(

--- a/common/v2/types/asset.tsx
+++ b/common/v2/types/asset.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from 'ethers/utils';
 import { NetworkId, TSymbol } from 'v2/types';
 
 enum TickerBrand {}
-export type TTicker = TickerBrand & string;
+export type TTicker = TickerBrand | string;
 
 export interface IAsset {
   symbol: TSymbol;

--- a/common/v2/types/asset.tsx
+++ b/common/v2/types/asset.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from 'ethers/utils';
 import { NetworkId, TSymbol } from 'v2/types';
 
 enum TickerBrand {}
-export type TTicker = TickerBrand | string;
+export type TTicker = TickerBrand & string;
 
 export interface IAsset {
   symbol: TSymbol;

--- a/common/v2/types/rates.ts
+++ b/common/v2/types/rates.ts
@@ -1,5 +1,3 @@
-import { TTicker } from './asset';
-
 // We use the response from the api which takes the form of
 // {
 //   ETH: {
@@ -8,5 +6,5 @@ import { TTicker } from './asset';
 //   }
 // }
 export type IRates = {
-  [k in TTicker]: any;
+  [k in string]: any;
 };

--- a/common/v2/utils/generateUUID.tsx
+++ b/common/v2/utils/generateUUID.tsx
@@ -1,4 +1,6 @@
 import * as crypto from 'crypto';
+import getUuid from 'uuid-by-string';
+import { toChecksumAddress } from 'ethereumjs-util';
 
 // TODO: If used for anything other than generating public ids, look up a more-secure way to do this.
 export const generateUUID = (): string => {
@@ -15,3 +17,6 @@ export const generateUUID = (): string => {
     hexstring.substring(20);
   return uuid;
 };
+
+export const getUUIDForAsset = (chainId: string | number, address?: string) =>
+  address ? getUuid(`${chainId}-${toChecksumAddress(address)}`) : getUuid(chainId.toString());

--- a/common/v2/utils/generateUUID.tsx
+++ b/common/v2/utils/generateUUID.tsx
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import getUuid from 'uuid-by-string';
 import { toChecksumAddress } from 'ethereumjs-util';
+import { TTicker } from 'v2/types';
 
 // TODO: If used for anything other than generating public ids, look up a more-secure way to do this.
 export const generateUUID = (): string => {
@@ -18,5 +19,7 @@ export const generateUUID = (): string => {
   return uuid;
 };
 
-export const getUUIDForAsset = (chainId: string | number, address?: string) =>
-  address ? getUuid(`${chainId}-${toChecksumAddress(address)}`) : getUuid(chainId.toString());
+export const generateAssetUUID = (chainId: string | number, address?: string): TTicker =>
+  address
+    ? (getUuid(`${chainId}-${toChecksumAddress(address)}`) as TTicker)
+    : (getUuid(chainId.toString()) as TTicker);

--- a/common/v2/utils/index.ts
+++ b/common/v2/utils/index.ts
@@ -4,7 +4,7 @@ export * from './validators';
 export { IS_ELECTRON, IS_MOBILE, IS_DOWNLOADABLE } from './platform';
 export { HAS_WEB3_PROVIDER, IS_DEV, IS_PROD } from './environment';
 export { getFeaturedOS } from './getFeaturedOS';
-export { generateUUID } from './generateUUID';
+export { generateUUID, getUUIDForAsset } from './generateUUID';
 export { isUrl } from './isUrl';
 export { truncate } from './truncate';
 export { useOnClickOutside } from './useOnClickOutside';

--- a/common/v2/utils/index.ts
+++ b/common/v2/utils/index.ts
@@ -4,7 +4,7 @@ export * from './validators';
 export { IS_ELECTRON, IS_MOBILE, IS_DOWNLOADABLE } from './platform';
 export { HAS_WEB3_PROVIDER, IS_DEV, IS_PROD } from './environment';
 export { getFeaturedOS } from './getFeaturedOS';
-export { generateUUID, getUUIDForAsset } from './generateUUID';
+export { generateUUID, generateAssetUUID } from './generateUUID';
 export { isUrl } from './isUrl';
 export { truncate } from './truncate';
 export { useOnClickOutside } from './useOnClickOutside';

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "trezor-connect": "7.0.1",
     "trezor.js": "6.17.5",
     "uuid": "3.2.1",
+    "uuid-by-string": "^3.0.2",
     "wallet-address-validator": "0.2.4",
     "whatwg-fetch": "2.0.3",
     "yup": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "trezor-connect": "7.0.1",
     "trezor.js": "6.17.5",
     "uuid": "3.2.1",
-    "uuid-by-string": "^3.0.2",
+    "uuid-by-string": "3.0.2",
     "wallet-address-validator": "0.2.4",
     "whatwg-fetch": "2.0.3",
     "yup": "0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16420,6 +16420,14 @@ uuid-by-string@^3.0.1:
     js-md5 "^0.7.3"
     js-sha1 "^0.6.0"
 
+uuid-by-string@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uuid-by-string/-/uuid-by-string-3.0.2.tgz#40e7a2049224715f566a13169f1f178aee42ac00"
+  integrity sha512-XA0BuWgMte7RcwEdM+AJOtQWVogkpQkWGX6bEgnYFWSkp4yebZTeapNvGZWZUX+T1/lo6kL+8nY7AczLI+Bjfw==
+  dependencies:
+    js-md5 "^0.7.3"
+    js-sha1 "^0.6.0"
+
 uuid@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16412,18 +16412,18 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid-by-string@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid-by-string/-/uuid-by-string-3.0.1.tgz#c5dcfc6b978f459d6a62d9c0d51e7e9b95d3707d"
-  integrity sha512-QmKVi1frS4jClppxJKFbPW07sY+EosIK494lR6A63IT+ywEQI2m2GFz27TQWU8N67VzrhkY0eUa9REhn+oc24Q==
+uuid-by-string@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uuid-by-string/-/uuid-by-string-3.0.2.tgz#40e7a2049224715f566a13169f1f178aee42ac00"
+  integrity sha512-XA0BuWgMte7RcwEdM+AJOtQWVogkpQkWGX6bEgnYFWSkp4yebZTeapNvGZWZUX+T1/lo6kL+8nY7AczLI+Bjfw==
   dependencies:
     js-md5 "^0.7.3"
     js-sha1 "^0.6.0"
 
-uuid-by-string@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/uuid-by-string/-/uuid-by-string-3.0.2.tgz#40e7a2049224715f566a13169f1f178aee42ac00"
-  integrity sha512-XA0BuWgMte7RcwEdM+AJOtQWVogkpQkWGX6bEgnYFWSkp4yebZTeapNvGZWZUX+T1/lo6kL+8nY7AczLI+Bjfw==
+uuid-by-string@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid-by-string/-/uuid-by-string-3.0.1.tgz#c5dcfc6b978f459d6a62d9c0d51e7e9b95d3707d"
+  integrity sha512-QmKVi1frS4jClppxJKFbPW07sY+EosIK494lR6A63IT+ywEQI2m2GFz27TQWU8N67VzrhkY0eUa9REhn+oc24Q==
   dependencies:
     js-md5 "^0.7.3"
     js-sha1 "^0.6.0"


### PR DESCRIPTION
[ch3535] [ch3536]
### Description
Migrate from cryptocompare to coingecko. Use asset mapping from mycryptohq/assets

Fixes handling token detail fetches for large amounts of assets.
Fixes a bug that results in token detail fetches occurring 8x times for every one time it needs to be run.

### ToDo:
- [x] Fix cors / csp issue with https://price.mycryptoapi.com.

~If you want to test before this csp /cors issue is fixed, find and replace `https://price.mycryptoapi.com` with `https://raw.githubusercontent.com/MyCryptoHQ/assets/master/assets/assets.json`~