### PR TITLE
Remove unecessary p container

### DIFF
--- a/common/v2/features/SwapAssets/components/fields/SwapFromToDiagram.tsx
+++ b/common/v2/features/SwapAssets/components/fields/SwapFromToDiagram.tsx
@@ -29,6 +29,7 @@ const AssetWrapper = styled.div`
   margin: 0 15px;
   width: 148px;
   height: 9em;
+  text-align: center;
   & > :first-child {
     margin-bottom: 14px;
   }

--- a/common/v2/features/SwapAssets/components/fields/SwapFromToDiagram.tsx
+++ b/common/v2/features/SwapAssets/components/fields/SwapFromToDiagram.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { TSymbol } from 'v2/types';
 import { AssetIcon, Currency } from 'v2/components';
+import { FONT_SIZE } from 'v2/theme';
 
 import arrowIcon from 'assets/images/arrow-right.svg';
 
@@ -27,6 +28,10 @@ const AssetWrapper = styled.div`
   align-items: center;
   margin: 0 15px;
   width: 148px;
+  height: 9em;
+  & > :first-child {
+    margin-bottom: 14px;
+  }
 `;
 
 const Arrow = styled.img`
@@ -35,36 +40,30 @@ const Arrow = styled.img`
   margin-bottom: 64px;
 `;
 
-const AssetAmount = styled.p`
-  font-size: 20px;
-  font-weight: bold;
-  margin-top: 14px;
-  height: 50px;
-  text-align: center;
-`;
-
 export default function SwapFromToDiagram(props: Props) {
   const { fromSymbol, toSymbol, fromAmount, toAmount } = props;
   return (
     <Wrapper>
       <AssetWrapper>
         <AssetIcon symbol={fromSymbol} size="72px" />
-        <AssetAmount>
-          <Currency
-            bold={true}
-            fontSize="1em"
-            amount={fromAmount}
-            symbol={fromSymbol}
-            decimals={6}
-          />
-        </AssetAmount>
+        <Currency
+          bold={true}
+          fontSize={FONT_SIZE.LG}
+          amount={fromAmount}
+          symbol={fromSymbol}
+          decimals={6}
+        />
       </AssetWrapper>
       <Arrow src={arrowIcon} />
       <AssetWrapper>
         <AssetIcon symbol={toSymbol} size="72px" />
-        <AssetAmount>
-          <Currency bold={true} fontSize="1em" amount={toAmount} symbol={toSymbol} decimals={6} />
-        </AssetAmount>
+        <Currency
+          bold={true}
+          fontSize={FONT_SIZE.LG}
+          amount={toAmount}
+          symbol={toSymbol}
+          decimals={6}
+        />
       </AssetWrapper>
     </Wrapper>
   );


### PR DESCRIPTION
On the confirm swap panel the console would display an error from `validateDOMNesting() ... div cannot be a descendant of p` .

This PR changes the HTML markup to remove the unnecessary nesting.

Display is identical
<img width="679" alt="Screenshot 2020-02-19 at 17 10 15" src="https://user-images.githubusercontent.com/2429708/74871766-c5cd5c00-533a-11ea-9594-a5f5163a9d55.png">
