### PR TITLE
Include link to add account in header

### DIFF
--- a/common/v2/features/Layout/Header/constants.ts
+++ b/common/v2/features/Layout/Header/constants.ts
@@ -28,6 +28,11 @@ export const links = [
         to: APP_ROUTES_OBJECT.SWAP.path,
         enabled: APP_ROUTES_OBJECT.SWAP.enabled,
         title: translateRaw('SWAP')
+      },
+      {
+        to: APP_ROUTES_OBJECT.ADD_ACCOUNT.path,
+        enabled: APP_ROUTES_OBJECT.ADD_ACCOUNT.enabled,
+        title: translateRaw('ADD_ACCOUNT')
       }
     ]
   },


### PR DESCRIPTION
Include link to `/add-account` in header for easy access.

<img width="1323" alt="Screenshot 2020-04-09 at 6 27 14 PM" src="https://user-images.githubusercontent.com/2429708/78918065-1d14c080-7a90-11ea-8c1f-024379c9b7c2.png">

