### PR TITLE
Add OBB copy to claim domain

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -6,3 +6,4 @@ Preferred-Languages: en
 Canonical: https://mycrypto.com/.well-known/security.txt
 Policy: https://hackerone.com/mycrypto?view_policy=true
 Hiring: https://about.mycrypto.com/jobs/
+OpenBugBounty: https://openbugbounty.org/bugbounty/MyCrypto/


### PR DESCRIPTION
🎉 🎉 🎉

## Description

Add line to `security.txt` to claim domain ownership on OpenBugBounty

## Changes

* Single line change

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
