### PR TITLE
Disable nodeIntegration and enable contextIsolation

### DIFF
--- a/electron-app/main/window.ts
+++ b/electron-app/main/window.ts
@@ -26,9 +26,12 @@ export default function getWindow() {
     titleBarStyle: 'hidden',
     webPreferences: {
       devTools: true,
-      nodeIntegration: true,
-      contextIsolation: false,
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+
+      // For security reasons the following params should not be modified
+      // https://electronjs.org/docs/tutorial/security#isolation-for-untrusted-content
+      nodeIntegration: false,
+      contextIsolation: true
     }
   });
 


### PR DESCRIPTION
Disable nodeIntegration and enable contextIsolation for security reasons

https://electronjs.org/docs/tutorial/security#isolation-for-untrusted-content