### PR TITLE
Better ENS Validation

### DIFF
--- a/common/v2/components/AddressField.tsx
+++ b/common/v2/components/AddressField.tsx
@@ -3,8 +3,9 @@ import { Identicon } from '@mycrypto/ui';
 import { FieldProps, Field } from 'formik';
 import styled from 'styled-components';
 
-import { DomainStatus } from 'v2/components';
 import { Network, InlineMessageType } from 'v2/types';
+import { DomainStatus } from 'v2/components';
+import { getIsValidENSAddressFunction } from 'v2/services/EthService';
 import { monospace } from 'v2/theme';
 import { ResolutionError } from '@unstoppabledomains/resolution';
 import InputField from './InputField';
@@ -117,10 +118,13 @@ function ETHAddressField({
                   if (!network || !network.chainId) {
                     return;
                   }
-                  const action = handleDomainResolve
-                    ? (domainName: string) => handleDomainResolve(domainName)
-                    : (address: string) =>
-                        form.setFieldValue(fieldName, { display: address, value: address });
+                  const isValidENSAddress = getIsValidENSAddressFunction(network.chainId);
+                  const isENSAddress = isValidENSAddress(e.currentTarget.value);
+                  const action =
+                    isENSAddress && handleDomainResolve
+                      ? (domainName: string) => handleDomainResolve(domainName)
+                      : (address: string) =>
+                          form.setFieldValue(fieldName, { display: address, value: address });
                   await action(e.currentTarget.value);
                   form.setFieldTouched(fieldName);
                   if (onBlur) {

--- a/common/v2/components/DomainStatus.tsx
+++ b/common/v2/components/DomainStatus.tsx
@@ -25,10 +25,10 @@ export const DomainStatus: React.FC<DomainStatusProps> = (props: DomainStatusPro
   );
 
   if (props.isLoading) return spinner();
-  if (props.domain === '') return <div data-testid="domainStatus">{''}</div>;
   if (props.isError || props.resolutionError) {
     return parseError(props.resolutionError);
   }
+  if (props.domain === '') return <div data-testid="domainStatus">{''}</div>;
   return (
     <div data-testid="domainStatus">{`${translateRaw('SEND_ASSETS_DID_RESOLVE')}: ${
       props.rawAddress

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -179,7 +179,9 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
         .test(
           'check-eth-address',
           translateRaw('TO_FIELD_ERROR'),
-          value => isValidETHAddress(value) || isValidENSName(value)
+          value =>
+            isValidETHAddress(value) ||
+            (isValidENSName(value) && UnstoppableResolution.isValidDomain(value))
         )
         // @ts-ignore Hack as Formik doesn't officially support warnings
         // tslint:disable-next-line

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -48,7 +48,8 @@ import {
   isValidPositiveNumber,
   isTransactionFeeHigh,
   isChecksumAddress,
-  isBurnAddress
+  isBurnAddress,
+  isValidENSName
 } from 'v2/services/EthService';
 import UnstoppableResolution from 'v2/services/UnstoppableService';
 import { fetchGasPriceEstimates, getGasEstimate } from 'v2/services/ApiService';
@@ -178,7 +179,7 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
         .test(
           'check-eth-address',
           translateRaw('TO_FIELD_ERROR'),
-          value => isValidETHAddress(value) || UnstoppableResolution.isValidDomain(value)
+          value => isValidETHAddress(value) || isValidENSName(value)
         )
         // @ts-ignore Hack as Formik doesn't officially support warnings
         // tslint:disable-next-line
@@ -258,15 +259,7 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
         onSubmit={fields => {
           onComplete(fields);
         }}
-        render={({
-          errors,
-          setFieldValue,
-          setFieldError,
-          setFieldTouched,
-          touched,
-          values,
-          handleChange
-        }) => {
+        render={({ errors, setFieldValue, setFieldTouched, touched, values, handleChange }) => {
           const toggleAdvancedOptions = () => {
             setFieldValue('advancedTransaction', !values.advancedTransaction);
           };
@@ -323,7 +316,6 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
                 ...values.address,
                 value: ''
               });
-              setFieldError('address', translateRaw('TO_FIELD_ERROR'));
               if (UnstoppableResolution.isResolutionError(err)) {
                 setResolutionError(err);
               } else throw err;

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -258,7 +258,15 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
         onSubmit={fields => {
           onComplete(fields);
         }}
-        render={({ errors, setFieldValue, setFieldTouched, touched, values, handleChange }) => {
+        render={({
+          errors,
+          setFieldValue,
+          setFieldError,
+          setFieldTouched,
+          touched,
+          values,
+          handleChange
+        }) => {
           const toggleAdvancedOptions = () => {
             setFieldValue('advancedTransaction', !values.advancedTransaction);
           };
@@ -310,6 +318,12 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
                 value: unstoppableAddress
               });
             } catch (err) {
+              // Force the field value to error so that isValidAddress is triggered!
+              setFieldValue('address', {
+                ...values.address,
+                value: ''
+              });
+              setFieldError('address', translateRaw('TO_FIELD_ERROR'));
               if (UnstoppableResolution.isResolutionError(err)) {
                 setResolutionError(err);
               } else throw err;

--- a/common/v2/services/EthService/ens/__tests__/validators.spec.ts
+++ b/common/v2/services/EthService/ens/__tests__/validators.spec.ts
@@ -4,9 +4,7 @@ describe('isValidENSName', () => {
   const valid = ['bob.eth', 'edouard.eth'];
 
   const invalid = [
-    'et.eth', // second level domain must be longer than 2
-    'edouard', // must contain domain
-    '0xbob.eth' // and is not a hex number
+    'edouard' // must contain domain
   ];
 
   it('returns true if the name is valid', () => {

--- a/common/v2/services/EthService/ens/validators.ts
+++ b/common/v2/services/EthService/ens/validators.ts
@@ -19,14 +19,15 @@ export function getValidTLDsForChain(chainId: number): ITLDCollection {
   return {
     eth: true,
     test: true,
-    reverse: true
+    reverse: true,
+    xyz: true
   };
 }
 
 export function isValidENSName(str: string) {
   try {
     return (
-      str.length > 6 && str.includes('.') && normalise(str) !== '' && str.substring(0, 2) !== '0x'
+      str.includes('.') && normalise(str) !== ''
     );
   } catch (e) {
     return false;

--- a/common/v2/services/EthService/ens/validators.ts
+++ b/common/v2/services/EthService/ens/validators.ts
@@ -26,9 +26,7 @@ export function getValidTLDsForChain(chainId: number): ITLDCollection {
 
 export function isValidENSName(str: string) {
   try {
-    return (
-      str.includes('.') && normalise(str) !== ''
-    );
+    return str.includes('.') && normalise(str) !== '';
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
[CH4517]

🎉 🎉 🎉

## Description

* Fixed bug that caused the user to be able to sign a transaction to a non-intended address if the ENS name was invalid (description in comment on ch4517)
* Adjusted logic to allow for more ENS TLDs so we can send to `*.argent.xyz` addresses
* Adjusted logic to check if a value is valid ENS name
   * Remove `0x` startswith condition because you can have a name like `0xharry.eth`
   * Remove strlen condition because short names released and we should be relying on onchain data. Too tight of a restriction for read-only interaction.

## Changes

* Added new TLD to the TLD dictionary
* Modified sanity checks

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
