### PR TITLE
Add translatable strings requirement to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,3 +35,4 @@
 - [ ] This is related to a maximum of one Clubhouse story or GitHub issue
 - [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
 - [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
+- [ ] If your code adds new text to the UI, the added text is [translatable](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributing---Translatable-strings)


### PR DESCRIPTION
Update Github readme to state that any strings [ch5589]