### PR TITLE
Add EtherCore support

### DIFF
--- a/common/v2/config/dpaths.ts
+++ b/common/v2/config/dpaths.ts
@@ -197,6 +197,11 @@ const AUX_DEFAULT: DPath = {
   value: "m/44'/344'/0'/0"
 };
 
+const ERE_DEFAULT: DPath = {
+  label: 'Default (ERE)',
+  value: "m/44'/466'/0'/0"
+};
+
 export const DPathsList = {
   ETH_DEFAULT,
   ETH_TREZOR,
@@ -237,7 +242,8 @@ export const DPathsList = {
   ASK_DEFAULT,
   ASK_TREZOR,
   AUX_DEFAULT,
-  ETH_SINGULAR
+  ETH_SINGULAR,
+  ERE_DEFAULT
 };
 
 // PATHS TO BE INCLUDED REGARDLESS OF WALLET FORMAT

--- a/common/v2/database/data/networks.ts
+++ b/common/v2/database/data/networks.ts
@@ -983,5 +983,29 @@ export const NETWORKS_CONFIG: NetworkConfig = {
       max: 40,
       initial: 4
     }
+  },
+  ERE: {
+    id: 'ERE',
+    name: 'EtherCore',
+    unit: 'ERE' as TSymbol,
+    chainId: 466,
+    isCustom: false,
+    color: '#3a6ea7',
+    blockExplorer: makeExplorer({
+      name: 'EtherCore Explorer',
+      origin: 'https://explorer.ethercore.org'
+    }),
+    tokens: [],
+    contracts: [],
+    dPaths: {
+      [WalletId.TREZOR]: DPaths.ERE_DEFAULT,
+      [WalletId.SAFE_T]: DPaths.ERE_DEFAULT,
+      [WalletId.MNEMONIC_PHRASE]: DPaths.ERE_DEFAULT
+    },
+    gasPriceSettings: {
+      min: 0.1,
+      max: 60,
+      initial: 1
+    }
   }
 };

--- a/common/v2/database/data/nodes.ts
+++ b/common/v2/database/data/nodes.ts
@@ -402,5 +402,14 @@ export const NODES_CONFIG: { [key in NetworkId]: NodeConfig[] } = {
       service: 'auxilium.global',
       url: 'https://rpc.auxilium.global'
     }
+  ],
+
+  ERE: [
+    {
+      name: makeNodeName('ERE', 'ethercore'),
+      type: NodeType.RPC,
+      service: 'ethercore.org',
+      url: 'https://rpc.ethercore.org'
+    }
   ]
 };

--- a/common/v2/types/networkId.ts
+++ b/common/v2/types/networkId.ts
@@ -37,4 +37,5 @@ export type NetworkId =
   | 'UBQ'
   | 'WEB'
   | 'AUX'
+  | 'ERE'
   | 'ASK';

--- a/shared/types/network.d.ts
+++ b/shared/types/network.d.ts
@@ -39,6 +39,7 @@ type StaticNetworkIds =
   | 'UBQ'
   | 'WEB'
   | 'AUX'
+  | 'ERE'
   | 'ASK';
 
 export interface BlockExplorerConfig {


### PR DESCRIPTION
## Description
Support **EtherCore Mainnet**, Proof of Work Ethereum compatible network.

Homepage: https://ethercore.org
Block Explorer: https://explorer.ethercore.org
RPC Endpoint: https://rpc.ethercore.org
ChainId / SLIP-44: **466** https://github.com/satoshilabs/slips/pull/847
Official Email: info@ethercore.org