### PR TITLE
Stop building electron-deps on postInstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,10 +209,10 @@
     "build:downloadable": "cross-env NODE_ENV=production webpack --config webpack_config/downloadable.js",
     "prebuild:downloadable": "check-node-version --package",
     "build:electron": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && node webpack_config/buildElectron.js",
+    "prebuild:electron": "check-node-version --package && electron-builder install-app-deps",
     "build:electron:osx": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=osx node webpack_config/buildElectron.js",
     "build:electron:windows": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=windows node webpack_config/buildElectron.js",
     "build:electron:linux": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=linux node webpack_config/buildElectron.js",
-    "prebuild:electron": "check-node-version --package",
     "test:coverage": "jest --config=jest_config/jest.config.json --coverage",
     "test": "jest --config=jest_config/jest.config.json",
     "test:single": "jest --config=jest_config/jest.config.json --coverage=false --watch",
@@ -221,6 +221,7 @@
     "predev": "check-node-version --package",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --config webpack_config/development.js",
     "dev:electron": "cross-env BUILD_ELECTRON=true concurrently -r --kill-others -n \"RENDERER,MAIN\" \"yarn run dev:electron:renderer\" \"yarn run dev:electron:main\"",
+    "predev:electron": "electron-builder install-app-deps",
     "dev:electron:main": "webpack --config webpack_config/electron-main.development.js && electron dist/electron-main/main.js",
     "dev:electron:renderer": "webpack-dev-server --config webpack_config/electron-renderer.development.js",
     "storybook": "start-storybook -p 3001 --ci",
@@ -233,7 +234,6 @@
     "formatAll": "find ./common/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
     "prettier:diff": "prettier --write --config ./.prettierrc --list-different \"common/**/*.ts\" \"common/**/*.tsx\"",
     "update:tokens": "parse-eth-tokens --networks all --output ./common/v2/database/data/tokens --exclude 0x5a276Aeb77bCfDAc8Ac6f31BBC7416AE1A85eEF2,0x0027449Bf0887ca3E431D263FFDeFb244D95b555",
-    "postinstall": "electron-builder install-app-deps",
     "lint:css": "stylelint ./common/**/*.tsx"
   },
   "lint-staged": {


### PR DESCRIPTION
We were rebuilding electron dependencies on every yarn add/remove.
This runs the `electron-builder install-app-deps` only when we actually need it.