### PR TITLE
Fix default asset ens bug in send flow

### DIFF
--- a/common/v2/features/SendAssets/components/SendAssetsForm.tsx
+++ b/common/v2/features/SendAssets/components/SendAssetsForm.tsx
@@ -59,7 +59,8 @@ import {
   GAS_LIMIT_UPPER_BOUND,
   GAS_PRICE_GWEI_LOWER_BOUND,
   GAS_PRICE_GWEI_UPPER_BOUND,
-  DEFAULT_ASSET_DECIMAL
+  DEFAULT_ASSET_DECIMAL,
+  DEFAULT_NETWORK
 } from 'v2/config';
 import { RatesContext } from 'v2/services/RatesProvider';
 import TransactionFeeDisplay from 'v2/components/TransactionFlow/displays/TransactionFeeDisplay';
@@ -118,14 +119,18 @@ const initialFormikValues: IFormikFields = {
 // To preserve form state between steps, we prefil the fields with state
 // values when they exits.
 type FieldValue = ValuesType<IFormikFields>;
-export const getInitialFormikValues = (s: ITxConfig, defaultAsset?: Asset): IFormikFields => {
+export const getInitialFormikValues = (
+  s: ITxConfig,
+  defaultAsset: Asset | undefined,
+  defaultNetwork: Network | undefined
+): IFormikFields => {
   const gasPriceInGwei =
     R.path(['rawTransaction', 'gasPrice'], s) &&
     bigNumGasPriceToViewableGwei(bigNumberify(s.rawTransaction.gasPrice));
   const state: Partial<IFormikFields> = {
     amount: s.amount,
     account: s.senderAccount,
-    network: s.network,
+    network: s.network || defaultNetwork,
     asset: s.asset || defaultAsset,
     nonceField: s.nonce,
     txDataField: s.data,
@@ -245,11 +250,12 @@ export default function SendAssetsForm({ txConfig, onComplete }: IStepComponentP
 
   const validAccounts = accounts.filter(account => account.wallet !== WalletId.VIEW_ONLY);
   const userAccountEthAsset = userAssets.find(a => a.uuid === EtherUUID);
+  const defaultNetwork = networks.find(n => n.id === DEFAULT_NETWORK);
 
   return (
     <div className="SendAssetsForm">
       <Formik
-        initialValues={getInitialFormikValues(txConfig, userAccountEthAsset)}
+        initialValues={getInitialFormikValues(txConfig, userAccountEthAsset, defaultNetwork)}
         validationSchema={SendAssetsSchema}
         onSubmit={fields => {
           onComplete(fields);

--- a/common/v2/services/UnstoppableService/index.ts
+++ b/common/v2/services/UnstoppableService/index.ts
@@ -6,7 +6,10 @@ class UnstoppableResolution {
 
   constructor() {
     this.resolution = new Resolution({
-      blockchain: { ens: { url: MYC_API_MAINNET, network: 'mainnet' } }
+      blockchain: {
+        ens: { url: MYC_API_MAINNET, network: 'mainnet' },
+        cns: { url: MYC_API_MAINNET, network: 'mainnet' }
+      }
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mycrypto/eth-scan": "2.1.0",
     "@mycrypto/ui": "0.22.0",
     "@parity/qr-signer": "0.3.1",
-    "@unstoppabledomains/resolution": "1.0.24",
+    "@unstoppabledomains/resolution": "1.3.5",
     "@walletconnect/browser": "1.0.0-beta.39",
     "axios": "0.18.1",
     "bignumber.js": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,19 +3289,21 @@
   resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.0.tgz#fbc1d941cc6d9d37d18405c513ba6b294f89b609"
   integrity sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==
 
-"@unstoppabledomains/resolution@1.0.24":
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-1.0.24.tgz#7506d20e956104116d746d19d32b42a6b74fb421"
-  integrity sha512-nJJ8oi41tfC9g/F4Cc1Ii3ifwTfge2gJXGBXt+5TRV/EAgrXSMLYkGSNvThGLvnFuHelkAxIrzDeYRPyObtdeA==
+"@unstoppabledomains/resolution@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-1.3.5.tgz#d3ad528c5b8a809b81e3ed96753ee28852231a26"
+  integrity sha512-9H400jdvVErDGf2xLm8Qx9Ek0N/ogWWfmAIN6zEBR6XchRfBWRO/MO8E+glTXUdpkJB2YuJ4GiJe9ngau3p/RA==
   dependencies:
     "@ensdomains/address-encoder" "0.1.2"
-    bip44-constants "8.0.5"
-    bn.js "5.1.1"
-    content-hash "2.5.2"
-    hash.js "1.1.7"
-    idna-uts46-hx "^3.2.2"
-    js-sha3 "0.8.0"
-    node-fetch "2.6.0"
+    bip44-constants "^8.0.5"
+    bn.js "^5.1.1"
+    commander "^4.1.1"
+    content-hash "^2.5.2"
+    hash.js "^1.1.7"
+    js-sha3 "^0.8.0"
+    node-fetch "^2.6.0"
+  optionalDependencies:
+    dotenv "^8.2.0"
 
 "@walletconnect/browser@1.0.0-beta.39":
   version "1.0.0-beta.39"
@@ -4724,10 +4726,10 @@ bip39@3.0.2:
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
 
-bip44-constants@8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/bip44-constants/-/bip44-constants-8.0.5.tgz#0684b3a026c19e919f1439d6e5fc49f8176d4066"
-  integrity sha512-Oz9neu5N8RzR+7CboveI4rsf1ETYJDivjlLqOqkI2D7oRSJKa34+MJw7nx3gJ+JnD6Pm8cSONbPTtiqIhF/pWg==
+bip44-constants@^8.0.5:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/bip44-constants/-/bip44-constants-8.0.6.tgz#4c91133b4a9174c20afa794c92baa3bfa52f1c90"
+  integrity sha512-vKQqiOQJcLvhYLlKc+zWqM2KDXQ5YizdNWb5cCNkEzNR667UtpLNUq/NIuGv1HzkPjhX7ATPHgxinp+Hhs+k0Q==
 
 bip66@^1.1.0, bip66@^1.1.5:
   version "1.1.5"
@@ -4848,7 +4850,7 @@ bn.js@4.11.8, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.0, bn.js@^4.
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-bn.js@5.1.1:
+bn.js@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.1.tgz#48efc4031a9c4041b9c99c6941d903463ab62eb5"
   integrity sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==
@@ -6181,7 +6183,7 @@ content-disposition@0.5.3, content-disposition@^0.5.2:
   dependencies:
     safe-buffer "5.1.2"
 
-content-hash@2.5.2:
+content-hash@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/content-hash/-/content-hash-2.5.2.tgz#bbc2655e7c21f14fd3bfc7b7d4bfe6e454c9e211"
   integrity sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==
@@ -9349,7 +9351,7 @@ hash.js@1.1.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -9743,13 +9745,6 @@ idempotent-babel-polyfill@7.4.4:
   integrity sha512-ULnqegUJke43XlsW5bI2zvoOCiFwn5AjRK/DJA5V6jj4yf+vKEZmiYll2x9+FQb9e6a+KQ/D+r8w7ydCYuiaRA==
   dependencies:
     "@babel/polyfill" "7.4.4"
-
-idna-uts46-hx@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-3.2.2.tgz#8e0c2c01870c0a777f23cbafad788b2c07dfde1c"
-  integrity sha512-VlhqNXU0AFeEll1w+ny9eGda8kNDQcG+Gz3T9wZ3wSCCPqYo000J6/fRqvkUAO4V2SuOaJuKMSWiNjy/n/Lwyg==
-  dependencies:
-    punycode "^2.1.1"
 
 idna-uts46@1.1.0:
   version "1.1.0"
@@ -11208,7 +11203,7 @@ js-sha3@0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
-js-sha3@0.8.0:
+js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==


### PR DESCRIPTION
Fixes: #3160 

We added a change to set default asset as ETH, but doesn't set default network too (which is conducted on asset selection). We should check to make sure this doesn't break `gasPrice` lookup as well.