### PR TITLE
Swap input sanity checks

### DIFF
--- a/common/v2/features/SwapAssets/stateFactory.tsx
+++ b/common/v2/features/SwapAssets/stateFactory.tsx
@@ -100,6 +100,24 @@ const SwapFlowFactory: TUseStateReducerFactory<SwapState> = ({ state, setState }
       return;
     }
 
+    if(value.length === 0) {
+      setState((prevState: SwapState) => ({
+        ...prevState,
+        toAmount: '',
+        fromAmount: ''
+      }));
+      return;
+    }
+
+    if(parseFloat(value)<=0) {
+      setState((prevState: SwapState) => ({
+        ...prevState,
+        isCalculatingFromAmount: false,
+        toAmountError: translate('SWAP_ZERO_VALUE')
+      }));
+      return;
+    }
+
     try {
       setState((prevState: SwapState) => ({
         ...prevState,
@@ -135,6 +153,24 @@ const SwapFlowFactory: TUseStateReducerFactory<SwapState> = ({ state, setState }
   const calculateNewToAmount = async (value: string) => {
     const { fromAsset, toAsset } = state;
     if (!fromAsset || !toAsset) {
+      return;
+    }
+
+    if(value.length === 0) {
+      setState((prevState: SwapState) => ({
+        ...prevState,
+        toAmount: '',
+        fromAmount: ''
+      }));
+      return;
+    }
+
+    if(parseFloat(value)<=0) {
+      setState((prevState: SwapState) => ({
+        ...prevState,
+        isCalculatingToAmount: false,
+        fromAmountError: translate('SWAP_ZERO_VALUE')
+      }));
       return;
     }
 

--- a/common/v2/translations/lang/en.json
+++ b/common/v2/translations/lang/en.json
@@ -82,6 +82,7 @@
     "SWAP_CONFIRM_TITLE": "Confirm Swap",
     "SWAP_ALLOWANCE_TITLE": "Set allowance",
     "SWAP_SETTING_ALLOWANCE": "Setting allowance...",
+    "SWAP_ZERO_VALUE": "Make sure you are inputting a value greater than 0.",
     "MSG_MESSAGE": "Message ",
     "MSG_DATE": "Date ",
     "MSG_SIGNATURE": "Signature ",


### PR DESCRIPTION
🎉 🎉 🎉

## Description

Added some input sanity validation to reduce the will-be-error responses from dexag and added logic to show a more logical error message.

* If the user clears one of the inputs, clear all swap inputs and don't send a request to dexag that will result in a 400 bad request
* If the user inputs a send/receive input of `0`, show a better error message and don't send a request to dexag that will result in a 400 bad request
* If the user inputs a send/receive input of `-n`, show a better error message and don't send a request to dexag that will result in a 400 bad request

We are now doing sanity checks to make sure we _should_ send a request to DEXAG without it intentionally resulting in a 400 bad request.

![image](https://user-images.githubusercontent.com/2313704/73504216-8dcf9a80-43c6-11ea-9cdb-4768da2e7a04.png)


## Changes

* Sanity checks on input with the swap input event handlers

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
