### PR TITLE
Fallback to default account if none found in store

### DIFF
--- a/common/v2/components/TransactionFlow/ConfirmTransaction.stories.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.stories.tsx
@@ -4,7 +4,9 @@ import { fTxConfig, fAccount } from '@fixtures';
 import { ExtendedAddressBook } from 'v2/types';
 import { noOp } from 'v2/utils';
 import { devContacts } from 'v2/database/seed';
+
 import { ConfirmTransactionUI } from './ConfirmTransaction';
+import { constructSenderFromTxConfig } from './helpers';
 
 // Define props
 const assetRate = 1.34;
@@ -20,11 +22,11 @@ export const confirmTransaction = () => (
     <ConfirmTransactionUI
       assetRate={assetRate}
       baseAssetRate={baseAssetRate}
-      senderAccount={fAccount}
       senderContact={senderContact}
       recipientContact={recipientContact}
       onComplete={onComplete}
       txConfig={fTxConfig}
+      sender={constructSenderFromTxConfig(fTxConfig, [fAccount])}
     />
   </div>
 );

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -111,7 +111,7 @@ export default function ConfirmTransaction({
   /* Get contact info */
   const recipientContact = getContactByAddressAndNetwork(receiverAddress, network);
   const senderContact = getContactByAccount(account);
-  const senderAccount = getAccount(account);
+  const senderAccount = getAccount(account) || account;
 
   /* Get Rates */
   const assetRate = getAssetRate(asset);
@@ -122,7 +122,7 @@ export default function ConfirmTransaction({
       assetRate={assetRate}
       baseAssetRate={baseAssetRate}
       senderContact={senderContact}
-      senderAccount={senderAccount!}
+      senderAccount={senderAccount}
       txConfig={txConfig}
       recipientContact={recipientContact}
       onComplete={onComplete}

--- a/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
+++ b/common/v2/components/TransactionFlow/ConfirmTransaction.tsx
@@ -3,23 +3,25 @@ import Styled from 'styled-components';
 import BN from 'bn.js';
 import { Button } from '@mycrypto/ui';
 
-import feeIcon from 'common/assets/images/icn-fee.svg';
-import sendIcon from 'common/assets/images/icn-send.svg';
-import walletIcon from 'common/assets/images/icn-wallet.svg';
 import { AddressBookContext, StoreContext } from 'v2/services/Store';
-import { Amount, AssetIcon } from 'v2/components';
+import { Amount, AssetIcon, Account } from 'v2/components';
 import { fromWei, Wei, totalTxFeeToString, totalTxFeeToWei } from 'v2/services/EthService';
 import { RatesContext } from 'v2/services/RatesProvider';
 import { IStepComponentProps, ExtendedAddressBook } from 'v2/types';
 import { BREAK_POINTS } from 'v2/theme';
-
-import TransactionDetailsDisplay from './displays/TransactionDetailsDisplay';
-import TxIntermediaryDisplay from './displays/TxIntermediaryDisplay';
 import { convertToFiat, truncate } from 'v2/utils';
 import translate from 'v2/translations';
 import { TSymbol } from 'v2/types/symbols';
-import Account from '../Account';
-import { StoreAccount } from 'v2/types/account';
+
+import TransactionDetailsDisplay from './displays/TransactionDetailsDisplay';
+import TxIntermediaryDisplay from './displays/TxIntermediaryDisplay';
+import { constructSenderFromTxConfig } from './helpers';
+import { ISender } from './types';
+
+import feeIcon from 'common/assets/images/icn-fee.svg';
+import sendIcon from 'common/assets/images/icn-send.svg';
+import walletIcon from 'common/assets/images/icn-wallet.svg';
+
 const { SCREEN_XS } = BREAK_POINTS;
 
 const ConfirmTransactionWrapper = Styled.div`
@@ -102,16 +104,16 @@ export default function ConfirmTransaction({
   onComplete,
   signedTx
 }: IStepComponentProps) {
-  const { asset, senderAccount: account, baseAsset, receiverAddress, network } = txConfig;
+  const { asset, baseAsset, receiverAddress, network, from } = txConfig;
 
-  const { getContactByAccount, getContactByAddressAndNetwork } = useContext(AddressBookContext);
+  const { getContactByAddressAndNetworkId } = useContext(AddressBookContext);
   const { getAssetRate } = useContext(RatesContext);
-  const { getAccount } = useContext(StoreContext);
+  const { accounts } = useContext(StoreContext);
 
   /* Get contact info */
-  const recipientContact = getContactByAddressAndNetwork(receiverAddress, network);
-  const senderContact = getContactByAccount(account);
-  const senderAccount = getAccount(account) || account;
+  const recipientContact = getContactByAddressAndNetworkId(receiverAddress, network.id);
+  const senderContact = getContactByAddressAndNetworkId(from, network.id);
+  const sender = constructSenderFromTxConfig(txConfig, accounts);
 
   /* Get Rates */
   const assetRate = getAssetRate(asset);
@@ -122,7 +124,7 @@ export default function ConfirmTransaction({
       assetRate={assetRate}
       baseAssetRate={baseAssetRate}
       senderContact={senderContact}
-      senderAccount={senderAccount}
+      sender={sender}
       txConfig={txConfig}
       recipientContact={recipientContact}
       onComplete={onComplete}
@@ -136,14 +138,14 @@ interface DataProps {
   baseAssetRate?: number;
   recipientContact?: ExtendedAddressBook;
   senderContact?: ExtendedAddressBook;
-  senderAccount: StoreAccount;
+  sender: ISender;
 }
 
 export const ConfirmTransactionUI = ({
   assetRate,
   baseAssetRate,
-  senderAccount,
   senderContact,
+  sender,
   recipientContact,
   txConfig,
   onComplete,
@@ -156,12 +158,10 @@ export const ConfirmTransactionUI = ({
     value,
     amount,
     receiverAddress,
-    network,
     nonce,
     data,
     baseAsset
   } = txConfig;
-
   const [isBroadcastingTx, setIsBroadcastingTx] = useState(false);
   const handleApprove = () => {
     setIsBroadcastingTx(true);
@@ -186,11 +186,7 @@ export const ConfirmTransactionUI = ({
       <RowWrapper stack={true}>
         <AddressWrapper position={'left'}>
           {translate('CONFIRM_TX_FROM')}
-          <Account
-            address={senderAccount ? senderAccount.address : 'Unknown'}
-            title={senderAccountLabel}
-            truncate={truncate}
-          />
+          <Account address={sender.address} title={senderAccountLabel} truncate={truncate} />
         </AddressWrapper>
         <AddressWrapper position={'right'}>
           {translate('CONFIRM_TX_TO')}
@@ -268,8 +264,7 @@ export const ConfirmTransactionUI = ({
         baseAsset={baseAsset}
         asset={asset}
         data={data}
-        network={network}
-        senderAccount={senderAccount}
+        sender={sender}
         gasLimit={gasLimit}
         gasPrice={gasPrice}
         nonce={nonce}

--- a/common/v2/components/TransactionFlow/TxReceipt.stories.tsx
+++ b/common/v2/components/TransactionFlow/TxReceipt.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { fTxConfig, fTxReceipt } from '@fixtures';
+import { fTxConfig, fTxReceipt, fAccount } from '@fixtures';
 import { ITxStatus, ExtendedAddressBook, ITxType } from 'v2/types';
 import { noOp } from 'v2/utils';
 import { devContacts } from 'v2/database/seed';
 import { IZapConfig, ZAPS_CONFIG } from 'v2/features/DeFiZap/config';
 
 import { TxReceiptUI } from './TxReceipt';
+import { constructSenderFromTxConfig } from './helpers';
 
 // Define props
 const assetRate = 1.34;
@@ -29,6 +30,7 @@ export const transactionReceipt = () => (
       senderContact={senderContact}
       recipientContact={recipientContact}
       txConfig={fTxConfig}
+      sender={constructSenderFromTxConfig(fTxConfig, [fAccount])}
     />
   </div>
 );
@@ -49,6 +51,7 @@ export const transactionReceiptDeFiZap = () => (
       senderContact={senderContact}
       recipientContact={recipientContact}
       txConfig={fTxConfig}
+      sender={constructSenderFromTxConfig(fTxConfig, [fAccount])}
     />
   </div>
 );

--- a/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
+++ b/common/v2/components/TransactionFlow/displays/TransactionDetailsDisplay.tsx
@@ -2,14 +2,15 @@ import React, { useState } from 'react';
 import { Network } from '@mycrypto/ui';
 import { bigNumberify } from 'ethers/utils';
 
-import { Asset, StoreAccount, Network as INetwork, ITxObject } from 'v2/types';
+import { Asset, ITxObject } from 'v2/types';
 import { baseToConvertedUnit, totalTxFeeToString } from 'v2/services/EthService';
-import { getAccountBalance } from 'v2/services/Store';
 import { CopyableCodeBlock, Button } from 'v2/components';
 import { DEFAULT_ASSET_DECIMAL } from 'v2/config';
 import { weiToFloat, isTransactionDataEmpty } from 'v2/utils';
 import translate from 'v2/translations';
 import { COLORS } from 'v2/theme';
+
+import { ISender } from '../types';
 
 import './TransactionDetailsDisplay.scss';
 
@@ -18,33 +19,33 @@ const { BLUE_BRIGHT } = COLORS;
 interface Props {
   baseAsset: Asset;
   asset: Asset;
-  network: INetwork;
   nonce: string;
   data: string;
   gasLimit: string;
   gasPrice: string;
-  senderAccount: StoreAccount;
   rawTransaction?: ITxObject;
   signedTransaction?: string;
+  sender: ISender;
 }
 
 function TransactionDetailsDisplay({
   baseAsset,
   asset,
-  network,
   nonce,
   data,
-  senderAccount,
   gasLimit,
   gasPrice,
   rawTransaction,
-  signedTransaction
+  signedTransaction,
+  sender
 }: Props) {
   const [showDetails, setShowDetails] = useState(false);
 
   const maxTransactionFeeBase: string = totalTxFeeToString(gasPrice, gasLimit);
-  const networkName = network ? network.name : undefined;
-  const userAssetToSend = senderAccount.assets.find(accountAsset => {
+  const {
+    network: { name: networkName, color: networkColor }
+  } = sender;
+  const userAssetToSend = sender.assets.find(accountAsset => {
     return accountAsset.uuid === asset.uuid;
   });
   const userAssetBalance = userAssetToSend
@@ -68,13 +69,13 @@ function TransactionDetailsDisplay({
         </div>
         {showDetails && (
           <div className="TransactionDetails-content">
-            {baseAsset && senderAccount.uuid && (
+            {sender.accountBalance && (
               <div className="TransactionDetails-row">
                 <div className="TransactionDetails-row-column">
                   {`Account Balance (${baseAsset.ticker}):`}
                 </div>
                 <div className="TransactionDetails-row-column">{`
-                  ${weiToFloat(getAccountBalance(senderAccount)).toFixed(6)}
+                  ${weiToFloat(sender.accountBalance).toFixed(6)}
                   ${baseAsset.ticker}
                 `}</div>
               </div>
@@ -93,7 +94,7 @@ function TransactionDetailsDisplay({
             <div className="TransactionDetails-row">
               <div className="TransactionDetails-row-column">Network:</div>
               <div className="TransactionDetails-row-column">
-                <Network color="blue">{networkName}</Network>
+                <Network color={networkColor || 'blue'}>{networkName}</Network>
               </div>
             </div>
             <div className="TransactionDetails-row">

--- a/common/v2/components/TransactionFlow/helpers.ts
+++ b/common/v2/components/TransactionFlow/helpers.ts
@@ -1,0 +1,40 @@
+import { ValuesType } from 'utility-types';
+import * as R from 'ramda';
+
+import { ITxConfig, TAddress, StoreAccount } from 'v2/types';
+import { getAccountBalance, getStoreAccount } from 'v2/services/Store';
+
+import { ISender } from './types';
+
+type FieldValue = ValuesType<ISender>;
+
+const preferValueFromSender = (l: FieldValue, r: FieldValue): FieldValue => (R.isEmpty(r) ? l : r);
+
+export const constructSenderFromTxConfig = (
+  txConfig: ITxConfig,
+  accounts: StoreAccount[]
+): ISender => {
+  const { network, senderAccount, from } = txConfig;
+  const defaultSender: ISender = {
+    address: from as TAddress,
+    assets: [],
+    network
+  };
+
+  const sender: ISender = R.mergeDeepWith(
+    preferValueFromSender,
+    defaultSender,
+    R.pick(['address', 'assets', 'network'], {
+      ...senderAccount
+    })
+  );
+
+  // if account exists in store add it to sender
+  const account = getStoreAccount(accounts)(sender.address, sender.network.id);
+  if (account) {
+    sender.account = account;
+    sender.accountBalance = getAccountBalance(senderAccount);
+  }
+
+  return sender;
+};

--- a/common/v2/components/TransactionFlow/types.ts
+++ b/common/v2/components/TransactionFlow/types.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from 'ethers/utils';
+
+import { TAddress, StoreAsset, Network, StoreAccount } from 'v2/types';
+
+export interface ISender {
+  address: TAddress;
+  assets: StoreAsset[];
+  network: Network;
+  accountBalance?: BigNumber;
+  account?: StoreAccount;
+}

--- a/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
+++ b/common/v2/services/Store/AddressBook/AddressBookProvider.tsx
@@ -4,10 +4,10 @@ import {
   AddressBook,
   ExtendedAddressBook,
   IAccount,
-  Network,
   StoreAccount,
   LSKeys,
-  TUuid
+  TUuid,
+  NetworkId
 } from 'v2/types';
 import { generateUUID } from 'v2/utils';
 import { DataContext } from '../DataManager';
@@ -18,8 +18,10 @@ interface IAddressBookContext {
   updateAddressBooks(uuid: TUuid, addressBooksData: ExtendedAddressBook): void;
   deleteAddressBooks(uuid: TUuid): void;
   getContactByAddress(address: string): ExtendedAddressBook | undefined;
-  getContactByAddressAndNetwork(address: string, network: Network): ExtendedAddressBook | undefined;
-  getContactByAccount(account: IAccount): ExtendedAddressBook | undefined;
+  getContactByAddressAndNetworkId(
+    address: string,
+    networkId: NetworkId
+  ): ExtendedAddressBook | undefined;
   getAccountLabel(account: StoreAccount | IAccount): string | undefined;
 }
 
@@ -41,23 +43,15 @@ export const AddressBookProvider: React.FC = ({ children }) => {
         (contact: ExtendedAddressBook) => contact.address.toLowerCase() === address.toLowerCase()
       );
     },
-    getContactByAddressAndNetwork: (address, network) => {
+    getContactByAddressAndNetworkId: (address, networkId) => {
       return addressBook
-        .filter((contact: ExtendedAddressBook) => contact.network === network.name)
+        .filter((contact: ExtendedAddressBook) => contact.network === networkId)
         .find(
           (contact: ExtendedAddressBook) => contact.address.toLowerCase() === address.toLowerCase()
         );
     },
-    getContactByAccount: account => {
-      return addressBook
-        .filter((contact: ExtendedAddressBook) => contact.network === account.networkId)
-        .find(
-          (contact: ExtendedAddressBook) =>
-            contact.address.toLowerCase() === account.address.toLowerCase()
-        );
-    },
-    getAccountLabel: account => {
-      const addressContact = state.getContactByAccount(account as IAccount);
+    getAccountLabel: ({ address, networkId }) => {
+      const addressContact = state.getContactByAddressAndNetworkId(address, networkId);
       return addressContact ? addressContact.label : undefined;
     }
   };

--- a/common/v2/services/Store/utils.ts
+++ b/common/v2/services/Store/utils.ts
@@ -17,4 +17,7 @@ export const getAccountBalance = (account: StoreAccount, token?: Asset): BigNumb
 export const getStoreAccount = (accounts: StoreAccount[]) => (
   address: TAddress,
   networkId: NetworkId
-) => accounts.find(a => a.address === address && a.networkId === networkId);
+) =>
+  accounts.find(
+    a => a.address.toLowerCase() === address.toLowerCase() && a.networkId === networkId
+  );

--- a/common/v2/utils/transaction.ts
+++ b/common/v2/utils/transaction.ts
@@ -91,11 +91,6 @@ export const makeTxConfigFromSignedTx = (
     network: networkDetected || ({} as Network),
     assets
   });
-  const defaultSenderAccount = {
-    address: decodedTx.from,
-    assets: [],
-    networkId: networkDetected && networkDetected.id
-  };
 
   const txConfig = {
     rawTransaction: oldTxConfig.rawTransaction,
@@ -113,9 +108,8 @@ export const makeTxConfigFromSignedTx = (
     senderAccount:
       decodedTx.from && networkDetected
         ? getStoreAccount(accounts)(decodedTx.from as TAddress, networkDetected.id) ||
-          oldTxConfig.senderAccount ||
-          defaultSenderAccount
-        : oldTxConfig.senderAccount || defaultSenderAccount,
+          oldTxConfig.senderAccount
+        : oldTxConfig.senderAccount,
     gasPrice: gasPriceToBase(parseInt(decodedTx.gasPrice, 10)).toString(),
     gasLimit: decodedTx.gasLimit,
     data: decodedTx.data,


### PR DESCRIPTION
Fix for a bug when sending from an account that does not exist in our store crash Confirm step.
Link to thread: https://mycryptohq.slack.com/archives/G8G1S4TG9/p1583283623101100