### PR TITLE
Remove link text from Dashboard AccountList

### DIFF
--- a/common/v2/components/AccountList.tsx
+++ b/common/v2/components/AccountList.tsx
@@ -205,7 +205,6 @@ export default function AccountList(props: AccountListProps) {
   const overlayRows = [deletingIndex];
 
   // Verify if AccountList is used in Dashboard to display Settings button
-  const headingRight = dashboard ? translateRaw('SETTINGS_HEADING') : undefined;
   const actionLink = dashboard ? ROUTE_PATHS.SETTINGS.path : undefined;
 
   const Footer = () => {
@@ -228,7 +227,6 @@ export default function AccountList(props: AccountListProps) {
           <Tooltip tooltip={translateRaw('DASHBOARD_ACCOUNTS_TOOLTIP')} />
         </>
       }
-      headingRight={headingRight}
       actionLink={actionLink}
       className={`AccountList ${className}`}
       footer={<Footer />}

--- a/common/v2/components/DashboardPanel.tsx
+++ b/common/v2/components/DashboardPanel.tsx
@@ -82,22 +82,18 @@ export const DashboardPanel = ({
   const getRightHeading = () => {
     if (headingRight && actionLink) {
       return (
-        <>
-          <SRouterLink to={actionLink} imageFirst={true}>
-            <img src={settingsIcon} alt={'settings'} width={24} />
-            <Typography>{headingRight}</Typography>
-          </SRouterLink>
-        </>
+        <SRouterLink to={actionLink} imageFirst={true}>
+          <img src={settingsIcon} alt={'settings'} width={24} />
+          <Typography>{headingRight}</Typography>
+        </SRouterLink>
       );
     } else if (headingRight && !actionLink) {
       return <Typography>{headingRight}</Typography>;
     } else if (!headingRight && actionLink) {
       return (
-        <>
-          <SRouterLink to={actionLink}>
-            <img src={settingsIcon} alt={'settings'} width={24} />
-          </SRouterLink>
-        </>
+        <SRouterLink to={actionLink}>
+          <img src={settingsIcon} alt={'settings'} width={24} />
+        </SRouterLink>
       );
     } else {
       return false;

--- a/common/v2/components/DashboardPanel.tsx
+++ b/common/v2/components/DashboardPanel.tsx
@@ -20,7 +20,7 @@ const SRouterLink = styled(RouterLink)`
     color: ${COLORS.BLUE_BRIGHT};
   }
   & img {
-    margin-right: 0.5em;
+    margin-right: ${(p: { imageFirst?: boolean }) => (p.imageFirst ? '0.5em' : '0')};
   }
 `;
 
@@ -79,20 +79,39 @@ export const DashboardPanel = ({
   padChildren,
   ...rest
 }: Props) => {
+  const getRightHeading = () => {
+    if (headingRight && actionLink) {
+      return (
+        <>
+          <SRouterLink to={actionLink} imageFirst={true}>
+            <img src={settingsIcon} alt={'settings'} width={24} />
+            <Typography>{headingRight}</Typography>
+          </SRouterLink>
+        </>
+      );
+    } else if (headingRight && !actionLink) {
+      return <Typography>{headingRight}</Typography>;
+    } else if (!headingRight && actionLink) {
+      return (
+        <>
+          <SRouterLink to={actionLink}>
+            <img src={settingsIcon} alt={'settings'} width={24} />
+          </SRouterLink>
+        </>
+      );
+    } else {
+      return false;
+    }
+  };
+
   return (
     <DPanel {...rest}>
-      {heading && (<DHeadingWrapper>
-        <DHeading>{heading}</DHeading>
-        {headingRight &&
-          (actionLink ? (
-            <SRouterLink to={actionLink}>
-              <img src={settingsIcon} alt={'settings'} width={32} />
-              <Typography>{headingRight}</Typography>
-            </SRouterLink>
-          ) : (
-              headingRight
-            ))}
-      </DHeadingWrapper>)}
+      {heading && (
+        <DHeadingWrapper>
+          <DHeading>{heading}</DHeading>
+          {(headingRight || actionLink) && getRightHeading()}
+        </DHeadingWrapper>
+      )}
       {padChildren ? <Content>{children}</Content> : children}
       {footer && <DFooterWrapper>{footer}</DFooterWrapper>}
     </DPanel>

--- a/common/v2/components/DashboardPanel.tsx
+++ b/common/v2/components/DashboardPanel.tsx
@@ -83,7 +83,7 @@ export const DashboardPanel = ({
     if (headingRight && actionLink) {
       return (
         <SRouterLink to={actionLink} imageFirst={true}>
-          <img src={settingsIcon} alt={'settings'} width={24} />
+          <img src={settingsIcon} alt={'settings'} width={30} />
           <Typography>{headingRight}</Typography>
         </SRouterLink>
       );
@@ -92,7 +92,7 @@ export const DashboardPanel = ({
     } else if (!headingRight && actionLink) {
       return (
         <SRouterLink to={actionLink}>
-          <img src={settingsIcon} alt={'settings'} width={24} />
+          <img src={settingsIcon} alt={'settings'} width={30} />
         </SRouterLink>
       );
     } else {


### PR DESCRIPTION
Following all hands design conversation:
Remove link text from table header.

### Before
<img width="739" alt="Screenshot 2020-04-10 at 11 06 57 AM" src="https://user-images.githubusercontent.com/2429708/78979110-7249e400-7b1b-11ea-8065-927959c37700.png">


### After
<img width="747" alt="Screenshot 2020-04-10 at 11 12 19 AM" src="https://user-images.githubusercontent.com/2429708/78979488-41b67a00-7b1c-11ea-9683-9a39cf182b12.png">

