### PR TITLE
Generalized Stepper Implementation

### DIFF
--- a/common/v2/components/GeneralStepper/GeneralStepper.tsx
+++ b/common/v2/components/GeneralStepper/GeneralStepper.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { ContentPanel } from 'v2/components';
+import { translateRaw } from 'v2/translations';
+import { ROUTE_PATHS } from 'v2/config';
+
+import { IStepperPath } from './types';
+
+export interface StepperProps {
+  steps: IStepperPath[];
+  defaultBackPath?: string; // Path that component reverts to when user clicks "back" from first step in flow.
+  defaultBackPathLabel?: string;
+  completeBtnText?: string; // Text for btn to navigate out of flow in last step.
+}
+
+export function GeneralStepper({
+  steps,
+  defaultBackPath,
+  defaultBackPathLabel,
+  completeBtnText
+}: StepperProps) {
+  const history = useHistory();
+  const [step, setStep] = useState(0);
+  console.debug('[GeneralStepper]: Refresh -> step: ', step);
+  const goToPrevStep = () => setStep(Math.max(0, step - 1));
+  const goToFirstStep = () => setStep(0);
+
+  const goBack = () =>
+    step === 0 ? history.push(defaultBackPath || ROUTE_PATHS.DASHBOARD.path) : goToPrevStep();
+
+  const getStep = (stepIndex: number) => {
+    const path = steps;
+    const { label, component, actions, props } = steps[stepIndex]; // tslint:disable-line
+    return { currentPath: path, label, Step: component, stepAction: actions, props };
+  };
+
+  const { currentPath, label, Step, stepAction } = getStep(step);
+
+  const getBackBtnLabel = () =>
+    Math.max(-1, step - 1) === -1
+      ? defaultBackPathLabel || translateRaw('DASHBOARD')
+      : getStep(Math.max(0, step - 1)).label;
+
+  const goToNextStep = () => {
+    console.debug('[GeneralStepper]: Trigger goToNextStep');
+    return setStep(Math.min(step + 1, currentPath.length - 1));
+  };
+
+  const stepObject = steps[step];
+  const stepProps = stepObject.props;
+  const stepActions = stepObject.actions;
+
+  return (
+    <ContentPanel
+      onBack={goBack}
+      backBtnText={getBackBtnLabel()}
+      heading={label}
+      stepper={{ current: step + 1, total: currentPath.length }}
+    >
+      <Step
+        onComplete={(payload: any) =>
+          stepAction ? stepAction(payload, goToNextStep()) : goToNextStep()
+        }
+        completeButtonText={completeBtnText || translateRaw('SEND_ASSETS_SEND_ANOTHER')}
+        resetFlow={goToFirstStep}
+        {...stepProps}
+        {...stepActions}
+      />
+    </ContentPanel>
+  );
+}
+
+export default GeneralStepper;

