### PR TITLE
Load preload.js after Electron intialization

### DIFF
--- a/electron-app/preload/index.ts
+++ b/electron-app/preload/index.ts
@@ -1,2 +1,5 @@
 import { registerProtocol } from 'shared/enclave/preload';
-registerProtocol();
+
+process.once('loaded', () => {
+  registerProtocol();
+});


### PR DESCRIPTION
Triggering preload after Electron has loaded its internal initialization script, removes the 'Unable to load preload' error

[ch4277]