### PR TITLE
Harmonize settings title

### DIFF
--- a/common/AppRoutes.tsx
+++ b/common/AppRoutes.tsx
@@ -24,7 +24,6 @@ const layoutConfig = (path: string, isMobile: boolean): LayoutConfig => {
         fullW: true,
         bgColor: '#fff'
       };
-    case ROUTE_PATHS.SETTINGS.path:
     case ROUTE_PATHS.DASHBOARD.path:
       return {
         centered: true,
@@ -33,7 +32,7 @@ const layoutConfig = (path: string, isMobile: boolean): LayoutConfig => {
     case ROUTE_PATHS.SETTINGS.path:
       return {
         centered: true,
-        ...(isMobile && { paddingV: '0px' })
+        paddingV: isMobile ? '0px' : SPACING.MD
       };
     default:
       return {

--- a/common/AppRoutes.tsx
+++ b/common/AppRoutes.tsx
@@ -24,6 +24,7 @@ const layoutConfig = (path: string, isMobile: boolean): LayoutConfig => {
         fullW: true,
         bgColor: '#fff'
       };
+    case ROUTE_PATHS.SETTINGS.path:
     case ROUTE_PATHS.DASHBOARD.path:
       return {
         centered: true,

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -11,15 +11,18 @@ import { AddressBookPanel, AddToAddressBook, GeneralSettings, DangerZone } from 
 import settingsIcon from 'common/assets/images/icn-settings.svg';
 import { IS_ACTIVE_FEATURE } from 'v2/config';
 
-const SettingsHeading = styled(Heading)`
+const SettingsHeading = styled(Heading)<{ forwardedAs?: string }>`
   display: flex;
   align-items: center;
-  margin-bottom: 22px;
-  color: #163150;
+  margin-bottom: 24px;
+  font-weight: bold;
+  margin-top: 0;
 `;
 
 const SettingsHeadingIcon = styled.img`
-  margin-right: 12px;
+  margin-right: 24px;
+  margin-top: -16px;
+  width: 20px;
 `;
 
 const StyledLayout = styled.div`
@@ -114,7 +117,7 @@ export default function Settings() {
         <>{currentTab}</>
       </Mobile>
       <Desktop>
-        <SettingsHeading>
+        <SettingsHeading as="h2">
           <SettingsHeadingIcon src={settingsIcon} alt="Settings" />
           {translate('SETTINGS_HEADING')}
         </SettingsHeading>

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -21,8 +21,8 @@ const SettingsHeading = styled(Heading)<{ forwardedAs?: string }>`
 
 const SettingsHeadingIcon = styled.img`
   margin-right: 24px;
-  margin-top: -16px;
-  width: 20px;
+  margin-top: 2px;
+  width: 30px;
 `;
 
 const StyledLayout = styled.div`


### PR DESCRIPTION
Make settings page title style correspond to 'Your Dashboard'

reference: https://www.figma.com/file/BY0SWc75teEUZzws8JdgLMpy/MyCrypto-GAU-Master?node-id=1522%3A84934


### Before
<img width="1076" alt="Screenshot 2020-04-10 at 3 45 10 PM" src="https://user-images.githubusercontent.com/2429708/78995289-53ab1380-7b42-11ea-8093-b3e0ef58d1b3.png">

### After
<img width="1075" alt="Screenshot 2020-04-10 at 3 44 32 PM" src="https://user-images.githubusercontent.com/2429708/78995286-51e15000-7b42-11ea-8cdf-52fe952244fc.png">

