### PR TITLE
ConfirmTransaction stories demo

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,8 +1,13 @@
-import { light, dark } from '@mycrypto/ui';
-import { GAU_COLORS } from '../common/v2/theme/constants';
+import React from 'react';
 import { addDecorator } from '@storybook/react';
-import { withThemesProvider } from 'storybook-addon-styled-component-theme';
 import { withA11y } from '@storybook/addon-a11y';
+import { withThemesProvider } from 'storybook-addon-styled-component-theme';
+import styled from 'styled-components';
+import { light, dark } from '@mycrypto/ui';
+
+import { GAU_COLORS } from 'v2/theme';
+
+import 'sass/styles'
 
 const LIGHT_THEME = {
   name: 'Light',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,13 +13,21 @@ module.exports = {
   ],
 
   webpackFinal: async config => {
+    // Remove storybooks handling of assets in favor of our own.
+    config.module.rules = config.module.rules.filter(
+      rule => !rule.test.toString().includes('svg')
+    )
+
+    // Merge storybook and our custom webpack_config/development.js
     return merge.smart(
       config,
-      // Use the existing dev webpack_config
+
       {
         resolve: custom.resolve,
         module: {
-          rules: custom.module.rules
+          rules: [
+            ...custom.module.rules
+          ]
         }
       },
       // Necessary to launch @storybook

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const merge = require('webpack-merge');
+const custom = require('../webpack_config/development');
 
 module.exports = {
   stories: ['../common/**/*.stories.(tsx|mdx)'],
@@ -11,22 +13,22 @@ module.exports = {
   ],
 
   webpackFinal: async config => {
-    config.module.rules.push({
-      test: /\.tsx?$/,
-      use: [require.resolve('babel-loader')]
-    });
-
-    config.resolve.extensions.push('.ts', '.tsx');
-    config.resolve.modules.push(
-      path.resolve(__dirname, '../common'),
-      path.resolve(__dirname, '..')
-    );
-
-    config.node = {
-      fs: 'empty',
-      child_process: 'empty'
-    };
-
-    return config;
+    return merge.smart(
+      config,
+      // Use the existing dev webpack_config
+      {
+        resolve: custom.resolve,
+        module: {
+          rules: custom.module.rules
+        }
+      },
+      // Necessary to launch @storybook
+      {
+        node: {
+          fs: 'empty',
+          child_process: 'empty'
+        }
+      }
+    )
   }
 };

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,13 @@
+<style>
+  #root {
+    height: 100%;
+    background-color: #f2f2f2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #root .sb-container {
+    background-color: #fff;
+  }
+</style>

--- a/common/v2/components/AccountDropdown.tsx
+++ b/common/v2/components/AccountDropdown.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { translateRaw } from 'v2/translations';
 import { formatEther } from 'ethers/utils';
 
 import { AccountSummary, AccountOption, Dropdown } from 'v2/components';
 import { StoreAccount, Asset } from 'v2/types';
-import { AddressBookContext, getAccountBalance, getBaseAsset } from 'v2/services/Store';
+import { getAccountBalance, getBaseAsset } from 'v2/services/Store';
 import { useEffectOnce } from 'v2/vendor';
 
 // Option item displayed in Dropdown menu. Props are passed by react-select Select.
@@ -20,10 +20,8 @@ interface IAccountDropdownProps {
 }
 
 function AccountDropdown({ accounts, name, value, onSelect, asset }: IAccountDropdownProps) {
-  const { getAccountLabel } = useContext(AddressBookContext);
   const relevantAccounts: StoreAccount[] = accounts.map(account => ({
     ...account,
-    label: getAccountLabel(account),
     balance: formatEther(asset ? getAccountBalance(account, asset) : getAccountBalance(account)),
     assetSymbol: asset ? asset.ticker : getBaseAsset(account)!.ticker
   }));

--- a/common/v2/components/Banner.stories.tsx
+++ b/common/v2/components/Banner.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+
+import { BannerType } from 'v2/types';
 import { Banner } from './Banner';
-import { BannerType } from '../types';
 
 export default { title: 'Banner' };
 

--- a/common/v2/components/SignTransactionWallets/__tests__/WalletConnect.test.tsx
+++ b/common/v2/components/SignTransactionWallets/__tests__/WalletConnect.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { simpleRender } from 'test-utils';
-import { fAccount, fTransaction, fNetwork } from 'fixtures';
+import { fAccount, fTransaction, fNetwork } from '@fixtures';
 
 import { default as WalletConnectComponent } from '../WalletConnect';
 

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.stories.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { fTxConfig, fAccount } from '@fixtures';
+import { ExtendedAddressBook } from 'v2/types';
+import { noOp } from 'v2/utils';
+import { devContacts } from 'v2/database/seed';
+import { ConfirmTransactionUI } from './ConfirmTransaction';
+
+// Define props
+const assetRate = 1.34;
+const baseAssetRate = 1.54;
+const senderContact = devContacts[0] as ExtendedAddressBook;
+const recipientContact = devContacts[1] as ExtendedAddressBook;
+const onComplete = noOp;
+
+export default { title: 'ConfirmTx' };
+
+export const confirmTransaction = () => (
+  <div className="sb-container" style={{ maxWidth: '620px' }}>
+    <ConfirmTransactionUI
+      assetRate={assetRate}
+      baseAssetRate={baseAssetRate}
+      senderAccount={fAccount}
+      senderContact={senderContact}
+      recipientContact={recipientContact}
+      onComplete={onComplete}
+      txConfig={fTxConfig}
+    />
+  </div>
+);
+
+// Uncomment this for Figma support:
+
+(confirmTransaction as any).story = {
+  name: 'ConfirmTransaction',
+  parameters: {
+    design: {
+      type: 'figma',
+      url:
+        'https://www.figma.com/file/BY0SWc75teEUZzws8JdgLMpy/MyCrypto-GAU-Master?node-id=325%3A79384'
+    }
+  }
+};

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -10,7 +10,7 @@ import { AddressBookContext, StoreContext } from 'v2/services/Store';
 import { Amount, AssetIcon } from 'v2/components';
 import { fromWei, Wei, totalTxFeeToString, totalTxFeeToWei } from 'v2/services/EthService';
 import { RatesContext } from 'v2/services/RatesProvider';
-import { IStepComponentProps, ExtendedAddressBook} from 'v2/types';
+import { IStepComponentProps, ExtendedAddressBook } from 'v2/types';
 import { BREAK_POINTS } from 'v2/theme';
 
 import TransactionDetailsDisplay from './displays/TransactionDetailsDisplay';
@@ -102,13 +102,7 @@ export default function ConfirmTransaction({
   onComplete,
   signedTx
 }: IStepComponentProps) {
-  const {
-    asset,
-    senderAccount: account,
-    baseAsset,
-    receiverAddress,
-    network
-  } = txConfig;
+  const { asset, senderAccount: account, baseAsset, receiverAddress, network } = txConfig;
 
   const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
   const { getAssetRate } = useContext(RatesContext);
@@ -123,16 +117,18 @@ export default function ConfirmTransaction({
   const assetRate = getAssetRate(asset);
   const baseAssetRate = getAssetRate(baseAsset);
 
-  return <ConfirmTransactionUI
-    assetRate={assetRate}
-    baseAssetRate={baseAssetRate}
-    senderContact={senderContact}
-    senderAccount={senderAccount!}
-    txConfig={txConfig}
-    recipientContact={recipientContact}
-    onComplete={onComplete}
-    signedTx={signedTx}
-  />
+  return (
+    <ConfirmTransactionUI
+      assetRate={assetRate}
+      baseAssetRate={baseAssetRate}
+      senderContact={senderContact}
+      senderAccount={senderAccount!}
+      txConfig={txConfig}
+      recipientContact={recipientContact}
+      onComplete={onComplete}
+      signedTx={signedTx}
+    />
+  );
 }
 
 interface DataProps {
@@ -152,7 +148,7 @@ export const ConfirmTransactionUI = ({
   txConfig,
   onComplete,
   signedTx
-}: Omit<IStepComponentProps, 'resetFlow'> & DataProps ) => {
+}: Omit<IStepComponentProps, 'resetFlow'> & DataProps) => {
   const {
     asset,
     gasPrice,
@@ -253,19 +249,19 @@ export const ConfirmTransactionUI = ({
               />
             </>
           ) : (
-              <>
-                <AssetIcon symbol={asset.ticker as TSymbol} size={'30px'} />
-                <Amount
-                  assetValue={`${amount} ${asset.ticker}`}
-                  bold={true}
-                  baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
-                  fiatValue={`$${(
-                    convertToFiat(parseFloat(amount), assetRate) +
-                    convertToFiat(parseFloat(totalEtherEgress), baseAssetRate)
-                  ).toFixed(2)}`}
-                />
-              </>
-            )}
+            <>
+              <AssetIcon symbol={asset.ticker as TSymbol} size={'30px'} />
+              <Amount
+                assetValue={`${amount} ${asset.ticker}`}
+                bold={true}
+                baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
+                fiatValue={`$${(
+                  convertToFiat(parseFloat(amount), assetRate) +
+                  convertToFiat(parseFloat(totalEtherEgress), baseAssetRate)
+                ).toFixed(2)}`}
+              />
+            </>
+          )}
         </AmountWrapper>
       </RowWrapper>
       <TransactionDetailsDisplay
@@ -288,4 +284,4 @@ export const ConfirmTransactionUI = ({
       </SendButton>
     </ConfirmTransactionWrapper>
   );
-}
+};

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -6,11 +6,11 @@ import { Button } from '@mycrypto/ui';
 import feeIcon from 'common/assets/images/icn-fee.svg';
 import sendIcon from 'common/assets/images/icn-send.svg';
 import walletIcon from 'common/assets/images/icn-wallet.svg';
-import { AddressBookContext } from 'v2/services/Store';
+import { AddressBookContext, StoreContext } from 'v2/services/Store';
 import { Amount, AssetIcon } from 'v2/components';
 import { fromWei, Wei, totalTxFeeToString, totalTxFeeToWei } from 'v2/services/EthService';
 import { RatesContext } from 'v2/services/RatesProvider';
-import { IStepComponentProps } from 'v2/types';
+import { IStepComponentProps, ExtendedAddressBook} from 'v2/types';
 import { BREAK_POINTS } from 'v2/theme';
 
 import TransactionDetailsDisplay from './displays/TransactionDetailsDisplay';
@@ -19,6 +19,7 @@ import { convertToFiat, truncate } from 'v2/utils';
 import translate from 'v2/translations';
 import { TSymbol } from 'v2/types/symbols';
 import Account from '../Account';
+import { StoreAccount } from 'v2/types/account';
 const { SCREEN_XS } = BREAK_POINTS;
 
 const ConfirmTransactionWrapper = Styled.div`
@@ -101,33 +102,76 @@ export default function ConfirmTransaction({
   onComplete,
   signedTx
 }: IStepComponentProps) {
+  const {
+    asset,
+    senderAccount: account,
+    baseAsset,
+    receiverAddress,
+    network
+  } = txConfig;
+
   const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
-  const [isBroadcastingTx, setIsBroadcastingTx] = useState(false);
-  const handleApprove = () => {
-    setIsBroadcastingTx(true);
-    onComplete(null);
-  };
-
   const { getAssetRate } = useContext(RatesContext);
-  const recipientContact = getContactByAddressAndNetwork(
-    txConfig.receiverAddress,
-    txConfig.network
-  );
-  const recipientLabel = recipientContact ? recipientContact.label : 'Unknown Address';
+  const { getAccount } = useContext(StoreContext);
 
+  /* Get contact info */
+  const recipientContact = getContactByAddressAndNetwork(receiverAddress, network);
+  const senderContact = getContactByAccount(account);
+  const senderAccount = getAccount(account);
+
+  /* Get Rates */
+  const assetRate = getAssetRate(asset);
+  const baseAssetRate = getAssetRate(baseAsset);
+
+  return <ConfirmTransactionUI
+    assetRate={assetRate}
+    baseAssetRate={baseAssetRate}
+    senderContact={senderContact}
+    senderAccount={senderAccount!}
+    txConfig={txConfig}
+    recipientContact={recipientContact}
+    onComplete={onComplete}
+    signedTx={signedTx}
+  />
+}
+
+interface DataProps {
+  assetRate?: number;
+  baseAssetRate?: number;
+  recipientContact?: ExtendedAddressBook;
+  senderContact?: ExtendedAddressBook;
+  senderAccount: StoreAccount;
+}
+
+export const ConfirmTransactionUI = ({
+  assetRate,
+  baseAssetRate,
+  senderAccount,
+  senderContact,
+  recipientContact,
+  txConfig,
+  onComplete,
+  signedTx
+}: Omit<IStepComponentProps, 'resetFlow'> & DataProps ) => {
   const {
     asset,
     gasPrice,
     gasLimit,
     value,
     amount,
-    senderAccount,
     receiverAddress,
     network,
     nonce,
     data,
     baseAsset
   } = txConfig;
+
+  const [isBroadcastingTx, setIsBroadcastingTx] = useState(false);
+  const handleApprove = () => {
+    setIsBroadcastingTx(true);
+    onComplete(null);
+  };
+
   const assetType = asset.type;
 
   /* Calculate Transaction Fee */
@@ -136,15 +180,10 @@ export default function ConfirmTransaction({
 
   /* Calculate total base asset amount */
   const valueWei = Wei(value);
-  const totalEtherEgress = parseFloat(fromWei(valueWei.add(transactionFeeWei), 'ether')).toFixed(6); // @TODO: BN math, add amount + maxCost !In same symbol
-
-  /* Determing User's Contact */
-  const senderContact = getContactByAccount(senderAccount);
+  // @TODO: BN math, add amount + maxCost !In same symbol
+  const totalEtherEgress = parseFloat(fromWei(valueWei.add(transactionFeeWei), 'ether')).toFixed(6);
   const senderAccountLabel = senderContact ? senderContact.label : 'Unknown Account';
-
-  /* Get Rates */
-  const assetRate = getAssetRate(asset);
-  const baseAssetRate = getAssetRate(baseAsset);
+  const recipientLabel = recipientContact ? recipientContact.label : 'Unknown Address';
 
   return (
     <ConfirmTransactionWrapper>
@@ -214,19 +253,19 @@ export default function ConfirmTransaction({
               />
             </>
           ) : (
-            <>
-              <AssetIcon symbol={asset.ticker as TSymbol} size={'30px'} />
-              <Amount
-                assetValue={`${amount} ${asset.ticker}`}
-                bold={true}
-                baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
-                fiatValue={`$${(
-                  convertToFiat(parseFloat(amount), assetRate) +
-                  convertToFiat(parseFloat(totalEtherEgress), baseAssetRate)
-                ).toFixed(2)}`}
-              />
-            </>
-          )}
+              <>
+                <AssetIcon symbol={asset.ticker as TSymbol} size={'30px'} />
+                <Amount
+                  assetValue={`${amount} ${asset.ticker}`}
+                  bold={true}
+                  baseAssetValue={`+ ${totalEtherEgress} ${baseAsset.ticker}`}
+                  fiatValue={`$${(
+                    convertToFiat(parseFloat(amount), assetRate) +
+                    convertToFiat(parseFloat(totalEtherEgress), baseAssetRate)
+                  ).toFixed(2)}`}
+                />
+              </>
+            )}
         </AmountWrapper>
       </RowWrapper>
       <TransactionDetailsDisplay

--- a/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
@@ -2,9 +2,9 @@ import React, { useState, useContext } from 'react';
 import { Network } from '@mycrypto/ui';
 import { bigNumberify } from 'ethers/utils';
 
-import { Asset, StoreAccount, IAccount, Network as INetwork, ITxObject } from 'v2/types';
+import { Asset, StoreAccount, Network as INetwork, ITxObject } from 'v2/types';
 import { baseToConvertedUnit, totalTxFeeToString } from 'v2/services/EthService';
-import { getAccountBalance, StoreContext } from 'v2/services/Store';
+import { getAccountBalance } from 'v2/services/Store';
 import { CopyableCodeBlock, Button } from 'v2/components';
 import { DEFAULT_ASSET_DECIMAL } from 'v2/config';
 import { weiToFloat, isTransactionDataEmpty } from 'v2/utils';
@@ -23,7 +23,7 @@ interface Props {
   data: string;
   gasLimit: string;
   gasPrice: string;
-  senderAccount: IAccount;
+  senderAccount: StoreAccount;
   rawTransaction?: ITxObject;
   signedTransaction?: string;
 }
@@ -41,7 +41,6 @@ function TransactionDetailsDisplay({
   signedTransaction
 }: Props) {
   const [showDetails, setShowDetails] = useState(false);
-  const { getAccount } = useContext(StoreContext);
 
   const maxTransactionFeeBase: string = totalTxFeeToString(gasPrice, gasLimit);
   const networkName = network ? network.name : undefined;
@@ -76,7 +75,7 @@ function TransactionDetailsDisplay({
                 </div>
                 <div className="TransactionDetails-row-column">{`
                   ${weiToFloat(
-                    getAccountBalance(getAccount(senderAccount) as StoreAccount)
+                    getAccountBalance(senderAccount)
                   ).toFixed(6)}
                   ${baseAsset.ticker}
                 `}</div>

--- a/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Network } from '@mycrypto/ui';
 import { bigNumberify } from 'ethers/utils';
 
@@ -74,9 +74,7 @@ function TransactionDetailsDisplay({
                   {`Account Balance (${baseAsset.ticker}):`}
                 </div>
                 <div className="TransactionDetails-row-column">{`
-                  ${weiToFloat(
-                    getAccountBalance(senderAccount)
-                  ).toFixed(6)}
+                  ${weiToFloat(getAccountBalance(senderAccount)).toFixed(6)}
                   ${baseAsset.ticker}
                 `}</div>
               </div>

--- a/common/v2/components/__tests__/AssetDropdown.test.tsx
+++ b/common/v2/components/__tests__/AssetDropdown.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { simpleRender } from 'test-utils';
-import { fAssets } from 'fixtures';
+import { fAssets } from '@fixtures';
 import { Asset, TSymbol } from 'v2/types';
 
 import AssetDropdown, { Props } from '../AssetDropdown';

--- a/common/v2/components/__tests__/ContactLookupField.test.tsx
+++ b/common/v2/components/__tests__/ContactLookupField.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+
 import { simpleRender, fireEvent, wait } from 'test-utils';
-import { fNetwork } from 'fixtures';
+import { fNetwork } from '@fixtures';
 
 import { AddressBookContext } from 'v2/services/Store';
 import { AddressBook, ExtendedAddressBook, TUuid, IReceiverAddress } from 'v2/types';

--- a/common/v2/features/BroadcastTransaction/stateFactory.tsx
+++ b/common/v2/features/BroadcastTransaction/stateFactory.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { TUseStateReducerFactory, fromTxReceiptObj, makeTxConfigFromSignedTx } from 'v2/utils';
 import { ITxReceipt, ITxConfig, ISignedTx, NetworkId } from 'v2/types';
 import { DEFAULT_NETWORK } from 'v2/config';
-import { NetworkContext, AssetContext, AccountContext } from 'v2/services/Store';
+import { NetworkContext, AssetContext, StoreContext } from 'v2/services/Store';
 import { ProviderHandler } from 'v2/services/EthService';
 import { ToastContext } from 'v2/features/Toasts';
 
@@ -25,7 +25,7 @@ const BroadcastTxConfigFactory: TUseStateReducerFactory<State> = ({ state, setSt
   const { networks, getNetworkByName } = useContext(NetworkContext);
   const { assets } = useContext(AssetContext);
   const { displayToast, toastTemplates } = useContext(ToastContext);
-  const { accounts } = useContext(AccountContext);
+  const { accounts } = useContext(StoreContext);
 
   const handleNetworkChanged = (network: NetworkId) => {
     setState((prevState: State) => ({

--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -36,7 +36,8 @@ import {
   IFormikFields,
   IStepComponentProps,
   ITxConfig,
-  ErrorObject
+  ErrorObject,
+  StoreAccount
 } from 'v2/types';
 import {
   getNonce,
@@ -94,7 +95,7 @@ const initialFormikValues: IFormikFields = {
     display: ''
   },
   amount: '',
-  account: {} as IAccount, // should be renamed senderAccount
+  account: {} as StoreAccount, // should be renamed senderAccount
   network: {} as Network, // Not a field move to state
   asset: {} as StoreAsset,
   txDataField: '0x',

--- a/common/v2/features/SendAssets/stateFactory.tsx
+++ b/common/v2/features/SendAssets/stateFactory.tsx
@@ -16,7 +16,8 @@ import {
   getBaseAssetByNetwork,
   AccountContext,
   AssetContext,
-  NetworkContext
+  NetworkContext,
+  StoreContext
 } from 'v2/services';
 import {
   ProviderHandler,
@@ -51,8 +52,8 @@ interface State {
 const TxConfigFactory: TUseStateReducerFactory<State> = ({ state, setState }) => {
   const { assets } = useContext(AssetContext);
   const { networks } = useContext(NetworkContext);
-
-  const { addNewTransactionToAccount, accounts } = useContext(AccountContext);
+  const { accounts } = useContext(StoreContext);
+  const { addNewTransactionToAccount } = useContext(AccountContext);
 
   const handleFormSubmit: TStepAction = (payload: IFormikFields, cb: any) => {
     const rawTransaction: ITxObject = processFormDataToTx(payload);

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -85,7 +85,7 @@ export const StoreProvider: React.FC = ({ children }) => {
   const [pendingTransactions, setPendingTransactions] = useState([] as ITxReceipt[]);
   // We transform rawAccounts into StoreAccount. Since the operation is exponential to the number of
   // accounts, make sure it is done only when rawAccounts change.
-  const accounts = useMemo(() => getStoreAccounts(rawAccounts, assets, networks), [
+  const accounts = useMemo(() => getStoreAccounts(rawAccounts, assets, networks, addressBook), [
     rawAccounts,
     assets,
     networks

--- a/common/v2/services/Store/helpers.tsx
+++ b/common/v2/services/Store/helpers.tsx
@@ -1,6 +1,5 @@
 import { bigNumberify } from 'ethers/utils';
 
-import { getNetworkById } from './Network';
 import {
   Network,
   AssetBalanceObject,
@@ -9,8 +8,12 @@ import {
   IAccount,
   StoreAccount,
   ITxStatus,
-  ITxReceipt
+  ITxReceipt,
+  ExtendedAddressBook
 } from 'v2/types';
+
+import { getLabelByAccount } from './AddressBook';
+import { getNetworkById } from './Network';
 
 const getAssetsByUuid = (accountAssets: AssetBalanceObject[], assets: Asset[]): StoreAsset[] =>
   accountAssets
@@ -26,12 +29,14 @@ const getAssetsByUuid = (accountAssets: AssetBalanceObject[], assets: Asset[]): 
 export const getStoreAccounts = (
   accounts: IAccount[],
   assets: Asset[],
-  networks: Network[]
+  networks: Network[],
+  contacts: ExtendedAddressBook[]
 ): StoreAccount[] => {
   return accounts.map(a => ({
     ...a,
     assets: getAssetsByUuid(a.assets, assets),
-    network: getNetworkById(a.networkId, networks)
+    network: getNetworkById(a.networkId, networks),
+    label: getLabelByAccount(a, contacts)!.label
   }));
 };
 

--- a/common/v2/services/Store/index.tsx
+++ b/common/v2/services/Store/index.tsx
@@ -6,4 +6,4 @@ export * from './Network';
 export * from './Settings';
 export * from './DataManager';
 export { StoreContext, StoreProvider } from './StoreProvider';
-export { getAccountBalance } from './utils';
+export { getAccountBalance, getStoreAccount } from './utils';

--- a/common/v2/services/Store/utils.ts
+++ b/common/v2/services/Store/utils.ts
@@ -1,6 +1,6 @@
 import { bigNumberify, BigNumber } from 'ethers/utils';
 
-import { Asset, StoreAccount } from 'v2/types';
+import { TAddress, NetworkId, Asset, StoreAccount } from 'v2/types';
 
 // Every StoreAccount has a base asset and a balance
 const getAccountBaseBalance = (account: StoreAccount) =>
@@ -13,3 +13,8 @@ const getAccountTokenBalance = (account: StoreAccount, token: Asset): BigNumber 
 
 export const getAccountBalance = (account: StoreAccount, token?: Asset): BigNumber =>
   token ? getAccountTokenBalance(account, token) : getAccountBaseBalance(account);
+
+export const getStoreAccount = (accounts: StoreAccount[]) => (
+  address: TAddress,
+  networkId: NetworkId
+) => accounts.find(a => a.address === address && a.networkId === networkId);

--- a/common/v2/types/account.tsx
+++ b/common/v2/types/account.tsx
@@ -35,4 +35,7 @@ export type StoreAccount = Overwrite<
   {
     assets: StoreAsset[];
   }
-> & { network: Network };
+> & {
+  network: Network;
+  label: string;
+};

--- a/common/v2/types/transactionFlow.ts
+++ b/common/v2/types/transactionFlow.ts
@@ -1,11 +1,10 @@
 import {
   Asset,
-  IAccount as IIAccount,
   Network as INetwork,
   GasEstimates,
-  IAccount,
   ITxReceipt,
-  WalletId
+  WalletId,
+  StoreAccount
 } from 'v2/types';
 
 export type ISignedTx = string;
@@ -25,7 +24,7 @@ export interface ITxConfig {
   readonly rawTransaction: ITxObject /* The rawTransaction object that will be signed */;
   readonly amount: string;
   readonly receiverAddress: string;
-  readonly senderAccount: IIAccount;
+  readonly senderAccount: StoreAccount;
   readonly from: string;
   readonly asset: Asset;
   readonly baseAsset: Asset;
@@ -41,7 +40,7 @@ export interface IFormikFields {
   asset: Asset;
   address: IReceiverAddress;
   amount: string;
-  account: IIAccount;
+  account: StoreAccount;
   txDataField: string;
   gasEstimates: GasEstimates;
   gasPriceField: string;
@@ -55,7 +54,7 @@ export interface IFormikFields {
 
 export interface ISignComponentProps {
   network: INetwork;
-  senderAccount: IAccount;
+  senderAccount: StoreAccount;
   rawTransaction: ITxObject;
   children?: never;
   onSuccess(receipt: ITxReceipt | ISignedTx): void;

--- a/common/v2/utils/transaction.ts
+++ b/common/v2/utils/transaction.ts
@@ -4,7 +4,7 @@ import {
   getNetworkByChainId,
   getBaseAssetByNetwork,
   getAssetByContractAndNetwork,
-  getAccountByAddressAndNetworkName
+  getStoreAccount
 } from 'v2/services/Store';
 import {
   ERC20,
@@ -20,8 +20,9 @@ import {
   getDecimalFromEtherUnit,
   gasPriceToBase
 } from 'v2/services/EthService';
-import { ITxReceipt, ExtendedAsset, Network, ITxConfig, IAccount } from 'v2/types';
+import { ITxReceipt, ExtendedAsset, Network, ITxConfig, StoreAccount } from 'v2/types';
 import { DEFAULT_ASSET_DECIMAL } from 'v2/config';
+import { TAddress } from 'v2/types/address';
 
 export const fromTxReceiptObj = (txReceipt: ITxReceipt) => (
   assets: ExtendedAsset[],
@@ -77,7 +78,7 @@ export const makeTxConfigFromSignedTx = (
   signedTx: Arrayish,
   assets: ExtendedAsset[],
   networks: Network[],
-  accounts: IAccount[],
+  accounts: StoreAccount[],
   oldTxConfig: ITxConfig = {} as ITxConfig
 ): ITxConfig => {
   const decodedTx = decodeTransaction(signedTx);
@@ -111,7 +112,7 @@ export const makeTxConfigFromSignedTx = (
     baseAsset: baseAsset || oldTxConfig.baseAsset,
     senderAccount:
       decodedTx.from && networkDetected
-        ? getAccountByAddressAndNetworkName(accounts)(decodedTx.from, networkDetected.name) ||
+        ? getStoreAccount(accounts)(decodedTx.from as TAddress, networkDetected.id) ||
           oldTxConfig.senderAccount ||
           defaultSenderAccount
         : oldTxConfig.senderAccount || defaultSenderAccount,

--- a/common/vendor/safe-t-connect.js
+++ b/common/vendor/safe-t-connect.js
@@ -1007,6 +1007,4 @@ function PopupManager() {
     };
 }
 
-var connect = new SafeTConnect();
-
-module.exports = connect;
+export default new SafeTConnect();

--- a/jest_config/__fixtures__/index.ts
+++ b/jest_config/__fixtures__/index.ts
@@ -2,3 +2,4 @@ export { fAssets } from './assets';
 export { fAccount } from './account';
 export { fNetwork } from './network';
 export { fTransaction } from './transaction';
+export { default as fTxConfig } from './txConfig.json';

--- a/jest_config/__fixtures__/txConfig.json
+++ b/jest_config/__fixtures__/txConfig.json
@@ -1,0 +1,131 @@
+{
+    "rawTransaction": {
+        "to": "0x909f74Ffdc223586d0d30E78016E707B6F5a45E2",
+        "value": "0x5af3107a4000",
+        "data": "0x",
+        "gasLimit": "0x5208",
+        "gasPrice": "0xee6b2800",
+        "nonce": "0x32",
+        "chainId": 3
+    },
+    "amount": "0.0001",
+    "senderAccount": {
+        "address": "0xfE5443FaC29fA621cFc33D41D1927fd0f5E0bB7c",
+        "networkId": "Ropsten",
+        "wallet": "WALLETCONNECT",
+        "dPath": "",
+        "assets": [
+            {
+                "uuid": "77de68da-ecd8-53ba-bbb5-8edb1c8e14d7",
+                "name": "RopstenETH",
+                "networkId": "Ropsten",
+                "type": "base",
+                "ticker": "RopstenETH",
+                "decimal": 18,
+                "balance": {
+                    "_hex": "0x1b0319f410dfc000"
+                },
+                "mtime": 1582563688522
+            }
+        ],
+        "transactions": [],
+        "favorite": false,
+        "mtime": 0,
+        "uuid": "93799435-3a78-342f-cc62-36e9e5d00455",
+        "network": {
+            "id": "Ropsten",
+            "name": "Ropsten",
+            "chainId": 3,
+            "isCustom": false,
+            "isTestnet": true,
+            "color": "#adc101",
+            "gasPriceSettings": {
+                "min": 0.1,
+                "max": 40,
+                "initial": 4
+            },
+            "dPaths": {
+                "TREZOR": {
+                    "label": "Testnet (ETH)",
+                    "value": "m/44'/1'/0'/0"
+                },
+                "SAFE_T_MINI": {
+                    "label": "Testnet (ETH)",
+                    "value": "m/44'/1'/0'/0"
+                },
+                "LEDGER_NANO_S": {
+                    "label": "Ledger (ETH)",
+                    "value": "m/44'/60'/0'"
+                },
+                "MNEMONIC_PHRASE": {
+                    "label": "Testnet (ETH)",
+                    "value": "m/44'/1'/0'/0"
+                },
+                "default": {
+                    "label": "Testnet (ETH)",
+                    "value": "m/44'/1'/0'/0"
+                }
+            },
+            "contracts": [],
+            "assets": [
+                "77de68da-ecd8-53ba-bbb5-8edb1c8e14d7",
+                "e0977bcb-30be-53cf-99d2-e5f031e8624b",
+                "8fa21ab1-48ac-544a-b13c-69d86528d126",
+                "3849a248-49b4-5e85-91cb-0f9f97eaa0c9",
+                "528fb72f-8536-5219-8b65-20fbd0e4355d",
+                "4f6380d2-303e-5fe4-8f0b-25f944e5dc84",
+                "39a543b0-ac4f-5b14-9467-86fd6538a6a2"
+            ],
+            "baseAsset": "77de68da-ecd8-53ba-bbb5-8edb1c8e14d7",
+            "baseUnit": "RopstenETH",
+            "nodes": [
+                {
+                    "name": "ropsten_infura",
+                    "type": "infura",
+                    "service": "Infura",
+                    "url": "https://ropsten.infura.io/v3/c02fff6b5daa434d8422b8ece54c7286"
+                },
+                {
+                    "name": "web3",
+                    "isCustom": false,
+                    "type": "web3",
+                    "url": "",
+                    "service": "MetaMask / Web3",
+                    "hidden": true,
+                    "network": "WEB3_Ropsten"
+                }
+            ],
+            "blockExplorer": {
+                "name": "Etherscan",
+                "origin": "https://ropsten.etherscan.io"
+            }
+        },
+        "label": "WalletConnect Account 2",
+        "balance": "1.946428",
+        "assetSymbol": "RopstenETH"
+    },
+    "receiverAddress": "0x909f74Ffdc223586d0d30E78016E707B6F5a45E2",
+    "asset": {
+        "uuid": "77de68da-ecd8-53ba-bbb5-8edb1c8e14d7",
+        "name": "RopstenETH",
+        "networkId": "Ropsten",
+        "type": "base",
+        "ticker": "RopstenETH",
+        "decimal": 18,
+        "mtime": 1582563685097
+    },
+    "baseAsset": {
+        "uuid": "77de68da-ecd8-53ba-bbb5-8edb1c8e14d7",
+        "name": "RopstenETH",
+        "networkId": "Ropsten",
+        "type": "base",
+        "ticker": "RopstenETH",
+        "decimal": 18
+    },
+    "from": "0xfE5443FaC29fA621cFc33D41D1927fd0f5E0bB7c",
+    "gasPrice": "4000000000",
+    "gasLimit": "21000",
+    "nonce": "50",
+    "data": "0x",
+    "value": "100000000000000"
+}

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "dev:electron": "cross-env BUILD_ELECTRON=true concurrently -r --kill-others -n \"RENDERER,MAIN\" \"yarn run dev:electron:renderer\" \"yarn run dev:electron:main\"",
     "dev:electron:main": "webpack --config webpack_config/electron-main.development.js && electron dist/electron-main/main.js",
     "dev:electron:renderer": "webpack-dev-server --config webpack_config/electron-renderer.development.js",
-    "storybook": "start-storybook",
+    "storybook": "start-storybook -p 3001 --ci",
     "tslint": "tslint --project .",
     "tscheck": "tsc",
     "start": " yarn run dev",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
       "shared*": ["../shared*"],
       "types*": ["../shared/types*"],
       "test-utils": ["../jest_config/test-utils"],
-      "fixtures": ["../jest_config/__fixtures__"]
+      "@fixtures": ["../jest_config/__fixtures__"]
     },
     "lib": ["esnext", "dom"],
     "allowSyntheticDefaultImports": true,
@@ -26,8 +26,8 @@
     "noImplicitAny": true,
     "skipLibCheck": true
   },
-  "include": ["./scripts", "./common/", "./electron-app/", "./shared/", "spec"],
-  "exclude": ["./jest_config/**/*"],
+  "include": ["./scripts", "./common/", "./electron-app/", "./shared/", "spec", "./jest_config"],
+  "exclude": ["jest_config/__mocks__"],
   "awesomeTypescriptLoaderOptions": {
     "transpileOnly": true
   }

--- a/webpack_config/common.js
+++ b/webpack_config/common.js
@@ -31,7 +31,8 @@ module.exports = {
       config.path.root
     ],
     alias: {
-      modernizr$: path.resolve(__dirname, '../.modernizrrc.js')
+      modernizr$: path.resolve(__dirname, '../.modernizrrc.js'),
+      '@fixtures': `${config.path.root}/jest_config/__fixtures__`
     }
   },
 
@@ -54,7 +55,8 @@ module.exports = {
         include: [
           config.path.src,
           config.path.shared,
-          config.path.electron
+          config.path.electron,
+          config.path.testConfig
         ],
         exclude: /node_modules/,
       },

--- a/webpack_config/config.js
+++ b/webpack_config/config.js
@@ -9,7 +9,8 @@ const paths = {
   static: path.join(__dirname, '../static'),
   electron: path.join(__dirname, '../electron-app'),
   shared: path.join(__dirname, '../shared'),
-  modules: path.join(__dirname, '../node_modules')
+  modules: path.join(__dirname, '../node_modules'),
+  testConfig: path.join(__dirname, '../jest_config')
 };
 
 module.exports = {
@@ -26,16 +27,6 @@ module.exports = {
     creator: '@MyCrypto'
   },
   path: paths,
-
-  // Typescript rule config
-  typescriptRule: {
-    test: /\.(ts|tsx)$/,
-    include: [paths.src, paths.shared, paths.electron],
-    use: [{ loader: 'ts-loader', options: { happyPackMode: true, logLevel: 'info' } }],
-    exclude: ['assets', 'sass', 'vendor', 'translations/lang']
-      .map(dir => path.resolve(paths.src, dir))
-      .concat([paths.modules])
-  },
 
   // File resolution
   resolve: {

--- a/webpack_config/config.js
+++ b/webpack_config/config.js
@@ -28,15 +28,6 @@ module.exports = {
   },
   path: paths,
 
-  // File resolution
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.css', '.json', '.scss'],
-    modules: [paths.src, paths.modules, paths.root],
-    alias: {
-      modernizr$: path.resolve(__dirname, '../.modernizrrc.js')
-    }
-  },
-
   // Vendor modules
   vendorModules: [
     'bip39',


### PR DESCRIPTION
1. Configure Storybook (SB) to use project css and assets.
2. Center display of story
3. Set default port to ':3001'
4. Update ConfirmTransaction component to enable use in Storybook
5. Updated StoreAccount to get existing account 'label'. (This commit was included because it removes unnecessary dependencies on `AddressBook` and creates more standard typing. It remains optional)


<img width="1103" alt="Screenshot 2020-02-25 at 19 04 12" src="https://user-images.githubusercontent.com/2429708/75291783-a97d6380-5801-11ea-8e32-8d08cd07b02f.png">



### Steps to test.
1. Pull PR and run `yarn && yarn storybook`.
2. Open browser at `localhost:3001`
3. Click on 'ConfirmTransaction'
4. Use the mycryptobuilds.com link and create a transaction (it should have no regressions).
