### PR TITLE
Return missing properties from MnemonicWallet

### DIFF
--- a/common/v2/components/SignTransactionWallets/Mnemonic.tsx
+++ b/common/v2/components/SignTransactionWallets/Mnemonic.tsx
@@ -125,7 +125,8 @@ export default class SignTransactionMnemonic extends Component<
   private async getPublicKey() {
     this.setState({ isSigning: true });
     try {
-      const wallet = await ethers.Wallet.fromMnemonic(this.state.phrase, this.state.selectedDPath);
+      const { senderAccount } = this.props;
+      const wallet = await ethers.Wallet.fromMnemonic(this.state.phrase, senderAccount.dPath);
       const checkSumAddress = utils.getAddress(wallet.address);
       this.checkPublicKeyMatchesCache(checkSumAddress);
     } catch (err) {

--- a/common/v2/components/SignTransactionWallets/Mnemonic.tsx
+++ b/common/v2/components/SignTransactionWallets/Mnemonic.tsx
@@ -14,7 +14,6 @@ interface MnemonicValueState {
   seed: string;
   phrase: string;
   pass: string;
-  selectedDPath: string;
   walletState: WalletSigningState;
   isSigning: boolean;
 }
@@ -33,7 +32,6 @@ export default class SignTransactionMnemonic extends Component<
     seed: '',
     phrase: '',
     pass: '',
-    selectedDPath: '',
     walletState: WalletSigningState.UNKNOWN,
     isSigning: false
   };
@@ -149,12 +147,9 @@ export default class SignTransactionMnemonic extends Component<
   }
 
   private async signTransaction() {
-    const { rawTransaction } = this.props;
+    const { rawTransaction, senderAccount } = this.props;
 
-    const signerWallet = await ethers.Wallet.fromMnemonic(
-      this.state.phrase,
-      this.state.selectedDPath
-    );
+    const signerWallet = await ethers.Wallet.fromMnemonic(this.state.phrase, senderAccount.dPath);
     const rawSignedTransaction: any = await signerWallet.sign(rawTransaction);
     this.props.onSuccess(rawSignedTransaction);
   }

--- a/common/v2/services/WalletService/deterministic/mnemonic.ts
+++ b/common/v2/services/WalletService/deterministic/mnemonic.ts
@@ -8,4 +8,11 @@ export const MnemonicWallet = (
   pass: string | undefined,
   path: string,
   address: string
-) => signWrapper(fromPrivateKey(decryptMnemonicToPrivKey(phrase, pass, path, address)));
+) =>
+  Object.assign(
+    signWrapper(fromPrivateKey(decryptMnemonicToPrivKey(phrase, pass, path, address))),
+    {
+      address,
+      path
+    }
+  );


### PR DESCRIPTION
- add missing properties to be returned from MnemonicWallet
- read dPath from sender account instead from state