### PR TITLE
Remove LOVE token

### DIFF
--- a/common/config/tokens/eth.json
+++ b/common/config/tokens/eth.json
@@ -5278,13 +5278,6 @@
     "uuid": "9f563cf7-f883-5459-845e-5021a2f58629"
   },
   {
-    "address": "0x5a276Aeb77bCfDAc8Ac6f31BBC7416AE1A85eEF2",
-    "symbol": "LOVE",
-    "decimal": 0,
-    "name": "Love",
-    "uuid": "1e917c91-e52b-5997-af67-2ffd01843701"
-  },
-  {
     "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
     "symbol": "LPT",
     "decimal": 18,


### PR DESCRIPTION
Note: not on prod, but in 1.7.4 release candidate.

One of those lovely contracts that mess up our interface by returning insane values :eyes: 

![image](https://user-images.githubusercontent.com/11412480/69528187-1e49c300-0fb1-11ea-98e3-c73eee21ff0d.png)

From the [contract](https://etherscan.io/address/0x5a276Aeb77bCfDAc8Ac6f31BBC7416AE1A85eEF2#code):

```
function balanceOf(address _owner) public view returns (uint256 balance) {
      return MAX_UINT256;
}
```