### PR TITLE
Sort token scanner list before display

### DIFF
--- a/common/v2/features/Dashboard/components/TokenPanel/TokenList.tsx
+++ b/common/v2/features/Dashboard/components/TokenPanel/TokenList.tsx
@@ -90,6 +90,7 @@ export function TokenList(props: TokenListProps) {
     setShowAddToken,
     handleScanTokens
   } = props;
+  const sortedTokens = tokens.sort((a, b) => a.name.localeCompare(b.name));
   return (
     <TokenDashboardPanel
       heading={
@@ -115,7 +116,7 @@ export function TokenList(props: TokenListProps) {
         </SpinnerWrapper>
       ) : (
         <TokenListWrapper>
-          {tokens.map(token => (
+          {sortedTokens.map(token => (
             <Token key={token.uuid}>
               <Asset>
                 <AssetIcon symbol={token.ticker as TSymbol} size={'26px'} />


### PR DESCRIPTION
### Description
Sort the token list in the token scanner panel before display

#### Steps to Test:
Add some accounts to dashboard, scan for tokens and make sure the token names are alphabetized.