### PR TITLE
feat: Update ETC endpoint to Ethercluster

### DIFF
--- a/common/v2/database/data/nodes.ts
+++ b/common/v2/database/data/nodes.ts
@@ -80,7 +80,7 @@ export const NODES_CONFIG: { [key in NetworkId]: NodeConfig[] } = {
       name: makeNodeName('ETC', 'etccooperative'),
       type: NodeType.RPC,
       service: 'ETC Cooperative',
-      url: 'https://ethereumclassic.network'
+      url: 'https://www.ethercluster.com/etc'
     }
   ],
 


### PR DESCRIPTION
Move ETC RPC endpoint to the more advanced Ethercluster

Ethercluster is a Hyperledger Labs project built by the ETC Cooperative for scalable node architecture. It's more robust than the outdated https://ethereumclassic.network endpoint.

This fixes issue with users getting wrong balances since they're tied to an old node.