### PR TITLE
Add EtherCore support

### DIFF
--- a/common/config/dpaths.ts
+++ b/common/config/dpaths.ts
@@ -197,6 +197,11 @@ export const AUX_DEFAULT: DPath = {
   value: "m/44'/344'/0'/0"
 };
 
+export const ERE_DEFAULT: DPath = {
+  label: 'Default (ERE)',
+  value: "m/44'/466'/0'/0"
+};
+
 export const DPaths: DPath[] = [
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -236,7 +241,8 @@ export const DPaths: DPath[] = [
   DEXON_DEFAULT,
   ASK_DEFAULT,
   ASK_TREZOR,
-  AUX_DEFAULT
+  AUX_DEFAULT,
+  ERE_DEFAULT
 ];
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/features/config/__snapshots__/sagas.spec.ts.snap
+++ b/common/features/config/__snapshots__/sagas.spec.ts.snap
@@ -5,7 +5,7 @@ Object {
   "@@redux-saga/IO": true,
   "SELECT": Object {
     "args": Array [
-      "AUX",
+      "ERE",
     ],
     "selector": [Function],
   },

--- a/common/features/config/networks/static/reducer.ts
+++ b/common/features/config/networks/static/reducer.ts
@@ -45,7 +45,8 @@ import {
   TOMO_DEFAULT,
   UBQ_DEFAULT,
   WEB_DEFAULT,
-  AUX_DEFAULT
+  AUX_DEFAULT,
+  ERE_DEFAULT
 } from 'config/dpaths';
 import { makeExplorer } from 'utils/helpers';
 import * as types from './types';
@@ -1022,6 +1023,30 @@ export const STATIC_NETWORKS_INITIAL_STATE: types.ConfigStaticNetworksState = {
       min: 0.1,
       max: 40,
       initial: 4
+    }
+  },
+  ERE: {
+    id: 'ERE',
+    name: 'EtherCore',
+    unit: 'ERE',
+    chainId: 466,
+    isCustom: false,
+    color: '#3a6ea7',
+    blockExplorer: makeExplorer({
+      name: 'EtherCore Explorer',
+      origin: 'https://explorer.ethercore.org'
+    }),
+    tokens: [],
+    contracts: [],
+    dPathFormats: {
+      [SecureWalletName.TREZOR]: ERE_DEFAULT,
+      [SecureWalletName.SAFE_T]: ERE_DEFAULT,
+      [InsecureWalletName.MNEMONIC_PHRASE]: ERE_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 0,
+      max: 60,
+      initial: 1
     }
   }
 };

--- a/common/libs/nodes/configs.ts
+++ b/common/libs/nodes/configs.ts
@@ -402,6 +402,15 @@ export const NODE_CONFIGS: { [key in StaticNetworkIds]: RawNodeConfig[] } = {
       service: 'auxilium.global',
       url: 'https://rpc.auxilium.global'
     }
+  ],
+
+  ERE: [
+    {
+      name: makeNodeName('ERE', 'ethercore'),
+      type: 'rpc',
+      service: 'ethercore.org',
+      url: 'https://rpc.ethercore.org'
+    }
   ]
 };
 

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -39,6 +39,7 @@ type StaticNetworkIds =
   | 'UBQ'
   | 'WEB'
   | 'AUX'
+  | 'ERE'
   | 'ASK';
 
 export interface BlockExplorerConfig {


### PR DESCRIPTION
## Description
Support **EtherCore Mainnet**, Proof of Work Ethereum compatible network.

Homepage: https://ethercore.org
Block Explorer: https://explorer.ethercore.org
RPC Endpoint: https://rpc.ethercore.org
ChainId / SLIP-44: **466** https://github.com/satoshilabs/slips/pull/847
Official Email: info@ethercore.org