### PR TITLE
(Legacy) Added Banner for user to acknowledge verifying builds

### DIFF
--- a/common/components/ElectronBuildVerified/Banner.scss
+++ b/common/components/ElectronBuildVerified/Banner.scss
@@ -4,7 +4,7 @@
     padding: 15px 10px;
     padding-right: 30px;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
     color: white;
 

--- a/common/components/ElectronBuildVerified/Banner.scss
+++ b/common/components/ElectronBuildVerified/Banner.scss
@@ -7,24 +7,23 @@
     align-items: flex-start;
     justify-content: center;
     color: white;
-    & > img {
-      vertical-align: top;
-      margin-right: 15px;
-      margin-top: 5px;
-    }
+
     a {
       color: white;
       font-weight: 600;
       text-decoration: underline; 
     }  
+
+    > span {
+      margin-left: 0.5rem;
+    }
+    
     // In mobile we let the icon stay top-aligned with the text
     // as screen grows we remove the arbitray value used to align the icon.
     @media (min-width: 850px) {
       align-items: center;
-      & > img {
-        margin-top: 0;
-      }
     }
+
     @media (max-width: 850px) {
       margin-top: 77px;
     }

--- a/common/components/ElectronBuildVerified/Banner.scss
+++ b/common/components/ElectronBuildVerified/Banner.scss
@@ -1,0 +1,32 @@
+.BannerContainer {
+    background-color: #1eb8e7;
+    color: 'inherit';
+    padding: 15px 10px;
+    padding-right: 30px;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    color: white;
+    & > img {
+      vertical-align: top;
+      margin-right: 15px;
+      margin-top: 5px;
+    }
+    a {
+      color: white;
+      font-weight: 600;
+      text-decoration: underline; 
+    }  
+    // In mobile we let the icon stay top-aligned with the text
+    // as screen grows we remove the arbitray value used to align the icon.
+    @media (min-width: 850px) {
+      align-items: center;
+      & > img {
+        margin-top: 0;
+      }
+    }
+    @media (max-width: 850px) {
+      margin-top: 77px;
+    }
+  }
+  

--- a/common/components/ElectronBuildVerified/index.tsx
+++ b/common/components/ElectronBuildVerified/index.tsx
@@ -4,68 +4,76 @@ import { VERSION } from 'config';
 import './Banner.scss';
 
 interface BannerState {
-    displayBanner: boolean;
+  displayBanner: boolean;
 }
 
 interface BannerProps {
-    versionNow: string;
+  versionNow: string;
 }
 