--- a/common/v2/components/GeneralStepper/GeneralStepper.tsx
+++ b/common/v2/components/GeneralStepper/GeneralStepper.tsx
@@ -60,7 +60,7 @@ export function GeneralStepper({
     >
       <Step
         onComplete={(payload: any) =>
-          stepAction ? stepAction(payload, goToNextStep()) : goToNextStep()
+          stepAction ? stepAction(payload, goToNextStep(), goToPrevStep()) : goToNextStep()
         }
         completeButtonText={completeBtnText || translateRaw('SEND_ASSETS_SEND_ANOTHER')}
         resetFlow={goToFirstStep}

--- a/common/v2/components/GeneralStepper/GeneralStepper.tsx
+++ b/common/v2/components/GeneralStepper/GeneralStepper.tsx
@@ -22,9 +22,13 @@ export function GeneralStepper({
 }: StepperProps) {
   const history = useHistory();
   const [step, setStep] = useState(0);
-  console.debug('[GeneralStepper]: Refresh -> step: ', step);
-  const goToPrevStep = () => setStep(Math.max(0, step - 1));
-  const goToFirstStep = () => setStep(0);
+
+  const goToPrevStep = () => {
+    return setStep(Math.max(0, step - 1));
+  };
+  const goToFirstStep = () => {
+    return setStep(0);
+  };
 
   const goBack = () =>
     step === 0 ? history.push(defaultBackPath || ROUTE_PATHS.DASHBOARD.path) : goToPrevStep();
@@ -42,15 +46,19 @@ export function GeneralStepper({
       ? defaultBackPathLabel || translateRaw('DASHBOARD')
       : getStep(Math.max(0, step - 1)).label;
 
-  const goToNextStep = () => {
-    console.debug('[GeneralStepper]: Trigger goToNextStep');
-    return setStep(Math.min(step + 1, currentPath.length - 1));
-  };
+  const goToNextStep = () => setStep(Math.min(step + 1, currentPath.length - 1));
 
   const stepObject = steps[step];
   const stepProps = stepObject.props;
   const stepActions = stepObject.actions;
-
+  console.debug(
+    '[GeneralStepper]: Rendering stepObject: ',
+    stepObject,
+    ' props: ',
+    stepProps,
+    ' actions: ',
+    stepActions
+  );
   return (
     <ContentPanel
       onBack={goBack}
@@ -60,7 +68,7 @@ export function GeneralStepper({
     >
       <Step
         onComplete={(payload: any) =>
-          stepAction ? stepAction(payload, goToNextStep(), goToPrevStep()) : goToNextStep()
+          stepAction ? stepAction(payload, goToNextStep, goToPrevStep) : goToNextStep()
         }
         completeButtonText={completeBtnText || translateRaw('SEND_ASSETS_SEND_ANOTHER')}
         resetFlow={goToFirstStep}

--- a/common/v2/components/GeneralStepper/GeneralStepper.tsx
+++ b/common/v2/components/GeneralStepper/GeneralStepper.tsx
@@ -26,6 +26,7 @@ export function GeneralStepper({
   const goToPrevStep = () => {
     return setStep(Math.max(0, step - 1));
   };
+
   const goToFirstStep = () => {
     return setStep(0);
   };
@@ -41,6 +42,9 @@ export function GeneralStepper({
 
   const { currentPath, label, Step, stepAction } = getStep(step);
 
+  // Creates the label for the btn that sends user to the previous step.
+  // If there is no previous step, you'll be going to either the default location (dashboard), or a user-specified location.
+  // If there is a previous step, you'll go to that step and it's title is used as the back btn label.
   const getBackBtnLabel = () =>
     Math.max(-1, step - 1) === -1
       ? defaultBackPathLabel || translateRaw('DASHBOARD')

--- a/common/v2/components/GeneralStepper/GeneralStepper.tsx
+++ b/common/v2/components/GeneralStepper/GeneralStepper.tsx
@@ -51,14 +51,7 @@ export function GeneralStepper({
   const stepObject = steps[step];
   const stepProps = stepObject.props;
   const stepActions = stepObject.actions;
-  console.debug(
-    '[GeneralStepper]: Rendering stepObject: ',
-    stepObject,
-    ' props: ',
-    stepProps,
-    ' actions: ',
-    stepActions
-  );
+
   return (
     <ContentPanel
       onBack={goBack}

--- a/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
+++ b/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
@@ -1,31 +1,26 @@
 import React from 'react';
-
+import { MemoryRouter, Switch, Route } from 'react-router-dom';
 import { simpleRender, fireEvent } from 'test-utils';
 
 import GeneralStepper, { StepperProps } from '../GeneralStepper';
-import { MemoryRouter, Switch, Route } from 'react-router-dom';
 
-const ExampleButtonComponent = ({ onComplete, onCompleteText }: any) => {
-  return (
-    <>
-      <button onClick={() => onComplete(onCompleteText)}>Click Me</button>
-    </>
-  );
-};
+const ExampleButtonComponent = ({ onComplete, onCompleteText }: any) => (
+  <>
+    <button onClick={() => onComplete(onCompleteText)}>Click Me</button>
+  </>
+);
 
 const ExampleButtonFinalComponent = ({
   onComplete,
   onCompleteText,
   resetFlow,
   completeButtonText
-}: any) => {
-  return (
-    <>
-      <button onClick={() => onComplete(onCompleteText)}>Click Me</button>
-      <button onClick={() => resetFlow()}>{completeButtonText}</button>
-    </>
-  );
-};
+}: any) => (
+  <>
+    <button onClick={() => onComplete(onCompleteText)}>Click Me</button>
+    <button onClick={() => resetFlow()}>{completeButtonText}</button>
+  </>
+);
 
 const functionTest = (textTriggered: string, cb: any) => {
   console.debug('textTriggered: ', textTriggered);

--- a/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
+++ b/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { simpleRender, fireEvent } from 'test-utils';
+
+import GeneralStepper, { StepperProps } from '../GeneralStepper';
+import { MemoryRouter } from 'react-router-dom';
+
+const ExampleButtonComponent = ({ onComplete, onCompleteText }: any) => {
+  return (
+    <>
+      <button onClick={onComplete(onCompleteText)}>Click Me</button>
+    </>
+  );
+};
+
+const functionTest = (textTriggered: string, cb: any) => {
+  console.debug('textTriggered: ', textTriggered);
+  cb();
+};
+const testSteps = [
+  {
+    label: 'Test Component 1',
+    component: ExampleButtonComponent,
+    props: { onCompleteText: 'Finished this1' },
+    actions: (payload: any, cb: any) => functionTest(payload, cb)
+  },
+  {
+    label: 'Test Component 2',
+    component: ExampleButtonComponent,
+    props: { onCompleteText: 'Finished this2' },
+    actions: (payload: any, cb: any) => functionTest(payload, cb)
+  }
+];
+
+const defaultBackPath = '/dashboard';
+const defaultBackPathLabel = 'Dashboard';
+const completeBtnText = 'Finished';
+
+const defaultProps: StepperProps = {
+  steps: testSteps,
+  defaultBackPath,
+  defaultBackPathLabel,
+  completeBtnText
+};
+
+const StepperComponent = (props: StepperProps, path?: any) => (
+  <MemoryRouter initialEntries={path ? [path] : undefined}>
+    <GeneralStepper {...props} />
+  </MemoryRouter>
+);
+
+function getComponent(props: StepperProps) {
+  return simpleRender(<StepperComponent {...props} />);
+}
+
+describe('GeneralStepper', () => {
+  test('it renders the steps correctly with the continue on button rendered.', async () => {
+    const { getByText } = getComponent(defaultProps);
+    const text = getByText('Test Component 1');
+    expect(text).toBeInTheDocument();
+  });
+  test('it renders step two when goToNext is clicked', async () => {
+    const { getByText } = getComponent(defaultProps);
+    const text = getByText('Click Me');
+    fireEvent.click(text);
+    const newText = getByText('Test Component 2');
+    expect(newText).toBeInTheDocument();
+  });
+  test('it renders step 1 when goBack is clicked from step 2', async () => {
+    const { getByText } = getComponent(defaultProps);
+    const text = getByText('Click Me');
+    fireEvent.click(text);
+    const goBackButton = getByText('Back : Test Component 1');
+    fireEvent.click(goBackButton);
+    const stepOneText = getByText('Test Component 1');
+    expect(stepOneText).toBeInTheDocument();
+  });
+});

--- a/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
+++ b/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
@@ -43,31 +43,28 @@ const defaultProps: StepperProps = {
   completeBtnText
 };
 
-const StepperComponent = (props: StepperProps, path?: any) => (
-  <MemoryRouter initialEntries={path ? [path] : undefined}>
-    <GeneralStepper {...props} />
-  </MemoryRouter>
-);
-
-function getComponent(props: StepperProps) {
-  return simpleRender(<StepperComponent {...props} />);
-}
-
 describe('GeneralStepper', () => {
+  const StepperComponent = (props: StepperProps, path?: any) => (
+    <MemoryRouter initialEntries={path ? [path] : undefined}>
+      <GeneralStepper {...props} />
+    </MemoryRouter>
+  );
+  const renderComponent = (props: StepperProps) => simpleRender(<StepperComponent {...props} />);
+
   test('it renders step 1 correctly first', async () => {
-    const { getByText } = getComponent(defaultProps);
+    const { getByText } = renderComponent(defaultProps);
     const text = getByText('Test Component 1'); // The header for step 1
     expect(text).toBeInTheDocument();
   });
   test('it renders step 2 when goToNext is clicked in step 1', async () => {
-    const { getByText } = getComponent(defaultProps);
+    const { getByText } = renderComponent(defaultProps);
     const text = getByText('Click Me');
     fireEvent.click(text); // Go to step 2
     const newText = getByText('Test Component 2'); // The header for step 2
     expect(newText).toBeInTheDocument();
   });
   test('it renders step 1 when back button is clicked from step 2', async () => {
-    const { getByText } = getComponent(defaultProps);
+    const { getByText } = renderComponent(defaultProps);
     const text = getByText('Click Me');
     fireEvent.click(text); // Go to step 2
     const goBackButton = getByText('Back : Test Component 1'); // The back button when step 2 is rendered

--- a/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
+++ b/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
@@ -54,25 +54,25 @@ function getComponent(props: StepperProps) {
 }
 
 describe('GeneralStepper', () => {
-  test('it renders the steps correctly with the continue on button rendered.', async () => {
+  test('it renders step 1 correctly first', async () => {
     const { getByText } = getComponent(defaultProps);
-    const text = getByText('Test Component 1');
+    const text = getByText('Test Component 1'); // The header for step 1
     expect(text).toBeInTheDocument();
   });
-  test('it renders step two when goToNext is clicked', async () => {
+  test('it renders step 2 when goToNext is clicked in step 1', async () => {
     const { getByText } = getComponent(defaultProps);
     const text = getByText('Click Me');
-    fireEvent.click(text);
-    const newText = getByText('Test Component 2');
+    fireEvent.click(text); // Go to step 2
+    const newText = getByText('Test Component 2'); // The header for step 2
     expect(newText).toBeInTheDocument();
   });
-  test('it renders step 1 when goBack is clicked from step 2', async () => {
+  test('it renders step 1 when back button is clicked from step 2', async () => {
     const { getByText } = getComponent(defaultProps);
     const text = getByText('Click Me');
-    fireEvent.click(text);
-    const goBackButton = getByText('Back : Test Component 1');
+    fireEvent.click(text); // Go to step 2
+    const goBackButton = getByText('Back : Test Component 1'); // The back button when step 2 is rendered
     fireEvent.click(goBackButton);
-    const stepOneText = getByText('Test Component 1');
+    const stepOneText = getByText('Test Component 1'); // The header for step 1
     expect(stepOneText).toBeInTheDocument();
   });
 });

--- a/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
+++ b/common/v2/components/GeneralStepper/__tests__/GeneralStepper.test.tsx
@@ -22,8 +22,7 @@ const ExampleButtonFinalComponent = ({
   </>
 );
 
-const functionTest = (textTriggered: string, cb: any) => {
-  console.debug('textTriggered: ', textTriggered);
+const functionTest = (_: string, cb: any) => {
   cb();
 };
 const testSteps = [

--- a/common/v2/components/GeneralStepper/index.ts
+++ b/common/v2/components/GeneralStepper/index.ts
@@ -1,0 +1,2 @@
+export { default as GeneralStepper } from './GeneralStepper';
+export * from './types';

--- a/common/v2/components/GeneralStepper/index.ts
+++ b/common/v2/components/GeneralStepper/index.ts
@@ -1,2 +1,1 @@
-export { default as GeneralStepper } from './GeneralStepper';
-export * from './types';
+export { default } from './GeneralStepper';

--- a/common/v2/components/GeneralStepper/types.ts
+++ b/common/v2/components/GeneralStepper/types.ts
@@ -1,0 +1,14 @@
+export type TStepAction = (payload: any, after: () => void) => void;
+
+export interface IStepperComponentProps {
+  completeButtonText: string;
+  resetFlow(): void;
+  onComplete(payload?: any): void;
+}
+
+export interface IStepperPath {
+  label: string;
+  component: any;
+  actions?: any;
+  props?: any;
+}

--- a/common/v2/components/GeneralStepper/types.ts
+++ b/common/v2/components/GeneralStepper/types.ts
@@ -9,6 +9,6 @@ export interface IStepperComponentProps {
 export interface IStepperPath {
   label: string;
   component: any;
-  actions?: any;
   props?: any;
+  actions?(payload?: any, cb?: any, cbTwo?: any): any;
 }

--- a/common/v2/components/GeneralStepper/types.ts
+++ b/common/v2/components/GeneralStepper/types.ts
@@ -10,5 +10,5 @@ export interface IStepperPath {
   label: string;
   component: any;
   props?: any;
-  actions?(payload?: any, cb?: any, cbTwo?: any): any;
+  actions?(payload?: any, cb?: any, cbTwo?: any): any; // cb = goToNextStep; cbTwo = goToPrevStep
 }

--- a/common/v2/components/index.ts
+++ b/common/v2/components/index.ts
@@ -63,3 +63,4 @@ export { default as LinkOut } from './LinkOut';
 export { default as EthAddress } from './EthAddress';
 export { default as EditableText } from './EditableText';
 export { default as Account } from './Account';
+export { default as GeneralStepper } from './GeneralStepper';

--- a/common/v2/features/SendAssets/SendAssets.tsx
+++ b/common/v2/features/SendAssets/SendAssets.tsx
@@ -1,27 +1,24 @@
-import React, { useState } from 'react';
-import { RouteComponentProps } from 'react-router';
+import React from 'react';
 
-import { ContentPanel } from 'v2/components';
+import { GeneralStepper } from 'v2/components';
 import { useStateReducer } from 'v2/utils';
-import { WalletId, ITxReceipt, IFormikFields } from 'v2/types';
-import { ROUTE_PATHS } from 'v2/config';
+import { WalletId, ITxReceipt, ISignedTx, IFormikFields, ITxConfig } from 'v2/types';
 import { ConfirmTransaction, TransactionReceipt } from 'v2/components/TransactionFlow';
 import { translateRaw } from 'v2/translations';
 
 import { SendAssetsForm, SignTransaction } from './components';
 import { txConfigInitialState, TxConfigFactory } from './stateFactory';
-import { IPath } from './types';
+import { IStepperPath } from 'v2/components/GeneralStepper/types';
+import { ROUTE_PATHS } from 'v2/config';
 
-function SendAssets({ history }: RouteComponentProps<{}>) {
-  const [step, setStep] = useState(0);
+function SendAssets() {
   const {
     handleFormSubmit,
     handleConfirmAndSign,
     handleConfirmAndSend,
     handleSignedTx,
     handleSignedWeb3Tx,
-    txConfig: txConfigState,
-    txReceipt: txReceiptState
+    txFactoryState
   } = useStateReducer(TxConfigFactory, { txConfig: txConfigInitialState, txReceipt: null });
 
   // tslint:disable-next-line
@@ -29,74 +26,72 @@ function SendAssets({ history }: RouteComponentProps<{}>) {
 
   // Due to MetaMask deprecating eth_sign method,
   // it has different step order, where sign and send are one panel
-  const web3Steps: IPath[] = [
-    { label: 'Send Assets', component: SendAssetsForm, action: handleFormSubmit },
+  const web3Steps: IStepperPath[] = [
     {
-      label: translateRaw('CONFIRM_TX_MODAL_TITLE'),
-      component: ConfirmTransaction,
-      action: handleConfirmAndSign
+      label: 'Send Assets',
+      component: SendAssetsForm,
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: IFormikFields, cb: any) => handleFormSubmit(payload, cb)
     },
-    { label: '', component: SignTransaction, action: handleSignedWeb3Tx },
-    {
-      label: translateRaw('TRANSACTION_BROADCASTED'),
-      component: TransactionReceipt,
-      action: goToDashoard
-    }
-  ];
-
-  const defaultSteps: IPath[] = [
-    { label: 'Send Assets', component: SendAssetsForm, action: handleFormSubmit },
-    { label: '', component: SignTransaction, action: handleSignedTx },
     {
       label: translateRaw('CONFIRM_TX_MODAL_TITLE'),
       component: ConfirmTransaction,
-      action: handleConfirmAndSend
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: ITxConfig, cb: any) => handleConfirmAndSign(payload, cb)
+    },
+    {
+      label: '',
+      component: SignTransaction,
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: ITxReceipt | ISignedTx, cb: any) => handleSignedWeb3Tx(payload, cb)
     },
     {
       label: translateRaw('TRANSACTION_BROADCASTED'),
       component: TransactionReceipt,
-      action: goToDashoard
+      actions: () => goToDashoard,
+      props: (({ txConfig, txReceipt }) => ({ txConfig, txReceipt }))(txFactoryState)
     }
   ];
 
-  const getStep = (walletId: WalletId, stepIndex: number) => {
-    const path = walletId === WalletId.METAMASK ? web3Steps : defaultSteps;
-    const { label, component, action } = path[stepIndex]; // tslint:disable-line
-    return { currentPath: path, label, Step: component, stepAction: action };
-  };
+  const defaultSteps: IStepperPath[] = [
+    {
+      label: 'Send Assets',
+      component: SendAssetsForm,
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: IFormikFields, cb: any) => handleFormSubmit(payload, cb)
+    },
+    {
+      label: '',
+      component: SignTransaction,
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: ITxConfig | ISignedTx, cb: any) => handleSignedTx(payload, cb)
+    },
+    {
+      label: translateRaw('CONFIRM_TX_MODAL_TITLE'),
+      component: ConfirmTransaction,
+      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      actions: (payload: ITxConfig | ISignedTx, cb: any) => handleConfirmAndSend(payload, cb)
+    },
+    {
+      label: translateRaw('TRANSACTION_BROADCASTED'),
+      component: TransactionReceipt,
+      actions: goToDashoard,
+      props: (({ txConfig, txReceipt }) => ({ txConfig, txReceipt }))(txFactoryState)
+    }
+  ];
 
-  const { senderAccount } = txConfigState;
+  const { senderAccount } = txFactoryState && txFactoryState.txConfig;
 
-  const { currentPath, label, Step, stepAction } = getStep(
-    senderAccount ? senderAccount.wallet : undefined,
-    step
-  );
-  const getBackBtnLabel = () =>
-    Math.max(-1, step - 1) === -1
-      ? translateRaw('DASHBOARD')
-      : getStep(senderAccount ? senderAccount.wallet : undefined, Math.max(0, step - 1)).label;
-
-  const goToNextStep = () => setStep(Math.min(step + 1, currentPath.length - 1));
-  const goToPrevStep = () => setStep(Math.max(0, step - 1));
-  const goToFirstStep = () => setStep(0);
-
-  const goBack = () => (step === 0 ? history.push(ROUTE_PATHS.DASHBOARD.path) : goToPrevStep());
+  const walletId = senderAccount ? senderAccount.wallet : undefined;
+  const steps = walletId === WalletId.METAMASK ? web3Steps : defaultSteps;
 
   return (
-    <ContentPanel
-      onBack={goBack}
-      backBtnText={getBackBtnLabel()}
-      heading={label}
-      stepper={{ current: step + 1, total: currentPath.length }}
-    >
-      <Step
-        txReceipt={txReceiptState}
-        txConfig={txConfigState}
-        onComplete={(payload: IFormikFields | ITxReceipt) => stepAction(payload, goToNextStep)}
-        completeButtonText={translateRaw('SEND_ASSETS_SEND_ANOTHER')}
-        resetFlow={goToFirstStep}
-      />
-    </ContentPanel>
+    <GeneralStepper
+      steps={steps}
+      defaultBackPath={ROUTE_PATHS.DASHBOARD.path}
+      defaultBackPathLabel={translateRaw('DASHBOARD')}
+      completeBtnText={translateRaw('SEND_ASSETS_SEND_ANOTHER')}
+    />
   );
 }
 

--- a/common/v2/features/SendAssets/SendAssets.tsx
+++ b/common/v2/features/SendAssets/SendAssets.tsx
@@ -22,7 +22,7 @@ function SendAssets() {
   } = useStateReducer(TxConfigFactory, { txConfig: txConfigInitialState, txReceipt: null });
 
   // tslint:disable-next-line
-  const goToDashoard = () => {};
+  const goToDashboard = () => {};
 
   // Due to MetaMask deprecating eth_sign method,
   // it has different step order, where sign and send are one panel
@@ -48,7 +48,7 @@ function SendAssets() {
     {
       label: translateRaw('TRANSACTION_BROADCASTED'),
       component: TransactionReceipt,
-      actions: () => goToDashoard,
+      actions: () => goToDashboard,
       props: (({ txConfig, txReceipt }) => ({ txConfig, txReceipt }))(txFactoryState)
     }
   ];
@@ -75,7 +75,7 @@ function SendAssets() {
     {
       label: translateRaw('TRANSACTION_BROADCASTED'),
       component: TransactionReceipt,
-      actions: goToDashoard,
+      actions: goToDashboard,
       props: (({ txConfig, txReceipt }) => ({ txConfig, txReceipt }))(txFactoryState)
     }
   ];

--- a/common/v2/features/SendAssets/SendAssets.tsx
+++ b/common/v2/features/SendAssets/SendAssets.tsx
@@ -21,6 +21,7 @@ function SendAssets() {
     txFactoryState
   } = useStateReducer(TxConfigFactory, { txConfig: txConfigInitialState, txReceipt: null });
 
+  // goToDashboard is defaulted to do-nothing, because goToNextStep handles redirect location.
   // tslint:disable-next-line
   const goToDashboard = () => {};
 
@@ -48,7 +49,7 @@ function SendAssets() {
     {
       label: translateRaw('TRANSACTION_BROADCASTED'),
       component: TransactionReceipt,
-      actions: () => goToDashboard,
+      actions: goToDashboard,
       props: (({ txConfig, txReceipt }) => ({ txConfig, txReceipt }))(txFactoryState)
     }
   ];

--- a/common/v2/features/SendAssets/__tests__/SendAssets.test.tsx
+++ b/common/v2/features/SendAssets/__tests__/SendAssets.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { simpleRender } from 'test-utils';
+
+// New
+import SendAssets from 'v2/features/SendAssets/SendAssets';
+import { StoreContext } from 'v2/services/Store';
+import { RatesContext } from 'v2/services/RatesProvider';
+
+/* Test components */
+describe('SendAssetsFlow', () => {
+  const component = (path?: string) => (
+    <MemoryRouter initialEntries={path ? [path] : undefined}>
+      <StoreContext.Provider
+        value={
+          ({
+            userAssets: [],
+            accounts: [],
+            getAccount: jest.fn(),
+            networks: []
+          } as unknown) as any
+        }
+      >
+        <RatesContext.Provider
+          value={
+            ({
+              getAssetRate: jest.fn()
+            } as unknown) as any
+          }
+        >
+          <SendAssets />;
+        </RatesContext.Provider>
+      </StoreContext.Provider>
+    </MemoryRouter>
+  );
+
+  const renderComponent = (pathToLoad?: string) => {
+    return simpleRender(component(pathToLoad));
+  };
+
+  test('Can render the first step (Send Assets Form) in the flow.', () => {
+    const { getByText } = renderComponent();
+    const selector = 'Send Assets';
+    expect(getByText(selector)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

This pr introduces a Generalized Stepper that is implemented into the Send-Assets flow. It also adds a number of tests to make sure that it works correctly :open_mouth:. This will be used in DeFiZap implementation. Eventually other flows should have it incorporated. in order to reduce QA time, it's only been introduced into one flow so far (Send Assets).

### Steps to Test:
1) Add an account (metamask or another normal (non-Frame) wallet type) on https://mycryptobuilds.com/pr/2996/
2) Attempt to send a transaction using this account in the normal Send Assets flow (https://mycryptobuilds.com/pr/2996/#/send).
3) Does it work? Does it stall on one of the steps from send flow?

#### ToDo:
- [x] Implement into flow (Send Flow)
- [x] React Testing Implementation