### PR TITLE
Allow Authereum frame source

### DIFF
--- a/webpack_config/common.js
+++ b/webpack_config/common.js
@@ -164,7 +164,7 @@ module.exports = {
       },
       metaCsp: IS_DEVELOPMENT
         ? ''
-        : "default-src 'none'; script-src 'self'; worker-src 'self' blob:; child-src 'self'; style-src 'self' 'unsafe-inline'; manifest-src 'self'; font-src 'self'; img-src 'self' data: https://cdn.mycryptoapi.com/; connect-src *; frame-src 'self' https://connect.trezor.io;"
+        : "default-src 'none'; script-src 'self'; worker-src 'self' blob:; child-src 'self'; style-src 'self' 'unsafe-inline'; manifest-src 'self'; font-src 'self'; img-src 'self' data: https://cdn.mycryptoapi.com/; connect-src *; frame-src 'self' https://connect.trezor.io https://x.authereum.com;"
     }),
 
     new CopyWebpackPlugin([


### PR DESCRIPTION
Adds the domain x.authereum.com to the CSP `frame-src` options to allow loading of secured sandboxed iframe used for ephemeral key management. [Authereum key architecture explained](https://medium.com/authereum/authereum-key-architecture-explained-8e0781cf3ea0)