### PR TITLE
Fixes for dropdown component and delete account clipping

### DIFF
--- a/common/v2/components/Account.tsx
+++ b/common/v2/components/Account.tsx
@@ -18,6 +18,7 @@ const Content = styled.div`
 const Title = styled(Typography)`
   display: inline;
   font-size: ${scale(0.5)};
+  word-break: break-word;
 `;
 
 Title.defaultProps = { as: 'div' };
@@ -44,6 +45,7 @@ const SIdenticon = styled(Identicon)`
   &&& img {
     height: 45px;
     width: 44px;
+    max-width: none;
   }
 `;
 

--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -425,12 +425,12 @@ const buildAccountTable = (
         <RowDeleteOverlay
           prompt={`Are you sure you want to delete
               ${
-                getLabelByAccount(accounts[overlayRows[0]], addressBook) !== undefined
-                  ? getLabelByAccount(accounts[overlayRows[0]], addressBook)!.label
+                getLabelByAccount(getFullTableData[overlayRows[0]].account, addressBook)
+                  ? getLabelByAccount(getFullTableData[overlayRows[0]].account, addressBook)!.label
                   : ''
-              } account with address: ${accounts[overlayRows[0]].address} ?`}
+              } account with address: ${getFullTableData[overlayRows[0]].account.address} ?`}
           deleteAction={() => {
-            deleteAccount(accounts[overlayRows[0]]);
+            deleteAccount(getFullTableData[overlayRows[0]].account);
             setDeletingIndex(undefined);
           }}
           cancelAction={() => setDeletingIndex(undefined)}
@@ -501,7 +501,15 @@ const buildAccountTable = (
       if (deletable) {
         bodyContent = [
           ...bodyContent,
-          <DeleteButton key={index} onClick={() => setDeletingIndex(index)} icon="exit" />
+          <DeleteButton
+            key={index}
+            onClick={() =>
+              setDeletingIndex(
+                getFullTableData.findIndex(row => row.account.uuid === accounts[index].uuid)
+              )
+            }
+            icon="exit"
+          />
         ];
       }
 

--- a/common/v2/components/ContactLookupDropdown.tsx
+++ b/common/v2/components/ContactLookupDropdown.tsx
@@ -52,6 +52,8 @@ const ContactLookupDropdown = ({
     )}
     searchable={true}
     clearable={true}
+    onCloseResetsInput={false}
+    onBlurResetsInput={false}
   />
 );
 

--- a/common/v2/components/Dropdown.tsx
+++ b/common/v2/components/Dropdown.tsx
@@ -57,12 +57,6 @@ const DropdownContainer = styled('div')`
     padding: 16px 15px 16px 15px;
     position: inherit;
   }
-
-  .is-open > .Select-control > .Select-multi-value-wrapper > .Select-input:only-child {
-    transform: translateY(0%);
-    padding: 16px 15px 16px 15px;
-    position: inherit;
-  }
 `;
 
 const Chevron = styled(Icon)`

--- a/common/v2/components/Dropdown.tsx
+++ b/common/v2/components/Dropdown.tsx
@@ -28,6 +28,14 @@ const SSelect = styled(Select)`
   .Select-menu {
     max-height: 20em !important;
   }
+
+  .Select-input {
+    width: 100%;
+
+    > input {
+      width: 100% !important;
+    }
+  }
 `;
 
 interface Props<T> {
@@ -46,6 +54,8 @@ interface Props<T> {
   inputValue?: string;
   onInputChange?: OnInputChangeHandler;
   onInputKeyDown?: OnInputKeyDownHandler;
+  onCloseResetsInput?: boolean;
+  onBlurResetsInput?: boolean;
   onChange?(option: T): void;
   onBlur?(e: string | undefined): void;
 }

--- a/common/v2/components/RowDeleteOverlay.tsx
+++ b/common/v2/components/RowDeleteOverlay.tsx
@@ -39,6 +39,7 @@ const OverlayText = styled('span')`
 `;
 
 const OverlayButtons = styled.div`
+  display: flex;
   padding: 8px 0px;
   & > * {
     margin-left: 2ch;

--- a/common/v2/features/Dashboard/Dashboard.tsx
+++ b/common/v2/features/Dashboard/Dashboard.tsx
@@ -23,11 +23,15 @@ const EmptyTile = styled.div`
   width: 30%;
 `;
 
+const DashboardWrapper = styled.div`
+  width: 100%;
+`;
+
 export default function Dashboard() {
   const { isMyCryptoMember, currentAccounts } = useContext(StoreContext);
   const { accounts } = useContext(AccountContext);
   return (
-    <div>
+    <DashboardWrapper>
       {/* Mobile only */}
       <Mobile className="Dashboard-mobile">
         <NotificationsPanel accounts={accounts} />
@@ -120,6 +124,6 @@ export default function Dashboard() {
           />
         </div>
       </Desktop>
-    </div>
+    </DashboardWrapper>
   );
 }

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -47,20 +47,12 @@ const SettingsTabs = styled(TabsNav)`
 function renderAccountPanel() {
   const { accounts } = useContext(StoreContext);
   return (
-    <FlippablePanel>
-      {({ flipped }) =>
-        flipped ? (
-          <p>Add Account</p>
-        ) : (
-          <AccountList
-            accounts={accounts}
-            deletable={true}
-            copyable={true}
-            privacyCheckboxEnabled={IS_ACTIVE_FEATURE.PRIVATE_TAGS}
-          />
-        )
-      }
-    </FlippablePanel>
+    <AccountList
+      accounts={accounts}
+      deletable={true}
+      copyable={true}
+      privacyCheckboxEnabled={IS_ACTIVE_FEATURE.PRIVATE_TAGS}
+    />
   );
 }
 


### PR DESCRIPTION
Fixes for: 
- Settings: Delete account clipping [ch5536]
- Global: searchable dropdown component dowshifts text [ch5538]
- Mobile Send: Trying to paste address into recipient field can erase the address [ch5529]
