### PR TITLE
Change webpack target for Electron production build

### DIFF
--- a/webpack_config/electron.production.js
+++ b/webpack_config/electron.production.js
@@ -20,7 +20,7 @@ const main = merge.smart(electronMain, {
 });
 
 const render = merge.smart(electronRender, {
-  target: 'electron-renderer',
+  target: 'web',
 
   output: {
     path: path.join(config.path.output, 'electron-js'),

--- a/webpack_config/electron.production.js
+++ b/webpack_config/electron.production.js
@@ -20,7 +20,7 @@ const main = merge.smart(electronMain, {
 });
 
 const render = merge.smart(electronRender, {
-  target: 'web',
+  target: 'web', // 'web' generates bundle that does not use Node.js functions (require, Buffer...) which would cause error when 'nodeIntegration' is disabled. (https://webpack.js.org/configuration/target/)
 
   output: {
     path: path.join(config.path.output, 'electron-js'),


### PR DESCRIPTION
Previous target value `electron-renderer` instructs webpack to use NodeTargetPlugin which should be only used if budle is running in Node.js environment.
Since we have `nodeIntegration` disabled, the bundle target should be set to `web`.