### PR TITLE
ev/copyable address component

### DIFF
--- a/common/v2/components/AccountList.scss
+++ b/common/v2/components/AccountList.scss
@@ -1,3 +1,0 @@
-.AccountList {
-  //
-}

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -1,10 +1,10 @@
 import React, { useContext, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { Button, Copyable, Identicon } from '@mycrypto/ui';
+import { Button, Identicon } from '@mycrypto/ui';
 
 import { translateRaw } from 'v2/translations';
 import { ROUTE_PATHS, Fiats } from 'v2/config';
-import { CollapsibleTable, Network, RowDeleteOverlay, RouterLink } from 'v2/components';
+import { EthAddress, CollapsibleTable, Network, RowDeleteOverlay, RouterLink } from 'v2/components';
 import { default as Typography } from 'v2/components/Typography'; // @TODO solve Circular Dependency issue
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
@@ -114,7 +114,14 @@ export const screenIsMobileSized = (breakpoint: number): boolean =>
   window.matchMedia(`(max-width: ${breakpoint}px)`).matches;
 
 export default function AccountList(props: AccountListProps) {
-  const { accounts: displayAccounts, className, deletable, favoritable, copyable, dashboard } = props;
+  const {
+    accounts: displayAccounts,
+    className,
+    deletable,
+    favoritable,
+    copyable,
+    dashboard
+  } = props;
   const { deleteAccountFromCache } = useContext(StoreContext);
   const { updateAccount } = useContext(AccountContext);
   const [deletingIndex, setDeletingIndex] = useState();
@@ -215,7 +222,12 @@ function buildAccountTable(
           <SIdenticon address={account.address} />
           <STypography bold={true} value={label} />
         </Label>,
-        <Copyable key={index} text={account.address} truncate={truncate} isCopyable={copyable} />,
+        <EthAddress
+          key={index}
+          address={account.address}
+          truncate={truncate}
+          isCopyable={copyable}
+        />,
         <Network key={index} color="#a682ff">
           {account.networkId}
         </Network>,

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -4,8 +4,14 @@ import { Button, Identicon } from '@mycrypto/ui';
 
 import { translateRaw } from 'v2/translations';
 import { ROUTE_PATHS, Fiats } from 'v2/config';
-import { EthAddress, CollapsibleTable, Network, RowDeleteOverlay, RouterLink } from 'v2/components';
-import { default as Typography } from 'v2/components/Typography'; // @TODO solve Circular Dependency issue
+import {
+  EthAddress,
+  CollapsibleTable,
+  Network,
+  RowDeleteOverlay,
+  RouterLink,
+  Typography
+} from 'v2/components';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, breakpointToNumber } from 'v2/theme';
 import { ExtendedAccount, AddressBook, StoreAccount } from 'v2/types';
@@ -17,7 +23,6 @@ import {
   AddressBookContext
 } from 'v2/services/Store';
 import { DashboardPanel } from './DashboardPanel';
-import './AccountList.scss';
 import { RatesContext } from 'v2/services';
 import { default as Currency } from './Currency';
 import { TUuid } from 'v2/types/uuid';
@@ -25,21 +30,18 @@ import { TUuid } from 'v2/types/uuid';
 const Label = styled.span`
   display: flex;
   align-items: center;
+  @media (min-width: ${BREAK_POINTS.SCREEN_SM} {
+    font-weight: bold;
+  })
 `;
 
 const SIdenticon = styled(Identicon)`
   img {
     height: 2em;
   }
-  margin-right: 10px;
+  margin-right: 0.8em;
   @media (min-width: ${BREAK_POINTS.SCREEN_SM}) {
-    margin-right: 27px;
-  }
-`;
-
-const STypography = styled(Typography)`
-  @media (min-width: ${BREAK_POINTS.SCREEN_SM}) {
-    font-weight: inherit;
+    margin-right: 1em;
   }
 `;
 
@@ -80,8 +82,11 @@ const FavoriteButton = styled(Button)`
 
 const DeleteButton = styled(Button)`
   align-self: flex-end;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 0.7em;
-  width: 20px;
+  width: 100%;
 `;
 
 const TableContainer = styled.div`
@@ -189,11 +194,14 @@ function buildAccountTable(
     translateRaw('ACCOUNT_LIST_NETWORK'),
     <HeaderAlignment key={'ACCOUNT_LIST_VALUE'} align="center">
       {translateRaw('ACCOUNT_LIST_VALUE')}
+    </HeaderAlignment>,
+    <HeaderAlignment key={'ACCOUNT_LIST_DELETE'} align="center">
+      {translateRaw('ACCOUNT_LIST_DELETE')}
     </HeaderAlignment>
   ];
 
   return {
-    head: deletable ? [...columns, translateRaw('ACCOUNT_LIST_DELETE')] : columns,
+    head: deletable ? columns : columns.slice(0, columns.length - 1),
     overlay:
       overlayRows && overlayRows[0] !== undefined ? (
         <RowDeleteOverlay
@@ -220,7 +228,7 @@ function buildAccountTable(
       const bodyContent = [
         <Label key={index}>
           <SIdenticon address={account.address} />
-          <STypography bold={true} value={label} />
+          <Typography value={label} />
         </Label>,
         <EthAddress
           key={index}
@@ -268,9 +276,7 @@ function buildAccountTable(
         const aLabel = a.props.label;
         const bLabel = b.props.label;
         return aLabel === bLabel ? true : aLabel.localeCompare(bLabel);
-      },
-      hiddenHeadings: deletable ? [translateRaw('ACCOUNT_LIST_DELETE')] : undefined,
-      iconColumns: deletable ? [translateRaw('ACCOUNT_LIST_DELETE')] : undefined
+      }
     }
   };
 }

--- a/common/v2/components/DashboardPanel.tsx
+++ b/common/v2/components/DashboardPanel.tsx
@@ -10,6 +10,20 @@ import { Panel } from './Panel';
 import RouterLink from './RouterLink';
 import Typography from './Typography';
 
+const SRouterLink = styled(RouterLink)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  & span,
+  p,
+  div {
+    color: ${COLORS.BRIGHT_SKY_BLUE};
+  }
+  & img {
+    margin-right: 0.5em;
+  }
+`;
+
 const Content = styled.div`
   padding-left: 15px;
   padding-right: 15px;
@@ -20,13 +34,6 @@ const DPanel = styled(Panel)`
 `;
 
 const DHeadingWrapper = styled.div`
-  & span {
-    color: ${COLORS.BRIGHT_SKY_BLUE};
-    padding-right: 15px;
-  }
-  & img {
-    margin-right: 0.5em;
-  }
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -76,10 +83,10 @@ export const DashboardPanel = ({
         <DHeading>{heading}</DHeading>
         {headingRight &&
           (actionLink ? (
-            <RouterLink to={actionLink}>
+            <SRouterLink to={actionLink}>
               <img src={settingsIcon} alt={'settings'} width={32} />
               <Typography>{headingRight}</Typography>
-            </RouterLink>
+            </SRouterLink>
           ) : (
             headingRight
           ))}

--- a/common/v2/components/EthAddress.tsx
+++ b/common/v2/components/EthAddress.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Copyable } from '@mycrypto/ui';
+
+import { COLORS } from 'v2/theme';
+
+// Override styles of @mycrypto/ui in order to vertically align text and icon.
+// Ensure the icon uses the discrete color.
+const Overrides = styled.div`
+  & button {
+    vertical-align: middle;
+    font-size: 1em;
+    line-height: 24px;
+  }
+  & button span {
+    display: inline-flex;
+    height: 100%;
+    align-items: center;
+    vertical-align: middle;
+    margin-top: -0.1ch;
+    line-height: 24px;
+  }
+  & button svg {
+    height: 0.8em;
+    color: ${COLORS.CLOUDY_BLUE};
+  }
+`;
+interface Props {
+  address: string;
+  isCopyable?: boolean;
+  truncate: any;
+}
+
+function EthAddress({ address, isCopyable = true, truncate }: Props) {
+  return (
+    <Overrides>
+      <Copyable text={address.toLowerCase()} isCopyable={isCopyable} truncate={truncate} />
+    </Overrides>
+  );
+}
+
+export default EthAddress;

--- a/common/v2/components/Network.tsx
+++ b/common/v2/components/Network.tsx
@@ -5,6 +5,12 @@ import { size } from 'polished';
 import { scale } from '@mycrypto/ui';
 import { default as Typography } from './Typography';
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
 const Color = styled.div`
   background: ${props => props.color};
 
@@ -16,10 +22,10 @@ const Color = styled.div`
 
 export function Network({ children, color }: { children: ReactNode; color: string }) {
   return (
-    <>
+    <Container>
       <Color color={color} />
       <Typography as="span">{children}</Typography>
-    </>
+    </Container>
   );
 }
 

--- a/common/v2/components/Typography.tsx
+++ b/common/v2/components/Typography.tsx
@@ -14,10 +14,13 @@ interface Props {
 type SProps = Props & { forwardedAs: string };
 
 const STypography = styled(UITypography)`
-  line-height: 1.5;
+  line-height: 24px;
   vertical-align: middle;
   font-weight: ${(p: SProps) => (p.bold ? '600' : '400')};
   font-size: ${(p: SProps) => p.fontSize} !important;
+  // UITypography component defaults to a 'p' tag with a margin-bottom.
+  // To facilitate text and icon alignement we remove it here once and for all.
+  margin-bottom: 0px;
 `;
 
 function Typography({ as = 'span', value, fontSize = '1rem', bold, children, ...props }: Props) {

--- a/common/v2/components/index.ts
+++ b/common/v2/components/index.ts
@@ -59,3 +59,4 @@ export { default as HelpLink } from './HelpLink';
 export { default as ParityQrSigner } from './ParityQrSigner';
 export { default as TranslateMarkdown } from './TranslateMarkdown';
 export { default as GasSelector } from './GasSelector';
+export { default as EthAddress } from './EthAddress';

--- a/common/v2/features/Settings/components/AddressBook.tsx
+++ b/common/v2/features/Settings/components/AddressBook.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Icon, Copyable, Identicon, Button } from '@mycrypto/ui';
+import { Icon, Identicon, Button } from '@mycrypto/ui';
 
 import {
   DashboardPanel,
   CollapsibleTable,
   RowDeleteOverlay,
   Network,
-  Typography
+  Typography,
+  EthAddress
 } from 'v2/components';
 import { ExtendedAddressBook } from 'v2/types';
 import { truncate } from 'v2/utils';
@@ -91,7 +92,7 @@ export default function AddressBook({ addressBook, toggleFlipped, deleteAddressB
         <SIdenticon address={address} />
         <STypography bold={true} value={label} />
       </Label>,
-      <Copyable key={2} text={address} truncate={truncate} isCopyable={true} />,
+      <EthAddress key={2} address={address} truncate={truncate} isCopyable={true} />,
       <Network key={3} color="#a682ff">
         {network}
       </Network>,


### PR DESCRIPTION
### Quick style fixes to stop eye bleeding. 

**The Problem**
<img width="837" alt="Screenshot 2020-01-23 at 17 50 38" src="https://user-images.githubusercontent.com/2429708/73005261-f340eb80-3e08-11ea-83f8-a0455a1b4632.png">



**Fixes:**
1. Create EthAddress and align and style copy icon with text.
<img width="202" alt="Screenshot 2020-01-23 at 17 43 34" src="https://user-images.githubusercontent.com/2429708/73004597-e96ab880-3e07-11ea-9771-b527ffd68168.png">

2. Fix AccountList row alignement and styles
<img width="965" alt="Screenshot 2020-01-23 at 17 47 17" src="https://user-images.githubusercontent.com/2429708/73004929-6dbd3b80-3e08-11ea-93e6-9805a373b73b.png">

3. Ensure that Link to Settings is inline
<img width="773" alt="Screenshot 2020-01-23 at 17 48 12" src="https://user-images.githubusercontent.com/2429708/73005080-9c3b1680-3e08-11ea-9dc1-5e24193031e5.png">

