### PR TITLE
Disable ShapeShift integration and show a warning to the user

### DIFF
--- a/common/components/ui/Warning.tsx
+++ b/common/components/ui/Warning.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import './Warning.scss';
+import { isDesktop } from 'v2/utils';
 
 interface WarningProps {
   highlighted?: boolean;
@@ -8,9 +9,10 @@ interface WarningProps {
 
 const Warning: React.SFC<WarningProps> = ({ highlighted, children }) => {
   const className = `Warning ${highlighted ? 'highlighted' : ''}`;
+  const addMarginTop = isDesktop() ? 0 : "1em"; //Add extra margin to fix a small CSS issue of the warning being too close to the Banner
 
   return (
-    <section className={className}>
+    <section className={className} style={{'marginTop': addMarginTop}}>
       <section className="Warning-icon">
         <i className="fa fa-exclamation-triangle" />
       </section>

--- a/common/config/navigation.ts
+++ b/common/config/navigation.ts
@@ -16,10 +16,10 @@ export const navigationLinks: NavigationLink[] = [
     name: 'NAV_GENERATEWALLET',
     to: '/generate'
   },
-  {
-    name: 'NAV_SWAP',
-    to: '/swap'
-  },
+  // {
+  //   name: 'NAV_SWAP',
+  //   to: '/swap'
+  // },
   {
     name: 'NAV_CONTRACTS',
     to: '/contracts'

--- a/common/v2/features/BuyAndExchange/BuyAndExchange.tsx
+++ b/common/v2/features/BuyAndExchange/BuyAndExchange.tsx
@@ -60,7 +60,10 @@ export class BuyAndExchange extends Component<RouteComponentProps<any>> {
                 A platform that gives you the power to quickly swap between assets in a seamless,
                 safe, and secure environment.
               </BuyAndExchangeOption>
-              <BuyAndExchangeOption option="0x Instant" logo={zeroExLogo} route="/swap/0x">
+              <BuyAndExchangeOption 
+                option="0x Instant" 
+                logo={zeroExLogo} 
+                route="/swap/0x">
                 Quick and secure token purchasing.
               </BuyAndExchangeOption>
             </section>

--- a/common/v2/features/BuyAndExchange/ShapeShift/ShapeShiftDisabled.tsx
+++ b/common/v2/features/BuyAndExchange/ShapeShift/ShapeShiftDisabled.tsx
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+
+// Legacy
+import TabSection from 'containers/TabSection';
+import Warning from 'components/ui/Warning';
+
+export default class ShapeShiftDisabled extends Component {
+  public render() {
+    return (
+      <TabSection>
+          <Warning>
+            ShapeShift functionality is currently unavailable on the Legacy MyCrypto App.
+          </Warning>
+      </TabSection>
+    );
+  }
+}

--- a/common/v2/features/BuyAndExchange/ShapeShift/ShapeShiftDisabled.tsx
+++ b/common/v2/features/BuyAndExchange/ShapeShift/ShapeShiftDisabled.tsx
@@ -9,7 +9,7 @@ export default class ShapeShiftDisabled extends Component {
     return (
       <TabSection>
           <Warning>
-            ShapeShift functionality is currently unavailable on the Legacy MyCrypto App.
+            ShapeShift functionality is currently unavailable on the MyCrypto App.
           </Warning>
       </TabSection>
     );

--- a/common/v2/features/BuyAndExchange/ShapeShift/index.ts
+++ b/common/v2/features/BuyAndExchange/ShapeShift/index.ts
@@ -1,3 +1,4 @@
 export { default as ShapeShift } from './ShapeShift';
 export { default as ShapeShiftAuthorization } from './ShapeShiftAuthorization';
 export { default as ShapeShiftSend } from './ShapeShiftSend';
+export { default as ShapeShiftDisabled } from './ShapeShiftDisabled';

--- a/common/v2/features/BuyAndExchange/routes.ts
+++ b/common/v2/features/BuyAndExchange/routes.ts
@@ -1,5 +1,5 @@
 import BuyAndExchange from './BuyAndExchange';
-import { ShapeShiftAuthorization } from './ShapeShift';
+import { ShapeShiftDisabled } from './ShapeShift';
 import { ZeroEx } from './ZeroEx';
 
 export default [
@@ -12,7 +12,7 @@ export default [
   {
     name: 'Buy and Exchange | ShapeShift',
     path: '/swap/shapeshift',
-    component: ShapeShiftAuthorization
+    component: ShapeShiftDisabled
   },
   {
     name: 'Buy and Exchange | 0x Instant',


### PR DESCRIPTION
[CH5205]

🎉 🎉 🎉

## Description

* Removal of Shapeshift to the web and desktop app for legacy.

## Changes

* Removed navigation item
* Displayed a warning page if they manually route to the shapeshift integration

<!-- Contributors: Delete this section. -->
## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56)
<!-- Upload screenshots here. -->

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
- [ ] If your code adds new text to the UI, the added text is [translatable](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributing---Translatable-strings)
