### PR TITLE
ev/combine account types

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -14,7 +14,7 @@ import {
 } from 'v2/components';
 import { truncate } from 'v2/utils';
 import { BREAK_POINTS, COLORS, SPACING, breakpointToNumber } from 'v2/theme';
-import { ExtendedAccount, StoreAccount, ExtendedAddressBook } from 'v2/types';
+import { IAccount, StoreAccount, ExtendedAddressBook } from 'v2/types';
 import {
   AccountContext,
   getLabelByAccount,
@@ -206,8 +206,8 @@ export default function AccountList(props: AccountListProps) {
 
 function buildAccountTable(
   accounts: StoreAccount[],
-  deleteAccount: (a: ExtendedAccount) => void,
-  updateAccount: (u: TUuid, a: ExtendedAccount) => void,
+  deleteAccount: (a: IAccount) => void,
+  updateAccount: (u: TUuid, a: IAccount) => void,
   deletable?: boolean,
   favoritable?: boolean,
   copyable?: boolean,

--- a/common/v2/components/SignTransactionWallets/Hardware.tsx
+++ b/common/v2/components/SignTransactionWallets/Hardware.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import { ExtendedAccount as IExtendedAccount, ITxReceipt, ITxObject, ISignedTx } from 'v2/types';
+import { IAccount as IIAccount, ITxReceipt, ITxObject, ISignedTx } from 'v2/types';
 import { WALLETS_CONFIG } from 'v2/config';
 import { makeTransaction } from 'v2/services/EthService';
 import { WalletFactory, HardwareWallet } from 'v2/services/WalletService';
@@ -29,7 +29,7 @@ export const splitDPath = (fullDPath: string): IDestructuredDPath => {
 export interface IProps {
   walletIcon: any;
   signerDescription: string;
-  senderAccount: IExtendedAccount;
+  senderAccount: IIAccount;
   rawTransaction: ITxObject;
   onSuccess(receipt: ITxReceipt | ISignedTx): void;
 }

--- a/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext } from 'react';
 import { Network } from '@mycrypto/ui';
 import { bigNumberify } from 'ethers/utils';
 
-import { Asset, StoreAccount, ExtendedAccount, Network as INetwork, ITxObject } from 'v2/types';
+import { Asset, StoreAccount, IAccount, Network as INetwork, ITxObject } from 'v2/types';
 import { baseToConvertedUnit, totalTxFeeToString } from 'v2/services/EthService';
 import { getAccountBalance, StoreContext } from 'v2/services/Store';
 import { CopyableCodeBlock, Button } from 'v2/components';
@@ -23,7 +23,7 @@ interface Props {
   data: string;
   gasLimit: string;
   gasPrice: string;
-  senderAccount: ExtendedAccount;
+  senderAccount: IAccount;
   rawTransaction?: ITxObject;
   signedTransaction?: string;
 }

--- a/common/v2/database/seed/accounts.ts
+++ b/common/v2/database/seed/accounts.ts
@@ -1,12 +1,12 @@
 import { Overwrite } from 'utility-types';
-import { TAddress, AssetBalanceObject, TTicker, Account, WalletId, TUuid } from 'v2/types';
+import { TAddress, AssetBalanceObject, TTicker, IRawAccount, WalletId, TUuid } from 'v2/types';
 
 export interface SeedAssetBalance extends AssetBalanceObject {
   ticker: TTicker;
 }
 
 export type DevAccount = Overwrite<
-  Account,
+  IRawAccount,
   {
     assets: SeedAssetBalance[];
   }

--- a/common/v2/database/v1.0.0/devSeed.ts
+++ b/common/v2/database/v1.0.0/devSeed.ts
@@ -5,7 +5,7 @@ import { devAccounts, DevAccount, SeedAssetBalance, devAssets, devContacts } fro
 import {
   Asset,
   AssetBalanceObject,
-  ExtendedAccount,
+  IAccount,
   AddressBook,
   LocalStorage,
   NetworkId,
@@ -53,7 +53,7 @@ const addDevAccounts = add(LSKeys.ACCOUNTS)((accounts: DevAccount[], store: Loca
     };
   };
 
-  const updateAssetUuid = ({ assets, ...rest }: ExtendedAccount): ExtendedAccount => ({
+  const updateAssetUuid = ({ assets, ...rest }: IAccount): IAccount => ({
     ...rest,
     assets: assets.map(formatAccountAssetBalance(rest.networkId))
   });

--- a/common/v2/database/v1.0.0/migration.ts
+++ b/common/v2/database/v1.0.0/migration.ts
@@ -3,7 +3,7 @@ import {
   LocalStorage,
   Asset,
   TUuid,
-  ExtendedAccount,
+  IAccount,
   TTicker,
   NetworkId,
   AssetBalanceObject
@@ -25,7 +25,7 @@ export function migrate(prev: LocalStorage, curr: LocalStorage) {
       R.values(assets)
     );
 
-  const updateAccountAssetsUUID = ({ networkId, assets = [], ...rest }: ExtendedAccount) => {
+  const updateAccountAssetsUUID = ({ networkId, assets = [], ...rest }: IAccount) => {
     const getTicker = (uuid: TUuid) => {
       //@ts-ignore
       const asset = prev.assets[uuid] || {};
@@ -53,7 +53,7 @@ export function migrate(prev: LocalStorage, curr: LocalStorage) {
   const accounts = Object.assign(
     {},
     curr.accounts,
-    R.map(updateAccountAssetsUUID, (prev.accounts as R.Functor<ExtendedAccount>) || {})
+    R.map(updateAccountAssetsUUID, (prev.accounts as R.Functor<IAccount>) || {})
   );
 
   // Add labels to address book

--- a/common/v2/database/v1.0.0/removeSeed.ts
+++ b/common/v2/database/v1.0.0/removeSeed.ts
@@ -3,7 +3,7 @@ import * as R from 'ramda';
 import { devAccounts, DevAccount, devContacts } from '../seed';
 import {
   AddressBook,
-  ExtendedAccount,
+  IAccount,
   ExtendedAddressBook,
   LocalStorage,
   TUuid,
@@ -14,14 +14,14 @@ import {
 import { toArray, toObject, add } from './helpers';
 
 const removeDevAccounts = add(LSKeys.ACCOUNTS)((accounts: DevAccount[], store: LocalStorage) => {
-  const cmp = (x: ExtendedAccount, y: DevAccount) => x.address === y.address;
+  const cmp = (x: IAccount, y: DevAccount) => x.address === y.address;
   const toKeep = R.differenceWith(cmp, toArray(store.accounts), accounts);
   return R.reduce(toObject('uuid'), {}, toKeep);
 });
 
 const removeDevAccountsFromSettings = add(LSKeys.SETTINGS)(
   (accounts: DevAccount[], store: LocalStorage) => {
-    const cmp = (x: ExtendedAccount, y: DevAccount) => x.address === y.address;
+    const cmp = (x: IAccount, y: DevAccount) => x.address === y.address;
     const devAccountUuids = R.differenceWith(cmp, toArray(store.accounts), accounts).map(
       a => a.uuid
     );

--- a/common/v2/features/CreateWallet/Keystore/Keystore.tsx
+++ b/common/v2/features/CreateWallet/Keystore/Keystore.tsx
@@ -16,7 +16,7 @@ import {
 import { stripHexPrefix } from 'v2/services/EthService';
 import { WalletFactory } from 'v2/services/WalletService';
 import { NotificationTemplates } from 'v2/features/NotificationsPanel';
-import { TAddress, Account, Asset, ISettings, Network, NetworkId, WalletId } from 'v2/types';
+import { TAddress, IRawAccount, Asset, ISettings, Network, NetworkId, WalletId } from 'v2/types';
 import { ROUTE_PATHS, N_FACTOR } from 'v2/config';
 
 import { KeystoreStages, keystoreStageToComponentHash, keystoreFlow } from './constants';
@@ -34,7 +34,7 @@ interface State {
 
 interface Props extends RouteComponentProps<{}> {
   settings: ISettings;
-  createAccountWithID(accountData: Account, uuid: string): void;
+  createAccountWithID(accountData: IRawAccount, uuid: string): void;
   updateSettingsAccounts(accounts: string[]): void;
   createAssetWithID(value: Asset, id: string): void;
   displayNotification(templateName: string, templateData?: object): void;
@@ -118,7 +118,7 @@ class CreateKeystore extends Component<Props & INetworkContext & IAssetContext, 
     const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(assets)(accountNetwork);
     const newAssetID = generateUUID();
     const newUUID = generateUUID();
-    const account: Account = {
+    const account: IRawAccount = {
       address: toChecksumAddress(addHexPrefix(keystore.address)) as TAddress,
       networkId: network as NetworkId,
       wallet: accountType,

--- a/common/v2/features/CreateWallet/Mnemonic/Mnemonic.tsx
+++ b/common/v2/features/CreateWallet/Mnemonic/Mnemonic.tsx
@@ -11,7 +11,7 @@ import { withAccountAndNotificationsContext } from '../components/withAccountAnd
 import { NotificationTemplates } from 'v2/features/NotificationsPanel';
 import {
   TAddress,
-  Account,
+  IRawAccount,
   Asset,
   DPathFormat,
   ISettings,
@@ -32,7 +32,7 @@ import { DEFAULT_NETWORK, ROUTE_PATHS } from 'v2/config';
 
 interface Props extends RouteComponentProps<{}> {
   settings: ISettings;
-  createAccountWithID(accountData: Account, uuid: string): void;
+  createAccountWithID(accountData: IRawAccount, uuid: string): void;
   updateSettingsAccounts(accounts: string[]): void;
   createAssetWithID(value: Asset, id: string): void;
   displayNotification(templateName: string, templateData?: object): void;
@@ -159,7 +159,7 @@ class CreateMnemonic extends Component<Props & IAssetContext & INetworkContext> 
     const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(this.props.assets)(accountNetwork);
     const newAssetID = generateUUID();
     const newUUID = generateUUID();
-    const account: Account = {
+    const account: IRawAccount = {
       address: toChecksumAddress(addHexPrefix(address)) as TAddress,
       networkId: network,
       wallet: accountType,

--- a/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/AccountDropdown.tsx
@@ -7,12 +7,12 @@ import { Checkbox } from 'v2/components';
 import { useOnClickOutside, truncate } from 'v2/utils';
 import { getLabelByAccount, AddressBookContext } from 'v2/services/Store';
 import { COLORS } from 'v2/theme';
-import { ExtendedAccount, ExtendedAddressBook, TUuid } from 'v2/types';
+import { IAccount, ExtendedAddressBook, TUuid } from 'v2/types';
 
 const { BLUE_BRIGHT } = COLORS;
 
 interface AccountDropdownProps {
-  accounts: ExtendedAccount[];
+  accounts: IAccount[];
   selected: TUuid[];
   onSubmit(selected: TUuid[]): void;
 }
@@ -81,12 +81,12 @@ const IconWrapper = styled(Icon)`
 `;
 
 const renderAccounts = (
-  accounts: ExtendedAccount[],
+  accounts: IAccount[],
   selected: string[],
   addressBook: ExtendedAddressBook[],
   handleChange: (uuid: string) => void
 ) =>
-  accounts.map((account: ExtendedAccount) => {
+  accounts.map((account: IAccount) => {
     const addressCard = getLabelByAccount(account, addressBook);
     const addressLabel = addressCard ? addressCard.label : 'Unknown Account';
     return (

--- a/common/v2/features/Dashboard/components/WalletBreakdown/types.ts
+++ b/common/v2/features/Dashboard/components/WalletBreakdown/types.ts
@@ -1,4 +1,4 @@
-import { ExtendedAccount, Fiat } from 'v2/types';
+import { IAccount, Fiat } from 'v2/types';
 
 export interface Balance {
   name: string;
@@ -12,7 +12,7 @@ export interface WalletBreakdownProps {
   balances: Balance[];
   totalFiatValue: number;
   fiat: Fiat;
-  accounts: ExtendedAccount[];
+  accounts: IAccount[];
   selected: string[];
   toggleShowChart(): void;
 }

--- a/common/v2/features/DevTools/DevTools.tsx
+++ b/common/v2/features/DevTools/DevTools.tsx
@@ -8,14 +8,15 @@ import { DEFAULT_NETWORK } from 'v2/config';
 import { generateUUID } from 'v2/utils';
 import {
   AccountContext,
-  getLabelByAccount,
+  getLabelByAddressAndNetwork,
   AddressBookContext,
-  DataContext
+  DataContext,
+  NetworkContext
 } from 'v2/services/Store';
 import { useDevTools } from 'v2/services';
 import {
   TAddress,
-  Account,
+  IRawAccount,
   AddressBook,
   WalletId,
   AssetBalanceObject,
@@ -35,8 +36,13 @@ const renderAccountForm = (addressBook: ExtendedAddressBook[]) => ({
   handleChange,
   handleBlur,
   isSubmitting
-}: FormikProps<Account>) => {
-  const detectedLabel: AddressBook | undefined = getLabelByAccount(values, addressBook);
+}: FormikProps<IRawAccount>) => {
+  const { getNetworkByName } = useContext(NetworkContext);
+  const detectedLabel: AddressBook | undefined = getLabelByAddressAndNetwork(
+    values.address,
+    addressBook,
+    getNetworkByName(values.networkId)
+  );
   const label = detectedLabel ? detectedLabel.label : 'Unknown Account';
   return (
     <Form>
@@ -162,7 +168,7 @@ const DevTools = () => {
         <div className="Settings-heading">Enter a new Account</div>
         <Formik
           initialValues={dummyAccount}
-          onSubmit={(values: Account, { setSubmitting }) => {
+          onSubmit={(values: IRawAccount, { setSubmitting }) => {
             createAccountWithID(values, generateUUID());
             setSubmitting(false);
           }}

--- a/common/v2/features/DevTools/ToolsAccountList.tsx
+++ b/common/v2/features/DevTools/ToolsAccountList.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { List, Button } from '@mycrypto/ui';
 import styled from 'styled-components';
 
-import { AddressBook, ExtendedAccount } from 'v2/types';
+import { AddressBook, IAccount } from 'v2/types';
 import { truncate } from 'v2/utils';
 import { getLabelByAccount, AddressBookContext } from 'v2/services/Store';
 import { Account } from 'v2/components';
@@ -18,14 +18,14 @@ const DeleteButton = styled(Button)`
 `;
 
 export interface AccountListProps {
-  accounts: ExtendedAccount[];
-  deleteAccount(account: ExtendedAccount): void;
+  accounts: IAccount[];
+  deleteAccount(account: IAccount): void;
 }
 
 const ToolsAccountList: React.FC<AccountListProps> = props => {
   const { addressBook } = useContext(AddressBookContext);
   const { accounts, deleteAccount } = props;
-  const list = accounts.map((account: ExtendedAccount, index: number) => {
+  const list = accounts.map((account: IAccount, index: number) => {
     const detectedLabel: AddressBook | undefined = getLabelByAccount(account, addressBook);
     const label = detectedLabel ? detectedLabel.label : 'Unknown Account';
     return (

--- a/common/v2/features/NotificationsPanel/NotificationsPanel.tsx
+++ b/common/v2/features/NotificationsPanel/NotificationsPanel.tsx
@@ -3,7 +3,7 @@ import { Panel, Button } from '@mycrypto/ui';
 import styled from 'styled-components';
 
 import { SPACING } from 'v2/theme';
-import { ExtendedAccount } from 'v2/types';
+import { IAccount } from 'v2/types';
 import { NotificationsContext } from './NotificationsProvider';
 import { notificationsConfigs, NotificationTemplates } from './constants';
 
@@ -27,7 +27,7 @@ const CloseButton = styled(Button)`
 `;
 
 interface Props {
-  accounts: ExtendedAccount[];
+  accounts: IAccount[];
 }
 
 const NotificationsPanel = ({ accounts }: Props) => {

--- a/common/v2/features/ReceiveAssets/ReceiveAssets.tsx
+++ b/common/v2/features/ReceiveAssets/ReceiveAssets.tsx
@@ -12,7 +12,7 @@ import {
 import { ContentPanel, QRCode, AccountDropdown, AssetDropdown } from 'v2/components';
 import { AssetContext, getNetworkById, StoreContext } from 'v2/services/Store';
 import { isValidAmount } from 'v2/utils';
-import { ExtendedAccount as IExtendedAccount, StoreAccount } from 'v2/types';
+import { IAccount as IIAccount, StoreAccount } from 'v2/types';
 import { ROUTE_PATHS } from 'v2/config';
 import translate, { translateRaw } from 'v2/translations';
 import questionToolTip from 'common/assets/images/icn-question.svg';
@@ -169,7 +169,7 @@ export function ReceiveAssets({ history }: RouteComponentProps<{}>) {
                     name={field.name}
                     value={field.value}
                     accounts={accounts}
-                    onSelect={(option: IExtendedAccount) => {
+                    onSelect={(option: IIAccount) => {
                       form.setFieldValue(field.name, option);
                       if (option.networkId) {
                         setNetworkId(option.networkId);

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -31,7 +31,7 @@ import {
 import {
   Asset,
   Network,
-  ExtendedAccount,
+  IAccount,
   StoreAsset,
   WalletId,
   IFormikFields,
@@ -92,7 +92,7 @@ const initialFormikValues: IFormikFields = {
     display: ''
   },
   amount: '',
-  account: {} as ExtendedAccount, // should be renamed senderAccount
+  account: {} as IAccount, // should be renamed senderAccount
   network: {} as Network, // Not a field move to state
   asset: {} as StoreAsset,
   txDataField: '0x',
@@ -354,7 +354,7 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
             }
           };
 
-          const handleNonceEstimate = async (account: ExtendedAccount) => {
+          const handleNonceEstimate = async (account: IAccount) => {
             if (!values || !values.network || !account) {
               return;
             }
@@ -424,7 +424,7 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
                         name={field.name}
                         value={field.value}
                         accounts={accountsWithAsset}
-                        onSelect={(option: ExtendedAccount) => {
+                        onSelect={(option: IAccount) => {
                           form.setFieldValue('account', option); //if this gets deleted, it no longer shows as selected on interface, would like to set only object keys that are needed instead of full object
                           handleNonceEstimate(option);
                           handleGasEstimate();

--- a/common/v2/services/EthService/nonce.ts
+++ b/common/v2/services/EthService/nonce.ts
@@ -1,7 +1,7 @@
-import { ExtendedAccount, Network } from 'v2/types';
+import { IAccount, Network } from 'v2/types';
 import { ProviderHandler } from './network';
 
-export function getNonce(network: Network, account: ExtendedAccount) {
+export function getNonce(network: Network, account: IAccount) {
   const provider = new ProviderHandler(network);
   return provider.getTransactionCount(account.address);
 }

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import * as R from 'ramda';
 
 import {
-  Account,
+  IRawAccount,
   IAccount,
   ITxReceipt,
   StoreAccount,
@@ -20,7 +20,7 @@ import { getAllTokensBalancesOfAccount } from '../BalanceService';
 
 export interface IAccountContext {
   accounts: IAccount[];
-  createAccountWithID(accountData: Account, uuid: TUuid): void;
+  createAccountWithID(accountData: IRawAccount, uuid: TUuid): void;
   deleteAccount(account: IAccount): void;
   updateAccount(uuid: TUuid, accountData: IAccount): void;
   addNewTransactionToAccount(account: IAccount, transaction: ITxReceipt): void;

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -5,7 +5,7 @@ import * as R from 'ramda';
 
 import {
   Account,
-  ExtendedAccount,
+  IAccount,
   ITxReceipt,
   StoreAccount,
   Asset,
@@ -19,14 +19,14 @@ import { getAccountByAddressAndNetworkName } from './helpers';
 import { getAllTokensBalancesOfAccount } from '../BalanceService';
 
 export interface IAccountContext {
-  accounts: ExtendedAccount[];
+  accounts: IAccount[];
   createAccountWithID(accountData: Account, uuid: TUuid): void;
-  deleteAccount(account: ExtendedAccount): void;
-  updateAccount(uuid: TUuid, accountData: ExtendedAccount): void;
-  addNewTransactionToAccount(account: ExtendedAccount, transaction: ITxReceipt): void;
-  getAccountByAddressAndNetworkName(address: string, network: string): ExtendedAccount | undefined;
+  deleteAccount(account: IAccount): void;
+  updateAccount(uuid: TUuid, accountData: IAccount): void;
+  addNewTransactionToAccount(account: IAccount, transaction: ITxReceipt): void;
+  getAccountByAddressAndNetworkName(address: string, network: string): IAccount | undefined;
   updateAccountAssets(account: StoreAccount, assets: Asset[]): Promise<void>;
-  updateAccountsBalances(toUpate: ExtendedAccount[]): void;
+  updateAccountsBalances(toUpate: IAccount[]): void;
 }
 
 export const AccountContext = createContext({} as IAccountContext);

--- a/common/v2/services/Store/Account/helpers.ts
+++ b/common/v2/services/Store/Account/helpers.ts
@@ -1,4 +1,4 @@
-import { Asset, ExtendedAccount, StoreAccount } from 'v2/types';
+import { Asset, IAccount, StoreAccount } from 'v2/types';
 
 export const getDashboardAccounts = (
   accounts: StoreAccount[],
@@ -9,10 +9,10 @@ export const getDashboardAccounts = (
     .filter(({ uuid }) => currentAccounts.indexOf(uuid) >= 0);
 };
 
-export const getAccountByAddressAndNetworkName = (accounts: ExtendedAccount[]) => (
+export const getAccountByAddressAndNetworkName = (accounts: IAccount[]) => (
   address: string,
   networkId: string
-): ExtendedAccount | undefined => {
+): IAccount | undefined => {
   return accounts.find(
     account =>
       account.address.toLowerCase() === address.toLowerCase() && account.networkId === networkId

--- a/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
+++ b/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
@@ -3,7 +3,7 @@ import React, { useContext, createContext } from 'react';
 import {
   AddressBook,
   ExtendedAddressBook,
-  ExtendedAccount,
+  IAccount,
   Network,
   StoreAccount,
   LSKeys,
@@ -19,8 +19,8 @@ interface IAddressBookContext {
   deleteAddressBooks(uuid: TUuid): void;
   getContactByAddress(address: string): ExtendedAddressBook | undefined;
   getContactByAddressAndNetwork(address: string, network: Network): ExtendedAddressBook | undefined;
-  getContactByAccount(account: ExtendedAccount): ExtendedAddressBook | undefined;
-  getAccountLabel(account: StoreAccount | ExtendedAccount): string | undefined;
+  getContactByAccount(account: IAccount): ExtendedAddressBook | undefined;
+  getAccountLabel(account: StoreAccount | IAccount): string | undefined;
 }
 
 export const AddressBookContext = createContext({} as IAddressBookContext);
@@ -57,7 +57,7 @@ export const AddressBookProvider: React.FC = ({ children }) => {
         );
     },
     getAccountLabel: account => {
-      const addressContact = state.getContactByAccount(account as ExtendedAccount);
+      const addressContact = state.getContactByAccount(account as IAccount);
       return addressContact ? addressContact.label : undefined;
     }
   };

--- a/common/v2/services/Store/AddressBook/helpers.ts
+++ b/common/v2/services/Store/AddressBook/helpers.ts
@@ -1,12 +1,11 @@
-
-import { Account, AddressBook, Network, WalletId, ExtendedAddressBook } from 'v2/types';
+import { IAccount, AddressBook, Network, WalletId, ExtendedAddressBook } from 'v2/types';
 import { WALLETS_CONFIG } from 'v2/config';
 
 export const getLabelByAccount = (
-  account: Account,
+  account: IAccount,
   addressLabels: ExtendedAddressBook[]
 ): ExtendedAddressBook | undefined => {
-if (!account || !addressLabels) return;
+  if (!account || !addressLabels) return;
   return addressLabels.find(
     label =>
       account.address.toLowerCase() === label.address.toLowerCase() &&

--- a/common/v2/services/Store/DataManager/reducer.spec.ts
+++ b/common/v2/services/Store/DataManager/reducer.spec.ts
@@ -1,4 +1,4 @@
-import { LSKeys, ExtendedAccount } from 'v2/types';
+import { LSKeys, IAccount } from 'v2/types';
 import { ActionT, ActionV, appDataReducer } from './reducer';
 
 const dispatch = (action: ActionV) => (state: any) => appDataReducer(state, action);
@@ -6,7 +6,7 @@ const dispatch = (action: ActionV) => (state: any) => appDataReducer(state, acti
 describe('AppStateReducer', () => {
   describe('ADD_ITEM', () => {
     it('can add an Item to an array', () => {
-      const account = { address: '0x0', uuid: 'fakeUUID' } as ExtendedAccount;
+      const account = { address: '0x0', uuid: 'fakeUUID' } as IAccount;
       const prevState = { [LSKeys.ACCOUNTS]: [] };
       const payload = {
         model: LSKeys.ACCOUNTS,
@@ -18,8 +18,8 @@ describe('AppStateReducer', () => {
     });
 
     it('preserves the previous items in the array', () => {
-      const account1 = { address: '0x1', uuid: 'fakeUUID' } as ExtendedAccount;
-      const account2 = { address: '0x2', uuid: 'fakeUUID' } as ExtendedAccount;
+      const account1 = { address: '0x1', uuid: 'fakeUUID' } as IAccount;
+      const account2 = { address: '0x2', uuid: 'fakeUUID' } as IAccount;
       const prevState = { [LSKeys.ACCOUNTS]: [account1] };
       const payload = {
         model: LSKeys.ACCOUNTS,
@@ -32,8 +32,8 @@ describe('AppStateReducer', () => {
     });
 
     // it('avoids duplicates in the array', () => {
-    //   const account1 = { address: '0x1', uuid: 'fakeUUID' } as ExtendedAccount;
-    //   const account2 = { address: '0x1', uuid: 'fakeUUID' } as ExtendedAccount;
+    //   const account1 = { address: '0x1', uuid: 'fakeUUID' } as IAccount;
+    //   const account2 = { address: '0x1', uuid: 'fakeUUID' } as IAccount;
     //   const prevState = { [LSKeys.ACCOUNTS]: [account1] };
     //   const payload = {
     //     model: LSKeys.ACCOUNTS,

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -8,7 +8,7 @@ import {
   Network,
   TTicker,
   ExtendedAsset,
-  ExtendedAccount,
+  IAccount,
   WalletId,
   Asset,
   ITxReceipt,
@@ -53,7 +53,7 @@ interface State {
   assetTickers(targetAssets?: StoreAsset[]): TTicker[];
   assetUUIDs(targetAssets?: StoreAsset[]): any[];
   scanTokens(asset?: ExtendedAsset): Promise<void[]>;
-  deleteAccountFromCache(account: ExtendedAccount): void;
+  deleteAccountFromCache(account: IAccount): void;
   addAccount(
     networkId: NetworkId,
     address: string,

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useMemo, createContext, useEffect } from '
 import * as R from 'ramda';
 import {
   TAddress,
-  Account,
+  IRawAccount,
   StoreAccount,
   StoreAsset,
   Network,
@@ -59,9 +59,9 @@ interface State {
     address: string,
     accountType: WalletId | undefined,
     dPath: string
-  ): Account | undefined;
+  ): IRawAccount | undefined;
   getAssetByTicker(symbol: string): Asset | undefined;
-  getAccount(a: Account): StoreAccount | undefined;
+  getAccount(a: IRawAccount): StoreAccount | undefined;
 }
 export const StoreContext = createContext({} as State);
 
@@ -240,7 +240,7 @@ export const StoreProvider: React.FC = ({ children }) => {
         accountType! === WalletId.WEB3 ? WalletId[getWeb3Config().id] : accountType!;
       const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(assets)(network);
       const newUUID = generateUUID();
-      const account: Account = {
+      const account: IRawAccount = {
         address,
         networkId,
         wallet: walletType,

--- a/common/v2/services/Store/helpers.tsx
+++ b/common/v2/services/Store/helpers.tsx
@@ -6,7 +6,7 @@ import {
   AssetBalanceObject,
   Asset,
   StoreAsset,
-  ExtendedAccount,
+  IAccount,
   StoreAccount,
   ITxStatus,
   ITxReceipt
@@ -24,7 +24,7 @@ const getAssetsByUuid = (accountAssets: AssetBalanceObject[], assets: Asset[]): 
     .map(asset => ({ ...asset, balance: bigNumberify(asset.balance), mtime: Date.now() }));
 
 export const getStoreAccounts = (
-  accounts: ExtendedAccount[],
+  accounts: IAccount[],
   assets: Asset[],
   networks: Network[]
 ): StoreAccount[] => {

--- a/common/v2/types/account.tsx
+++ b/common/v2/types/account.tsx
@@ -21,7 +21,7 @@ export interface IAccount {
   favorite: boolean;
 }
 
-export type Account = Omit<IAccount, 'uuid'>;
+export type IRawAccount = Omit<IAccount, 'uuid'>;
 
 export interface AssetBalanceObject {
   uuid: TUuid;

--- a/common/v2/types/account.tsx
+++ b/common/v2/types/account.tsx
@@ -8,7 +8,8 @@ import { ITxReceipt } from './transaction';
 import { TUuid } from './uuid';
 import { TAddress } from './address';
 
-export interface Account {
+export interface IAccount {
+  uuid: TUuid;
   label?: string;
   address: TAddress;
   networkId: NetworkId;
@@ -20,9 +21,7 @@ export interface Account {
   favorite: boolean;
 }
 
-export interface ExtendedAccount extends Account {
-  uuid: TUuid;
-}
+export type Account = Omit<IAccount, 'uuid'>;
 
 export interface AssetBalanceObject {
   uuid: TUuid;
@@ -31,7 +30,7 @@ export interface AssetBalanceObject {
 }
 
 export type StoreAccount = Overwrite<
-  ExtendedAccount,
+  IAccount,
   {
     assets: StoreAsset[];
   }

--- a/common/v2/types/index.ts
+++ b/common/v2/types/index.ts
@@ -35,7 +35,7 @@ export {
   AssetWithDetails
 } from './asset';
 import { StoreAccount } from './account';
-export { Account, IAccount } from './account';
+export { IRawAccount, IAccount } from './account';
 export type StoreAccount = StoreAccount;
 export { AddressBook, ExtendedAddressBook } from './addressBook';
 export { Contract, ExtendedContract } from './contract';

--- a/common/v2/types/index.ts
+++ b/common/v2/types/index.ts
@@ -35,7 +35,7 @@ export {
   AssetWithDetails
 } from './asset';
 import { StoreAccount } from './account';
-export { Account, ExtendedAccount } from './account';
+export { Account, IAccount } from './account';
 export type StoreAccount = StoreAccount;
 export { AddressBook, ExtendedAddressBook } from './addressBook';
 export { Contract, ExtendedContract } from './contract';

--- a/common/v2/types/store.ts
+++ b/common/v2/types/store.ts
@@ -7,7 +7,7 @@ import {
   Network,
   Notification,
   ExtendedAddressBook,
-  ExtendedAccount,
+  IAccount,
   ExtendedAsset,
   ExtendedNotification,
   TUuid,
@@ -29,7 +29,7 @@ export interface LocalStorage {
   readonly version: string;
   readonly mtime: number;
   readonly [LSKeys.SETTINGS]: ISettings;
-  readonly [LSKeys.ACCOUNTS]: Record<TUuid, ExtendedAccount>;
+  readonly [LSKeys.ACCOUNTS]: Record<TUuid, IAccount>;
   readonly [LSKeys.ASSETS]: Record<TUuid, Asset>;
   readonly [LSKeys.NETWORKS]: Record<NetworkId, Network>;
   readonly [LSKeys.CONTRACTS]: Record<TUuid, ExtendedContract>;
@@ -40,7 +40,7 @@ export interface LocalStorage {
 
 export interface DataStore {
   readonly version: string;
-  readonly [LSKeys.ACCOUNTS]: ExtendedAccount[];
+  readonly [LSKeys.ACCOUNTS]: IAccount[];
   readonly [LSKeys.ASSETS]: ExtendedAsset[];
   readonly [LSKeys.NETWORKS]: Network[];
   readonly [LSKeys.CONTRACTS]: ExtendedContract[];

--- a/common/v2/types/transactionFlow.ts
+++ b/common/v2/types/transactionFlow.ts
@@ -1,9 +1,9 @@
 import {
   Asset,
-  ExtendedAccount as IExtendedAccount,
+  IAccount as IIAccount,
   Network as INetwork,
   GasEstimates,
-  ExtendedAccount,
+  IAccount,
   ITxReceipt,
   WalletId
 } from 'v2/types';
@@ -25,7 +25,7 @@ export interface ITxConfig {
   readonly rawTransaction: ITxObject /* The rawTransaction object that will be signed */;
   readonly amount: string;
   readonly receiverAddress: string;
-  readonly senderAccount: IExtendedAccount;
+  readonly senderAccount: IIAccount;
   readonly from: string;
   readonly asset: Asset;
   readonly baseAsset: Asset;
@@ -41,7 +41,7 @@ export interface IFormikFields {
   asset: Asset;
   address: IReceiverAddress;
   amount: string;
-  account: IExtendedAccount;
+  account: IIAccount;
   txDataField: string;
   gasEstimates: GasEstimates;
   gasPriceField: string;
@@ -55,7 +55,7 @@ export interface IFormikFields {
 
 export interface ISignComponentProps {
   network: INetwork;
-  senderAccount: ExtendedAccount;
+  senderAccount: IAccount;
   rawTransaction: ITxObject;
   children?: never;
   onSuccess(receipt: ITxReceipt | ISignedTx): void;


### PR DESCRIPTION
Within the app, an account should always have an uuid.
We replace set `ExtendedAccount` as the default type declaration and rename to a shorter `IAccount`.
We use Omit to define the case of an account that is about to created and name it `IRawAccount`
