### PR TITLE
Reset scroll on page change

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -17,6 +17,7 @@ const AppProvidersInnerContainer = styled.div`
 `;
 const AppRouterContainer = styled.div`
   flex: 1;
+  max-width: 100vw;
   max-height: 100vh;
 `;
 const DevToolsManagerContainer = styled.div`

--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -17,15 +17,18 @@ const AppProvidersInnerContainer = styled.div`
 `;
 const AppRouterContainer = styled.div`
   flex: 1;
-  overflow: auto;
   max-height: 100vh;
 `;
 const DevToolsManagerContainer = styled.div`
-  overflow: auto;
-  max-height: 100vh;
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  width: 450px;
+  height: 100vh;
 
   @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
-    position: absolute;
+    position: fixed;
     z-index: 100;
     width: 100vw;
   }

--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -24,13 +24,13 @@ const DevToolsManagerContainer = styled.div`
   z-index: 100;
   top: 0;
   left: 0;
-  width: 450px;
+  max-width: 450px;
   height: 100vh;
 
   @media (max-width: ${BREAK_POINTS.SCREEN_SM}) {
     position: fixed;
     z-index: 100;
-    width: 100vw;
+    max-width: 100vw;
   }
 `;
 

--- a/common/v2/utils/scrollToTop.tsx
+++ b/common/v2/utils/scrollToTop.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from 'react';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 // Scroll to top on route change
 // https://reacttraining.com/react-router/web/guides/scroll-restoration
-const ScrollToTop = ({ history, location: { pathname } }: RouteComponentProps<any>) => {
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
   useEffect(() => {
-    const unlisten = history.listen(() => {
-      window.scrollTo(0, 0);
-    });
-    return () => unlisten();
+    window.scrollTo(0, 0);
   }, [pathname]);
+
   return null;
 };
 
-export default withRouter(ScrollToTop);
+export default ScrollToTop;


### PR DESCRIPTION
### What it changes
**Links when clicked now reset page scroll to top**

### What I did
- Removed `overflow` css rule on Router container (_This is what resolved the bug_)
- Updated scrollToTop method for the newest recommended one on [React Training](https://reacttraining.com/react-router/web/guides/scroll-restoration)
- Made the DevTool `fixed` so we can still use it

### Steps to test
Just scroll and change page via a button or navigation.

### Extra
Verify that the new integration of DevTool is okay for you since we couldn’t keep it as it was before due to the necessity of adding the `overflow` rule to the container to keep the "shape" of the app.

[Story details](https://app.clubhouse.io/mycrypto/story/5782)