### PR TITLE
AQUA: update explorer URL

### DIFF
--- a/common/v2/database/data/networks.ts
+++ b/common/v2/database/data/networks.ts
@@ -580,7 +580,7 @@ export const NETWORKS_CONFIG: NetworkConfig = {
     color: '#00ffff',
     blockExplorer: makeExplorer({
       name: 'AQUA Explorer',
-      origin: 'https://aquachain.github.io/explorer/#'
+      origin: 'https://blockscout.aqua.signal2noi.se'
     }),
     tokens: [],
     contracts: [],


### PR DESCRIPTION
Uses a faster explorer hosted by aqua.signal2noi.se pool