### PR TITLE
Enabled signed tx in confirm panel

### DIFF
--- a/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
@@ -145,7 +145,7 @@ function TransactionDetailsDisplay({
                 <div className="TransactionDetails-row stacked">
                   <div className="TransactionDetails-row-column">Signed Transaction:</div>
                   <div className="TransactionDetails-row-data">
-                    <CopyableCodeBlock>{signedTransaction}></CopyableCodeBlock>
+                    <CopyableCodeBlock>{signedTransaction}</CopyableCodeBlock>
                   </div>
                 </div>
               </>

--- a/common/v2/features/SendAssets/SendAssets.tsx
+++ b/common/v2/features/SendAssets/SendAssets.tsx
@@ -70,7 +70,7 @@ function SendAssets() {
     {
       label: translateRaw('CONFIRM_TX_MODAL_TITLE'),
       component: ConfirmTransaction,
-      props: (({ txConfig }) => ({ txConfig }))(txFactoryState),
+      props: (({ txConfig, signedTx }) => ({ txConfig, signedTx }))(txFactoryState),
       actions: (payload: ITxConfig | ISignedTx, cb: any) => handleConfirmAndSend(payload, cb)
     },
     {

--- a/common/v2/features/SendAssets/helpers.ts
+++ b/common/v2/features/SendAssets/helpers.ts
@@ -24,7 +24,7 @@ import {
   encodeTransfer
 } from 'v2/services/EthService';
 
-export function decodeTransaction(signedTx: string) {
+export function decodeTransaction(signedTx: utils.Arrayish) {
   const decodedTransaction = utils.parseTransaction(signedTx);
   const gasLimit = bigNumGasLimitToViewable(decodedTransaction.gasLimit);
   const gasPriceGwei = bigNumGasPriceToViewableGwei(decodedTransaction.gasPrice);

--- a/common/v2/features/SendAssets/stateFactory.tsx
+++ b/common/v2/features/SendAssets/stateFactory.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { bufferToHex } from 'ethereumjs-util';
 
 import { TUseStateReducerFactory, fromTxReceiptObj } from 'v2/utils';
 import {
@@ -30,7 +31,6 @@ import { ProviderHandler } from 'v2/services/EthService';
 
 import { TStepAction } from './types';
 import { processFormDataToTx, decodeTransaction } from './helpers';
-import { bufferToHex } from 'ethereumjs-util';
 
 const txConfigInitialState = {
   tx: {

--- a/common/v2/features/SendAssets/stateFactory.tsx
+++ b/common/v2/features/SendAssets/stateFactory.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { bufferToHex } from 'ethereumjs-util';
+import { Arrayish, hexlify } from 'ethers/utils';
 
 import { TUseStateReducerFactory, fromTxReceiptObj } from 'v2/utils';
 import {
@@ -126,13 +126,10 @@ const TxConfigFactory: TUseStateReducerFactory<State> = ({ state, setState }) =>
       .finally(cb);
   };
 
-  const handleSignedTx: TStepAction = (payload: any, cb) => {
-    let signedTx = payload;
+  const handleSignedTx: TStepAction = (payload: Arrayish, cb) => {
+    const signedTx = hexlify(payload);
     // Used when signedTx is a buffer instead of a string.
     // Hardware wallets return a buffer.
-    if (typeof signedTx === 'object') {
-      signedTx = bufferToHex(signedTx);
-    }
 
     const decodedTx = decodeTransaction(payload);
     const networkDetected = getNetworkByChainId(decodedTx.chainId, networks);
@@ -200,7 +197,7 @@ const TxConfigFactory: TUseStateReducerFactory<State> = ({ state, setState }) =>
     cb();
   };
 
-  const txFactoryState = {
+  const txFactoryState: State = {
     txConfig: state.txConfig,
     txReceipt: state.txReceipt,
     signedTx: state.signedTx


### PR DESCRIPTION
### Description
Ran into an issue of there being no signed tx field in the ConfirmTransaction panel for hardware wallets.

### Steps to Test:
1) Navigate to https://mycryptobuilds.com/pr/3030/ and add a hardware wallet address.
2) Attempt to send a transaction.
3) After signing the transaction, on the confirm transaction step, click the "more details" section and see if a signed transaction field appears. does it? 