### PR TITLE
Use stateMutability payable param if exists

### DIFF
--- a/common/v2/features/InteractWithContracts/components/GeneratedInteractionForm.tsx
+++ b/common/v2/features/InteractWithContracts/components/GeneratedInteractionForm.tsx
@@ -14,7 +14,8 @@ import {
   generateFunctionFieldsDisplayNames,
   getFunctionsFromABI,
   setFunctionOutputValues,
-  constructGasCallProps
+  constructGasCallProps,
+  isPayable
 } from '../helpers';
 import { FieldLabel, BooleanOutputField, BooleanSelector } from './fields';
 import WriteForm from './WriteForm';
@@ -272,16 +273,15 @@ export default function GeneratedInteractionForm({
             <SpinnerWrapper>{isLoading && <Spinner size="x2" />}</SpinnerWrapper>
             {error && <InlineErrorMsg>{error}</InlineErrorMsg>}
             <ActionWrapper>
-              {isRead &&
-                (inputs.length > 0 && (
-                  <ActionButton onClick={() => submitFormRead(currentFunction)}>
-                    {translateRaw('ACTION_16')}
-                  </ActionButton>
-                ))}
+              {isRead && inputs.length > 0 && (
+                <ActionButton onClick={() => submitFormRead(currentFunction)}>
+                  {translateRaw('ACTION_16')}
+                </ActionButton>
+              )}
               {!isRead && (
                 <WriteFormWrapper>
                   <HorizontalLine />
-                  {currentFunction.payable && (
+                  {isPayable(currentFunction) && (
                     <FieldWrapper>
                       <InputField
                         label={translateRaw('VALUE')}

--- a/common/v2/features/InteractWithContracts/helpers.ts
+++ b/common/v2/features/InteractWithContracts/helpers.ts
@@ -24,7 +24,7 @@ import { AbiFunction } from 'v2/services/EthService/contracts/ABIFunction';
 
 import { StateMutabilityType, ABIItem, ABIItemType } from './types';
 
-export const isReadOperation = (abiFunction: ABIItem) => {
+export const isReadOperation = (abiFunction: ABIItem): boolean => {
   const { stateMutability } = abiFunction;
 
   if (stateMutability) {
@@ -34,6 +34,11 @@ export const isReadOperation = (abiFunction: ABIItem) => {
   } else {
     return !!abiFunction.constant;
   }
+};
+
+export const isPayable = (abiFunction: ABIItem): boolean => {
+  const { stateMutability } = abiFunction;
+  return stateMutability ? stateMutability === StateMutabilityType.PAYABLE : !!abiFunction.payable;
 };
 
 export const generateFunctionFieldsDisplayNames = (abiFunction: ABIItem) => {
@@ -85,9 +90,10 @@ export const setFunctionOutputValues = (abiFunction: ABIItem, outputValues: any)
 };
 
 export const getFunctionsFromABI = (pAbi: ABIItem[]) =>
-  sortBy(pAbi.filter(x => x.type === ABIItemType.FUNCTION), item => item.name.toLowerCase()).map(
-    x => Object.assign(x, { label: x.name })
-  );
+  sortBy(
+    pAbi.filter(x => x.type === ABIItemType.FUNCTION),
+    item => item.name.toLowerCase()
+  ).map(x => Object.assign(x, { label: x.name }));
 
 export const WALLET_STEPS: SigningComponents = {
   [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,


### PR DESCRIPTION
The deprecated `payable` and `constant` fields were removed from the ABI JSON output of Solidity with 0.6.0. The functionality is replaced with the `stateMutability` field. In this PR we added support for the `stateMutability `field when interacting with contracts

[ch4282]