### PR TITLE
Fixed slowdown when disabling MetaMask

### DIFF
--- a/common/v2/services/EthService/network/helpers.ts
+++ b/common/v2/services/EthService/network/helpers.ts
@@ -3,6 +3,7 @@ import { FallbackProvider, BaseProvider } from 'ethers/providers';
 import * as R from 'ramda';
 
 import { Network, NetworkId, NodeType, DPathFormat } from 'v2/types';
+import { hasWeb3Provider } from 'v2/utils';
 
 // Network names accepted by ethers.EtherscanProvider
 type TValidEtherscanNetwork = 'homestead' | 'ropsten' | 'rinkeby' | 'kovan' | 'goerli';
@@ -12,28 +13,31 @@ const getValidEthscanNetworkId = (id: NetworkId): TValidEtherscanNetwork =>
 
 export const createNetworkProviders = (network: Network): FallbackProvider => {
   const { id, nodes } = network;
-  const providers: BaseProvider[] = nodes.map(({ type, url }) => {
-    switch (type) {
-      case NodeType.ETHERSCAN: {
-        const networkName = getValidEthscanNetworkId(id);
-        return new ethers.providers.EtherscanProvider(networkName);
-      }
-      case NodeType.WEB3: {
-        const ethereumProvider = window.ethereum;
-        const networkName = getValidEthscanNetworkId(id);
-        return new ethers.providers.Web3Provider(ethereumProvider, networkName);
-      }
+  // Remove WEB3 nodes if no Web3 provider is available at this moment
+  const providers: BaseProvider[] = nodes
+    .filter(n => (n.type === NodeType.WEB3 && hasWeb3Provider()) || n.type !== NodeType.WEB3)
+    .map(({ type, url }) => {
+      switch (type) {
+        case NodeType.ETHERSCAN: {
+          const networkName = getValidEthscanNetworkId(id);
+          return new ethers.providers.EtherscanProvider(networkName);
+        }
+        case NodeType.WEB3: {
+          const ethereumProvider = window.ethereum;
+          const networkName = getValidEthscanNetworkId(id);
+          return new ethers.providers.Web3Provider(ethereumProvider, networkName);
+        }
 
-      // Option to use the EthersJs InfuraProvider, but need figure out the apiAcessKey
-      // https://docs.ethers.io/ethers.js/html/api-providers.html#jsonrpcprovider-inherits-from-provider
-      // case NodeType.INFURA:
-      //   return new ethers.providers.InfuraProvider(name);
+        // Option to use the EthersJs InfuraProvider, but need figure out the apiAcessKey
+        // https://docs.ethers.io/ethers.js/html/api-providers.html#jsonrpcprovider-inherits-from-provider
+        // case NodeType.INFURA:
+        //   return new ethers.providers.InfuraProvider(name);
 
-      // default case covers the remaining NodeTypes.
-      default:
-        return new ethers.providers.JsonRpcProvider(url);
-    }
-  });
+        // default case covers the remaining NodeTypes.
+        default:
+          return new ethers.providers.JsonRpcProvider(url);
+      }
+    });
 
   return new ethers.providers.FallbackProvider(providers);
 };


### PR DESCRIPTION
Fixed an obscure bug where disabling the MetaMask extension would cause massive amounts of requests to our API, re-renders of the site etc.


When polling for balances we only update the balance state in case there is changes. Due to the bug with node configuration, the request would always fail, and therefore there would always be a difference between the current balance and the new balance. This would trigger an infinite loop of requests to ethscan.