### PR TITLE
Dedupe declaration of wallet signing components

### DIFF
--- a/common/v2/components/SignTransactionWallets/index.ts
+++ b/common/v2/components/SignTransactionWallets/index.ts
@@ -1,9 +1,26 @@
-export { default as SignTransactionKeystore } from './Keystore';
-export { default as SignTransactionLedger } from './Ledger';
-export { default as SignTransactionWeb3 } from './Web3';
-export { default as SignTransactionMnemonic } from './Mnemonic';
-export { default as SignTransactionParity } from './Parity';
-export { default as SignTransactionPrivateKey } from './PrivateKey';
-export { default as SignTransactionSafeT } from './SafeTmini';
-export { default as SignTransactionTrezor } from './Trezor';
-export { default as HardwareSignTransaction } from './Hardware';
+import { WalletId, SigningComponents } from 'v2/types';
+
+import { default as SignTransactionKeystore } from './Keystore';
+import { default as SignTransactionLedger } from './Ledger';
+import { default as SignTransactionWeb3 } from './Web3';
+import { default as SignTransactionMnemonic } from './Mnemonic';
+import { default as SignTransactionParity } from './Parity';
+import { default as SignTransactionPrivateKey } from './PrivateKey';
+import { default as SignTransactionSafeT } from './SafeTmini';
+import { default as SignTransactionTrezor } from './Trezor';
+
+export const WALLET_STEPS: SigningComponents = {
+  [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,
+  [WalletId.WEB3]: SignTransactionWeb3,
+  [WalletId.METAMASK]: SignTransactionWeb3,
+  [WalletId.TRUST]: SignTransactionWeb3,
+  [WalletId.FRAME]: SignTransactionWeb3,
+  [WalletId.COINBASE]: SignTransactionWeb3,
+  [WalletId.LEDGER_NANO_S]: SignTransactionLedger,
+  [WalletId.TREZOR]: SignTransactionTrezor,
+  [WalletId.SAFE_T_MINI]: SignTransactionSafeT,
+  [WalletId.KEYSTORE_FILE]: SignTransactionKeystore,
+  [WalletId.PARITY_SIGNER]: SignTransactionParity,
+  [WalletId.MNEMONIC_PHRASE]: SignTransactionMnemonic,
+  [WalletId.VIEW_ONLY]: null
+};

--- a/common/v2/features/DeployContracts/DeployContractsFlow.tsx
+++ b/common/v2/features/DeployContracts/DeployContractsFlow.tsx
@@ -3,7 +3,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { translateRaw } from 'v2/translations';
-import { ExtendedContentPanel, Tabs } from 'v2/components';
+import { ExtendedContentPanel, Tabs, WALLET_STEPS } from 'v2/components';
 import { ROUTE_PATHS } from 'v2/config';
 import { useStateReducer } from 'v2/utils';
 import { ITxReceipt, ISignedTx, Tab } from 'v2/types';
@@ -12,7 +12,6 @@ import { BREAK_POINTS } from 'v2/theme';
 import { deployContractsInitialState, DeployContractsFactory } from './stateFactory';
 import { Deploy, DeployConfirm, DeployReceipt } from './components';
 import { DeployContractsState } from './types';
-import { WALLET_STEPS } from './helpers';
 
 const { SCREEN_XS } = BREAK_POINTS;
 

--- a/common/v2/features/DeployContracts/helpers.ts
+++ b/common/v2/features/DeployContracts/helpers.ts
@@ -1,38 +1,6 @@
-import {
-  WalletId,
-  SigningComponents,
-  StoreAccount,
-  NetworkId,
-  ITxConfig,
-  ITxObject
-} from 'v2/types';
-import {
-  SignTransactionPrivateKey,
-  SignTransactionWeb3,
-  SignTransactionLedger,
-  SignTransactionTrezor,
-  SignTransactionSafeT,
-  SignTransactionKeystore,
-  SignTransactionParity,
-  SignTransactionMnemonic
-} from 'v2/components';
+import { StoreAccount, NetworkId, ITxConfig, ITxObject } from 'v2/types';
+import { WALLET_STEPS } from 'v2/components';
 import { getAssetByUUID, hexToString, hexWeiToString } from 'v2/services';
-
-export const WALLET_STEPS: SigningComponents = {
-  [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,
-  [WalletId.WEB3]: SignTransactionWeb3,
-  [WalletId.METAMASK]: SignTransactionWeb3,
-  [WalletId.TRUST]: SignTransactionWeb3,
-  [WalletId.FRAME]: SignTransactionWeb3,
-  [WalletId.COINBASE]: SignTransactionWeb3,
-  [WalletId.LEDGER_NANO_S]: SignTransactionLedger,
-  [WalletId.TREZOR]: SignTransactionTrezor,
-  [WalletId.SAFE_T_MINI]: SignTransactionSafeT,
-  [WalletId.KEYSTORE_FILE]: SignTransactionKeystore,
-  [WalletId.PARITY_SIGNER]: SignTransactionParity,
-  [WalletId.MNEMONIC_PHRASE]: SignTransactionMnemonic,
-  [WalletId.VIEW_ONLY]: null
-};
 
 export const getAccountsInNetwork = (accounts: StoreAccount[], networkId: NetworkId) =>
   accounts.filter(acc => acc.networkId === networkId && WALLET_STEPS[acc.wallet]);

--- a/common/v2/features/InteractWithContracts/InteractWithContractsFlow.tsx
+++ b/common/v2/features/InteractWithContracts/InteractWithContractsFlow.tsx
@@ -3,7 +3,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { translateRaw } from 'v2/translations';
-import { ExtendedContentPanel, Tabs } from 'v2/components';
+import { ExtendedContentPanel, Tabs, WALLET_STEPS } from 'v2/components';
 import { ROUTE_PATHS, DEFAULT_NETWORK } from 'v2/config';
 import { useStateReducer } from 'v2/utils';
 import { ITxReceipt, ISignedTx, Tab } from 'v2/types';
@@ -13,7 +13,6 @@ import { BREAK_POINTS } from 'v2/theme';
 import { interactWithContractsInitialState, InteractWithContractsFactory } from './stateFactory';
 import { Interact, InteractionReceipt } from './components';
 import { ABIItem, InteractWithContractState } from './types';
-import { WALLET_STEPS } from './helpers';
 import InteractionConfirm from './components/InteractionConfirm';
 
 const { SCREEN_XS } = BREAK_POINTS;

--- a/common/v2/features/InteractWithContracts/helpers.ts
+++ b/common/v2/features/InteractWithContracts/helpers.ts
@@ -1,24 +1,8 @@
 import { sortBy, cloneDeep } from 'lodash';
 import { bufferToHex } from 'ethereumjs-util';
 
-import {
-  WalletId,
-  SigningComponents,
-  StoreAccount,
-  NetworkId,
-  ITxConfig,
-  ITxObject
-} from 'v2/types';
-import {
-  SignTransactionPrivateKey,
-  SignTransactionWeb3,
-  SignTransactionLedger,
-  SignTransactionTrezor,
-  SignTransactionSafeT,
-  SignTransactionKeystore,
-  SignTransactionParity,
-  SignTransactionMnemonic
-} from 'v2/components';
+import { StoreAccount, NetworkId, ITxConfig, ITxObject } from 'v2/types';
+import { WALLET_STEPS } from 'v2/components';
 import { getAssetByUUID, hexToString, hexWeiToString, inputValueToHex } from 'v2/services';
 import { AbiFunction } from 'v2/services/EthService/contracts/ABIFunction';
 
@@ -94,22 +78,6 @@ export const getFunctionsFromABI = (pAbi: ABIItem[]) =>
     pAbi.filter(x => x.type === ABIItemType.FUNCTION),
     item => item.name.toLowerCase()
   ).map(x => Object.assign(x, { label: x.name }));
-
-export const WALLET_STEPS: SigningComponents = {
-  [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,
-  [WalletId.WEB3]: SignTransactionWeb3,
-  [WalletId.METAMASK]: SignTransactionWeb3,
-  [WalletId.TRUST]: SignTransactionWeb3,
-  [WalletId.FRAME]: SignTransactionWeb3,
-  [WalletId.COINBASE]: SignTransactionWeb3,
-  [WalletId.LEDGER_NANO_S]: SignTransactionLedger,
-  [WalletId.TREZOR]: SignTransactionTrezor,
-  [WalletId.SAFE_T_MINI]: SignTransactionSafeT,
-  [WalletId.KEYSTORE_FILE]: SignTransactionKeystore,
-  [WalletId.PARITY_SIGNER]: SignTransactionParity,
-  [WalletId.MNEMONIC_PHRASE]: SignTransactionMnemonic,
-  [WalletId.VIEW_ONLY]: null
-};
 
 export const getAccountsInNetwork = (accounts: StoreAccount[], networkId: NetworkId) =>
   accounts.filter(acc => acc.networkId === networkId && WALLET_STEPS[acc.wallet]);

--- a/common/v2/features/SendAssets/components/SignTransaction.tsx
+++ b/common/v2/features/SendAssets/components/SignTransaction.tsx
@@ -5,34 +5,9 @@ import {
   ITxReceipt,
   IStepComponentProps,
   ISignComponentProps,
-  ISignedTx,
-  SigningComponents as SigningComponentsType
+  ISignedTx
 } from 'v2/types';
-import {
-  SignTransactionPrivateKey,
-  SignTransactionWeb3,
-  SignTransactionLedger,
-  SignTransactionTrezor,
-  SignTransactionSafeT,
-  SignTransactionKeystore,
-  SignTransactionMnemonic
-} from 'v2/components';
-
-const SigningComponents: SigningComponentsType = {
-  [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,
-  [WalletId.WEB3]: SignTransactionWeb3,
-  [WalletId.METAMASK]: SignTransactionWeb3,
-  [WalletId.TRUST]: SignTransactionWeb3,
-  [WalletId.FRAME]: SignTransactionWeb3,
-  [WalletId.COINBASE]: SignTransactionWeb3,
-  [WalletId.LEDGER_NANO_S]: SignTransactionLedger,
-  [WalletId.TREZOR]: SignTransactionTrezor,
-  [WalletId.SAFE_T_MINI]: SignTransactionSafeT,
-  [WalletId.KEYSTORE_FILE]: SignTransactionKeystore,
-  [WalletId.PARITY_SIGNER]: null,
-  [WalletId.MNEMONIC_PHRASE]: SignTransactionMnemonic,
-  [WalletId.VIEW_ONLY]: null
-};
+import { WALLET_STEPS } from 'v2/components';
 
 export default function SignTransaction({ txConfig, onComplete }: IStepComponentProps) {
   // @TODO remove before deployement.
@@ -54,7 +29,7 @@ export default function SignTransaction({ txConfig, onComplete }: IStepComponent
   } = txConfig;
 
   const getWalletComponent = (walletType: WalletId) => {
-    return SigningComponents[walletType];
+    return WALLET_STEPS[walletType];
   };
 
   const WalletComponent: React.ComponentType<ISignComponentProps> = getWalletComponent(walletName)!;

--- a/common/v2/features/SwapAssets/SwapAssetsFlow.tsx
+++ b/common/v2/features/SwapAssets/SwapAssetsFlow.tsx
@@ -3,7 +3,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { translateRaw } from 'v2/translations';
 
-import { ExtendedContentPanel } from 'v2/components';
+import { ExtendedContentPanel, WALLET_STEPS } from 'v2/components';
 import { ROUTE_PATHS } from 'v2/config';
 import { ITxReceipt, ISignedTx } from 'v2/types';
 import { useStateReducer } from 'v2/utils';
@@ -16,7 +16,6 @@ import {
   SwapTransactionReceipt,
   SetAllowance
 } from './components';
-import { WALLET_STEPS } from './helpers';
 import { SwapFlowFactory, swapFlowInitialState } from './stateFactory';
 import { SwapState } from './types';
 

--- a/common/v2/features/SwapAssets/components/SetAllowance.tsx
+++ b/common/v2/features/SwapAssets/components/SetAllowance.tsx
@@ -4,9 +4,7 @@ import styled from 'styled-components';
 import translate from 'v2/translations';
 
 import { StoreAccount } from 'v2/types';
-import { Spinner, Typography } from 'v2/components';
-
-import { WALLET_STEPS } from '../helpers';
+import { Spinner, Typography, WALLET_STEPS } from 'v2/components';
 
 const AllowanceWrapper = styled.div`
   display: flex;

--- a/common/v2/features/SwapAssets/helpers.ts
+++ b/common/v2/features/SwapAssets/helpers.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import BN from 'bn.js';
 import { addHexPrefix } from 'ethereumjs-util';
 
-import { Asset, StoreAccount, WalletId, ITxConfig, SigningComponents } from 'v2/types';
+import { Asset, StoreAccount, ITxConfig } from 'v2/types';
 import { DEXAG_PROXY_CONTRACT } from 'v2/config';
 import { fetchGasPriceEstimates, getGasEstimate } from 'v2/services/ApiService';
 import {
@@ -13,35 +13,10 @@ import {
   hexToString
 } from 'v2/services/EthService';
 import { getAssetByUUID, getAssetByTicker } from 'v2/services';
-import {
-  SignTransactionPrivateKey,
-  SignTransactionWeb3,
-  SignTransactionLedger,
-  SignTransactionTrezor,
-  SignTransactionSafeT,
-  SignTransactionKeystore,
-  SignTransactionParity,
-  SignTransactionMnemonic
-} from 'v2/components';
+import { WALLET_STEPS } from 'v2/components';
 import { weiToFloat } from 'v2/utils';
 
 import { ISwapAsset } from './types';
-
-export const WALLET_STEPS: SigningComponents = {
-  [WalletId.PRIVATE_KEY]: SignTransactionPrivateKey,
-  [WalletId.WEB3]: SignTransactionWeb3,
-  [WalletId.METAMASK]: SignTransactionWeb3,
-  [WalletId.TRUST]: SignTransactionWeb3,
-  [WalletId.FRAME]: SignTransactionWeb3,
-  [WalletId.COINBASE]: SignTransactionWeb3,
-  [WalletId.LEDGER_NANO_S]: SignTransactionLedger,
-  [WalletId.TREZOR]: SignTransactionTrezor,
-  [WalletId.SAFE_T_MINI]: SignTransactionSafeT,
-  [WalletId.KEYSTORE_FILE]: SignTransactionKeystore,
-  [WalletId.PARITY_SIGNER]: SignTransactionParity,
-  [WalletId.MNEMONIC_PHRASE]: SignTransactionMnemonic,
-  [WalletId.VIEW_ONLY]: null
-};
 
 export const makeAllowanceTransaction = async (
   trade: any,


### PR DESCRIPTION
Each sign step would map the walletId to the SignComponent.
This PR makes a single declaration in `SignTransactionWallets`