-const STORAGE_NAME = "ElectronBuildVerified";
+const STORAGE_NAME = 'ElectronBuildVerified';
 
 export default class ElectronBuildVerified extends Component<BannerProps, BannerState> {
-    public state: State = {
-        displayBanner: this.isBannerPrompted()
-    };
+  public state: State = {
+    displayBanner: this.isBannerPrompted()
+  };
 
-    constructor(props: BannerProps) {
-        super(props);
+  constructor(props: BannerProps) {
+    super(props);
+  }
+
+  public render() {
+    const { displayBanner } = this.state;
+    if (displayBanner) {
+      return (
+        <div className="BannerContainer">
+          <input type="checkbox" onChange={e => this.handleCheck(e)} />{' '}
+          <span>
+            I have{' '}
+            <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">
+              verified that this build ({VERSION})
+            </a>{' '}
+            is signed by MyCrypto and I understand the risks of not verifying the build.
+          </span>
+        </div>
+      );
     }
 
-    public render() {
-        const { displayBanner } = this.state;
-        if(displayBanner) {
-            return(<div className="BannerContainer">
-                <input
-                    type="checkbox"
-                    onChange={(e) => this.handleCheck(e)}
-                />{' '}
-                <span>
-                    I have{' '}
-                    <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">verified that this build ({VERSION})</a>{' '}
-                    is signed by MyCrypto and I understand the risks of not verifying the build.
-                </span>
-            </div>)
+    return null;
+  }
+
+  componentWillMount() {
+    this.setState({ displayBanner: this.isBannerPrompted() });
+  }
+
+  private isBannerPrompted() {
+    let storageVerified;
+    if (localStorage.getItem(STORAGE_NAME) !== null) {
+      try {
+        storageVerified = localStorage.getItem(STORAGE_NAME);
+        const objStorage = JSON.parse(storageVerified);
+        if (objStorage.versionChecked === this.props.versionNow) {
+          return false;
         }
-
-        return null;
+      } catch {
+        //
+      }
     }
 
-    componentWillMount() {
-        this.setState({ displayBanner: this.isBannerPrompted() })
-    }
+    return true;
+  }
 
-    private isBannerPrompted() {
-        let storageVerified;
-        if(localStorage.getItem(STORAGE_NAME) !== null) {
-            try {
-                storageVerified = localStorage.getItem(STORAGE_NAME);
-                const objStorage = JSON.parse(storageVerified);
-                if(objStorage.versionChecked === this.props.versionNow) {
-                    return false;
-                }
-            } catch {
-                //
-            }
-        } 
-
-        return true;
+  private handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.checked) {
+      this.setState({ displayBanner: false });
+      localStorage.setItem(
+        STORAGE_NAME,
+        JSON.stringify({
+          versionChecked: this.props.versionNow,
+          ack: true,
+          ts: Math.floor(Date.now() / 1000)
+        })
+      );
     }
-
-    private handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
-        if(event.target.checked) {
-            this.setState({ displayBanner: false })
-            localStorage.setItem(STORAGE_NAME, JSON.stringify({"versionChecked": this.props.versionNow, "ack": true, "ts": Math.floor(Date.now() / 1000)}))
-        }
-    }
+  };
 }

--- a/common/components/ElectronBuildVerified/index.tsx
+++ b/common/components/ElectronBuildVerified/index.tsx
@@ -27,7 +27,9 @@ export default class ElectronBuildVerified extends Component<BannerProps, Banner
     if (displayBanner) {
       return (
         <div className="BannerContainer">
-          <input type="checkbox" onChange={e => this.handleCheck(e)} />{' '}
+          <div style={{display: 'flex', padding: '0em 0.5em 0em 0em'}}>
+            <input type="checkbox" onChange={e => this.handleCheck(e)} />{' '}
+          </div>
           <span>
             I have{' '}
             <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">

--- a/common/components/ElectronBuildVerified/index.tsx
+++ b/common/components/ElectronBuildVerified/index.tsx
@@ -11,7 +11,7 @@ interface BannerProps {
     versionNow: string;
 }
 
-const StorageName = "ElectronBuildVerified";
+const STORAGE_NAME = "ElectronBuildVerified";
 
 export default class ElectronBuildVerified extends Component<BannerProps, BannerState> {
     public state: State = {
@@ -24,27 +24,21 @@ export default class ElectronBuildVerified extends Component<BannerProps, Banner
 
     public render() {
         const { displayBanner } = this.state;
-        return(
-            <>
-            {
-                displayBanner
-                ?
-                    (<div className="BannerContainer">
-                        <input
-                            type="checkbox"
-                            onChange={(e) => this.CheckedBox(e)}
-                        />{' '}
-                        <p>
-                            I have{' '}
-                            <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">verified that this build ({VERSION})</a>{' '}
-                            is signed by MyCrypto and I understand the risks of not verifying the build.
-                        </p>
-                    </div>)
-                :
-                    (<></>)
-            }
-            </>
-        )
+        if(displayBanner) {
+            return(<div className="BannerContainer">
+                <input
+                    type="checkbox"
+                    onChange={(e) => this.handleCheck(e)}
+                />{' '}
+                <p>
+                    I have{' '}
+                    <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">verified that this build ({VERSION})</a>{' '}
+                    is signed by MyCrypto and I understand the risks of not verifying the build.
+                </p>
+            </div>)
+        }
+
+        return null;
     }
 
     componentWillMount() {
@@ -53,9 +47,9 @@ export default class ElectronBuildVerified extends Component<BannerProps, Banner
 
     private isBannerPrompted() {
         let storageVerified;
-        if(localStorage.getItem(StorageName) !== null) {
+        if(localStorage.getItem(STORAGE_NAME) !== null) {
             try {
-                storageVerified = localStorage.getItem(StorageName);
+                storageVerified = localStorage.getItem(STORAGE_NAME);
                 const objStorage = JSON.parse(storageVerified);
                 if(objStorage.versionChecked === this.props.versionNow) {
                     return false;
@@ -68,10 +62,10 @@ export default class ElectronBuildVerified extends Component<BannerProps, Banner
         return true;
     }
 
-    private CheckedBox = (event: React.ChangeEvent<HTMLInputElement>) => {
+    private handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
         if(event.target.checked) {
             this.setState({ displayBanner: false })
-            localStorage.setItem(StorageName, JSON.stringify({"versionChecked": this.props.versionNow, "ack": true, "ts": Math.floor(Date.now() / 1000)}))
+            localStorage.setItem(STORAGE_NAME, JSON.stringify({"versionChecked": this.props.versionNow, "ack": true, "ts": Math.floor(Date.now() / 1000)}))
         }
     }
 }

--- a/common/components/ElectronBuildVerified/index.tsx
+++ b/common/components/ElectronBuildVerified/index.tsx
@@ -30,11 +30,11 @@ export default class ElectronBuildVerified extends Component<BannerProps, Banner
                     type="checkbox"
                     onChange={(e) => this.handleCheck(e)}
                 />{' '}
-                <p>
+                <span>
                     I have{' '}
                     <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">verified that this build ({VERSION})</a>{' '}
                     is signed by MyCrypto and I understand the risks of not verifying the build.
-                </p>
+                </span>
             </div>)
         }
 

--- a/common/components/ElectronBuildVerified/index.tsx
+++ b/common/components/ElectronBuildVerified/index.tsx
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import { VERSION } from 'config';
+
+import './Banner.scss';
+
+interface BannerState {
+    displayBanner: boolean;
+}
+
+interface BannerProps {
+    versionNow: string;
+}
+
+const StorageName = "ElectronBuildVerified";
+
+export default class ElectronBuildVerified extends Component<BannerProps, BannerState> {
+    public state: State = {
+        displayBanner: this.isBannerPrompted()
+    };
+
+    constructor(props: BannerProps) {
+        super(props);
+    }
+
+    public render() {
+        const { displayBanner } = this.state;
+        return(
+            <>
+            {
+                displayBanner
+                ?
+                    (<div className="BannerContainer">
+                        <input
+                            type="checkbox"
+                            onChange={(e) => this.CheckedBox(e)}
+                        />{' '}
+                        <p>
+                            I have{' '}
+                            <a href="https://support.mycrypto.com/staying-safe/verifying-authenticity-of-desktop-app">verified that this build ({VERSION})</a>{' '}
+                            is signed by MyCrypto and I understand the risks of not verifying the build.
+                        </p>
+                    </div>)
+                :
+                    (<></>)
+            }
+            </>
+        )
+    }
+
+    componentWillMount() {
+        this.setState({ displayBanner: this.isBannerPrompted() })
+    }
+
+    private isBannerPrompted() {
+        let storageVerified;
+        if(localStorage.getItem(StorageName) !== null) {
+            try {
+                storageVerified = localStorage.getItem(StorageName);
+                const objStorage = JSON.parse(storageVerified);
+                if(objStorage.versionChecked === this.props.versionNow) {
+                    return false;
+                }
+            } catch {
+                //
+            }
+        } 
+
+        return true;
+    }
+
+    private CheckedBox = (event: React.ChangeEvent<HTMLInputElement>) => {
+        if(event.target.checked) {
+            this.setState({ displayBanner: false })
+            localStorage.setItem(StorageName, JSON.stringify({"versionChecked": this.props.versionNow, "ack": true, "ts": Math.floor(Date.now() / 1000)}))
+        }
+    }
+}

--- a/common/containers/TabSection/ElectronTemplate.tsx
+++ b/common/containers/TabSection/ElectronTemplate.tsx
@@ -1,12 +1,15 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { VERSION } from 'config';
 import { AppState } from 'features/reducers';
 import { configMetaSelectors } from 'features/config';
 import { ElectronNav } from 'components';
 import OfflineTab from './OfflineTab';
 import Notifications from './Notifications';
 import './ElectronTemplate.scss';
+
+import ElectronBuildVerified from 'components/ElectronBuildVerified';
 
 interface StateProps {
   isOffline: AppState['config']['meta']['offline'];
@@ -30,6 +33,7 @@ class ElectronTemplate extends Component<Props, {}> {
         </div>
         <div className="ElectronTemplate-content">
           <div className="Tab ElectronTemplate-content-tab">
+            <ElectronBuildVerified versionNow={VERSION} />
             {isUnavailableOffline && isOffline ? <OfflineTab /> : children}
           </div>
           <Notifications />


### PR DESCRIPTION
[CH5455]

🎉 🎉 🎉

## Description

* Adds a banner to the Electron view to prompt users to verify the builds
   * Fetches the version number from `config/data.tsx` (which is from the `packageJson.version`) and compares that string with the one in LocalStorage from when they last accepted

## Changes

* Added new component `ElectronBuildVerified`

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
