### PR TITLE
Fix network dropdown usage

### DIFF
--- a/common/v2/components/NetworkSelectDropdown.tsx
+++ b/common/v2/components/NetworkSelectDropdown.tsx
@@ -9,7 +9,7 @@ import { DEFAULT_NETWORK } from 'v2/config';
 import { Typography, Dropdown, Tooltip } from 'v2/components';
 
 interface Props {
-  network: string | undefined;
+  network: NetworkId;
   accountType?: WalletId;
   className?: string;
   showTooltip?: boolean;
@@ -30,18 +30,18 @@ const NetworkOption = ({ option, onSelect }: OptionComponentProps) => (
 );
 
 function NetworkSelectDropdown({
-  network,
+  network: networkId,
   accountType,
   onChange,
   showTooltip = false,
   disabled = false,
   ...props
 }: Props) {
-  const { networks } = useContext(NetworkContext);
+  const { networks, getNetworkById } = useContext(NetworkContext);
 
   // set default network if none selected
   useEffect(() => {
-    if (!network) {
+    if (!networkId) {
       onChange(DEFAULT_NETWORK);
     }
   }, []);
@@ -52,6 +52,7 @@ function NetworkSelectDropdown({
     // @ts-ignore CHANGE IN WALLETYPE OBJECT CAUSING accountType to error -> TODO: FIX accountType
     .filter(options => isWalletFormatSupportedOnNetwork(options, accountType))
     .map(n => ({ label: n.name, value: n }));
+  const network = getNetworkById(networkId);
 
   return (
     <div {...props}>
@@ -60,7 +61,7 @@ function NetworkSelectDropdown({
         {showTooltip && <Tooltip tooltip={translate('NETWORK_TOOLTIP')} />}
       </label>
       <Dropdown
-        value={{ label: network }}
+        value={{ label: network!.name }}
         options={validNetworks.sort()}
         placeholder={DEFAULT_NETWORK}
         searchable={true}

--- a/common/v2/components/NetworkSelectDropdown.tsx
+++ b/common/v2/components/NetworkSelectDropdown.tsx
@@ -61,7 +61,7 @@ function NetworkSelectDropdown({
         {showTooltip && <Tooltip tooltip={translate('NETWORK_TOOLTIP')} />}
       </label>
       <Dropdown
-        value={{ label: network!.name }}
+        value={{ label: network.name }}
         options={validNetworks.sort()}
         placeholder={DEFAULT_NETWORK}
         searchable={true}

--- a/common/v2/components/WalletUnlock/LedgerNano.tsx
+++ b/common/v2/components/WalletUnlock/LedgerNano.tsx
@@ -36,10 +36,8 @@ class LedgerNanoSDecryptClass extends PureComponent<Props, State> {
     publicKey: '',
     chainCode: '',
     dPath:
-      getDPath(
-        this.context.getNetworkByName(this.props.formData.network),
-        WalletId.LEDGER_NANO_S
-      ) || getDPaths(this.context.networks, WalletId.LEDGER_NANO_S)[0],
+      getDPath(this.context.getNetworkById(this.props.formData.network), WalletId.LEDGER_NANO_S) ||
+      getDPaths(this.context.networks, WalletId.LEDGER_NANO_S)[0],
     error: null,
     isLoading: false
   };
@@ -47,7 +45,7 @@ class LedgerNanoSDecryptClass extends PureComponent<Props, State> {
   public render() {
     const { dPath, publicKey, chainCode, isLoading } = this.state;
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
 
     if (!dPath) {
       return <UnsupportedNetwork walletType={translateRaw('x_Ledger')} network={network} />;
@@ -162,7 +160,7 @@ class LedgerNanoSDecryptClass extends PureComponent<Props, State> {
 
   private reset() {
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
     this.setState({
       publicKey: '',
       chainCode: '',

--- a/common/v2/components/WalletUnlock/Mnemonic.tsx
+++ b/common/v2/components/WalletUnlock/Mnemonic.tsx
@@ -40,7 +40,7 @@ class MnemonicDecryptClass extends PureComponent<OwnProps, State> {
     pass: undefined,
     selectedDPath:
       getDPath(
-        this.context.getNetworkByName(this.props.formData.network),
+        this.context.getNetworkById(this.props.formData.network),
         WalletId.MNEMONIC_PHRASE
       ) || getDPaths(this.context.networks, WalletId.MNEMONIC_PHRASE)[0]
   };
@@ -49,7 +49,7 @@ class MnemonicDecryptClass extends PureComponent<OwnProps, State> {
     const { seed, phrase, formattedPhrase, pass, selectedDPath } = this.state;
     const isValidMnemonic = validateMnemonic(formattedPhrase || '');
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
 
     if (seed) {
       return (

--- a/common/v2/components/WalletUnlock/ParitySigner.tsx
+++ b/common/v2/components/WalletUnlock/ParitySigner.tsx
@@ -32,8 +32,8 @@ const WalletService = WalletFactory(WalletId.PARITY_SIGNER);
 const wikiLink = getWalletConfig(WalletId.PARITY_SIGNER).helpLink;
 
 export function ParitySignerDecrypt({ formData, onUnlock }: OwnProps & StateProps) {
-  const { getNetworkByName } = useContext(NetworkContext);
-  const [network] = useState(getNetworkByName(formData.network));
+  const { getNetworkById } = useContext(NetworkContext);
+  const [network] = useState(getNetworkById(formData.network));
   const unlockAddress = (content: SignerQrContent) => {
     if (
       typeof content === 'string' ||

--- a/common/v2/components/WalletUnlock/SafeT.tsx
+++ b/common/v2/components/WalletUnlock/SafeT.tsx
@@ -35,7 +35,7 @@ class SafeTminiDecryptClass extends PureComponent<OwnProps, State> {
     publicKey: '',
     chainCode: '',
     dPath:
-      getDPath(this.context.getNetworkByName(this.props.formData.network), WalletId.SAFE_T_MINI) ||
+      getDPath(this.context.getNetworkById(this.props.formData.network), WalletId.SAFE_T_MINI) ||
       getDPaths(this.context.networks, WalletId.SAFE_T_MINI)[0],
     error: null,
     isLoading: false
@@ -45,7 +45,7 @@ class SafeTminiDecryptClass extends PureComponent<OwnProps, State> {
     const { dPath, publicKey, chainCode, error, isLoading } = this.state;
     const showErr = error ? 'is-showing' : '';
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
 
     if (!dPath) {
       return <UnsupportedNetwork walletType={translateRaw('X_SAFE_T')} network={network} />;
@@ -153,7 +153,7 @@ class SafeTminiDecryptClass extends PureComponent<OwnProps, State> {
 
   private reset() {
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
     this.setState({
       publicKey: '',
       chainCode: '',

--- a/common/v2/components/WalletUnlock/Trezor.tsx
+++ b/common/v2/components/WalletUnlock/Trezor.tsx
@@ -36,7 +36,7 @@ class TrezorDecryptClass extends PureComponent<OwnProps, State> {
     publicKey: '',
     chainCode: '',
     dPath:
-      getDPath(this.context.getNetworkByName(this.props.formData.network), WalletId.TREZOR) ||
+      getDPath(this.context.getNetworkById(this.props.formData.network), WalletId.TREZOR) ||
       getDPaths(this.context.networks, WalletId.TREZOR)[0],
     error: null,
     isLoading: false
@@ -45,7 +45,7 @@ class TrezorDecryptClass extends PureComponent<OwnProps, State> {
   public render() {
     const { dPath, publicKey, chainCode, isLoading } = this.state;
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
 
     if (!dPath) {
       return <UnsupportedNetwork walletType={translateRaw('x_Trezor')} network={network} />;
@@ -148,7 +148,7 @@ class TrezorDecryptClass extends PureComponent<OwnProps, State> {
 
   private reset() {
     const networks = this.context.networks;
-    const network = this.context.getNetworkByName(this.props.formData.network);
+    const network = this.context.getNetworkById(this.props.formData.network);
     this.setState({
       publicKey: '',
       chainCode: '',

--- a/common/v2/components/WalletUnlock/ViewOnly.tsx
+++ b/common/v2/components/WalletUnlock/ViewOnly.tsx
@@ -44,9 +44,7 @@ export function ViewOnlyDecrypt({ formData, onUnlock }: Props) {
 
   const onSubmit = (fields: FormValues) => {
     if (R.equals(fields, initialFormikValues)) return;
-    onUnlock(
-      WalletService.init(toChecksumAddressByChainId(fields.address.value, network!.chainId))
-    );
+    onUnlock(WalletService.init(toChecksumAddressByChainId(fields.address.value, network.chainId)));
   };
 
   return (
@@ -61,7 +59,7 @@ export function ViewOnlyDecrypt({ formData, onUnlock }: Props) {
               name="address"
               value={values.address}
               error={errors && touched.address && errors.address && (errors.address as ErrorObject)}
-              network={network!}
+              network={network}
               isResolvingName={isResolvingDomain}
               setIsResolvingDomain={setIsResolvingDomain}
             />

--- a/common/v2/components/WalletUnlock/ViewOnly.tsx
+++ b/common/v2/components/WalletUnlock/ViewOnly.tsx
@@ -38,9 +38,9 @@ const initialFormikValues: FormValues = {
 };
 
 export function ViewOnlyDecrypt({ formData, onUnlock }: Props) {
-  const { getNetworkByName } = useContext(NetworkContext);
+  const { getNetworkById } = useContext(NetworkContext);
   const [isResolvingDomain, setIsResolvingDomain] = useState(false);
-  const [network] = useState(getNetworkByName(formData.network));
+  const [network] = useState(getNetworkById(formData.network));
 
   const onSubmit = (fields: FormValues) => {
     if (R.equals(fields, initialFormikValues)) return;

--- a/common/v2/database/v1.0.0/generateDefaultValues.spec.ts
+++ b/common/v2/database/v1.0.0/generateDefaultValues.spec.ts
@@ -36,7 +36,7 @@ describe('Schema', () => {
 
     it('adds Nodes to each Network', () => {
       const nodes = toArray(defaultData[LSKeys.NETWORKS]).flatMap(n => n.nodes);
-      expect(nodes.length).toBeGreaterThanOrEqual(39);
+      expect(nodes.length).toBe(40);
     });
 
     it('adds BaseAssets to Networks', () => {

--- a/common/v2/database/v1.0.0/generateDefaultValues.ts
+++ b/common/v2/database/v1.0.0/generateDefaultValues.ts
@@ -29,7 +29,7 @@ const addNetworks = add(LSKeys.NETWORKS)((networks: SeedData) => {
 
     return Object.assign(
       {
-        // Also availbale are: blockExplorer, tokenExplorer, tokens aka assets, contracts
+        // Also available are: blockExplorer, tokenExplorer, tokens aka assets, contracts
         id: n.id,
         name: n.name,
         chainId: n.chainId,

--- a/common/v2/features/BroadcastTransaction/stateFactory.tsx
+++ b/common/v2/features/BroadcastTransaction/stateFactory.tsx
@@ -22,7 +22,7 @@ interface State {
 }
 
 const BroadcastTxConfigFactory: TUseStateReducerFactory<State> = ({ state, setState }) => {
-  const { networks, getNetworkByName } = useContext(NetworkContext);
+  const { networks, getNetworkById } = useContext(NetworkContext);
   const { assets } = useContext(AssetContext);
   const { displayToast, toastTemplates } = useContext(ToastContext);
   const { accounts } = useContext(StoreContext);
@@ -37,7 +37,7 @@ const BroadcastTxConfigFactory: TUseStateReducerFactory<State> = ({ state, setSt
   const handleSendClicked = (signedTx: ISignedTx, cb: any) => {
     const { network } = state;
     const txConfig = makeTxConfigFromSignedTx(signedTx, assets, networks, accounts, {
-      network: getNetworkByName(network)
+      network: getNetworkById(network)
     } as ITxConfig);
 
     setState((prevState: State) => ({

--- a/common/v2/features/CreateWallet/Keystore/Keystore.tsx
+++ b/common/v2/features/CreateWallet/Keystore/Keystore.tsx
@@ -16,8 +16,8 @@ import {
 import { stripHexPrefix } from 'v2/services/EthService';
 import { WalletFactory } from 'v2/services/WalletService';
 import { NotificationTemplates } from 'v2/features/NotificationsPanel';
-import { TAddress, IRawAccount, Asset, ISettings, Network, NetworkId, WalletId } from 'v2/types';
-import { ROUTE_PATHS, N_FACTOR } from 'v2/config';
+import { TAddress, IRawAccount, Asset, ISettings, NetworkId, WalletId } from 'v2/types';
+import { ROUTE_PATHS, N_FACTOR, DEFAULT_NETWORK } from 'v2/config';
 
 import { KeystoreStages, keystoreStageToComponentHash, keystoreFlow } from './constants';
 import { withAccountAndNotificationsContext } from '../components/withAccountAndNotificationsContext';
@@ -27,7 +27,7 @@ interface State {
   privateKey: string;
   keystore?: IV3Wallet;
   filename: string;
-  network: string;
+  network: NetworkId;
   stage: KeystoreStages;
   accountType: WalletId;
 }
@@ -47,7 +47,7 @@ class CreateKeystore extends Component<Props & INetworkContext & IAssetContext, 
     password: '',
     privateKey: '',
     filename: '',
-    network: '',
+    network: DEFAULT_NETWORK,
     stage: KeystoreStages.GenerateKeystore,
     accountType: WalletId.KEYSTORE_FILE
   };
@@ -106,12 +106,12 @@ class CreateKeystore extends Component<Props & INetworkContext & IAssetContext, 
       updateSettingsAccounts,
       createAssetWithID,
       displayNotification,
-      getNetworkByName,
+      getNetworkById,
       assets
     } = this.props;
     const { keystore, network, accountType } = this.state;
 
-    const accountNetwork: Network | undefined = getNetworkByName(network);
+    const accountNetwork = getNetworkById(network);
     if (!keystore || !accountNetwork) {
       return;
     }
@@ -120,7 +120,7 @@ class CreateKeystore extends Component<Props & INetworkContext & IAssetContext, 
     const newUUID = generateUUID();
     const account: IRawAccount = {
       address: toChecksumAddress(addHexPrefix(keystore.address)) as TAddress,
-      networkId: network as NetworkId,
+      networkId: network,
       wallet: accountType,
       dPath: '',
       assets: [{ uuid: newAssetID, balance: '0', mtime: Date.now() }],
@@ -153,7 +153,7 @@ class CreateKeystore extends Component<Props & INetworkContext & IAssetContext, 
     }
   };
 
-  private selectNetwork = async (network: string) => {
+  private selectNetwork = async (network: NetworkId) => {
     this.setState({ network });
   };
 

--- a/common/v2/features/CreateWallet/Mnemonic/Mnemonic.tsx
+++ b/common/v2/features/CreateWallet/Mnemonic/Mnemonic.tsx
@@ -16,7 +16,6 @@ import {
   DPathFormat,
   ISettings,
   WalletId,
-  Network,
   NetworkId
 } from 'v2/types';
 import { generateUUID, withContext } from 'v2/utils';
@@ -25,8 +24,7 @@ import {
   AssetContext,
   IAssetContext,
   INetworkContext,
-  getNewDefaultAssetTemplateByNetwork,
-  getNetworkById
+  getNewDefaultAssetTemplateByNetwork
 } from 'v2/services/Store';
 import { DEFAULT_NETWORK, ROUTE_PATHS } from 'v2/config';
 
@@ -123,7 +121,7 @@ class CreateMnemonic extends Component<Props & IAssetContext & INetworkContext> 
   };
 
   private selectNetwork = async (network: NetworkId) => {
-    const accountNetwork: Network | undefined = getNetworkById(network, this.props.networks);
+    const accountNetwork = this.props.getNetworkById(network);
     const pathFormat = accountNetwork && accountNetwork.dPaths[this.state.accountType];
     const path = (pathFormat && pathFormat.value) || '';
     this.setState({ network, path });
@@ -148,14 +146,14 @@ class CreateMnemonic extends Component<Props & IAssetContext & INetworkContext> 
       createAccountWithID,
       updateSettingsAccounts,
       createAssetWithID,
-      displayNotification
+      displayNotification,
+      getNetworkById
     } = this.props;
     const { network, accountType, address, path } = this.state;
 
-    const accountNetwork: Network | undefined = getNetworkById(network, this.props.networks);
-    if (!accountNetwork) {
-      return;
-    }
+    const accountNetwork = getNetworkById(network);
+    if (!accountNetwork) return;
+
     const newAsset: Asset = getNewDefaultAssetTemplateByNetwork(this.props.assets)(accountNetwork);
     const newAssetID = generateUUID();
     const newUUID = generateUUID();

--- a/common/v2/features/CreateWallet/components/SelectNetworkPanel.tsx
+++ b/common/v2/features/CreateWallet/components/SelectNetworkPanel.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import translate, { translateRaw } from 'v2/translations';
 import { ExtendedContentPanel, InlineMessage, NetworkSelectDropdown } from 'v2/components';
-import { WalletId } from 'v2/types';
+import { WalletId, NetworkId } from 'v2/types';
 import { NetworkContext } from 'v2/services/Store';
 import { PanelProps } from '../CreateWallet';
 
@@ -27,7 +27,7 @@ const ErrorWrapper = styled.div`
 `;
 
 interface Props extends PanelProps {
-  network: string;
+  network: NetworkId;
   accountType: WalletId;
   selectNetwork(network: string): void;
 }

--- a/common/v2/features/CreateWallet/components/SelectNetworkPanel.tsx
+++ b/common/v2/features/CreateWallet/components/SelectNetworkPanel.tsx
@@ -38,7 +38,7 @@ export default class SelectNetworkPanel extends Component<Props> {
 
   public handleSubmitClick = () => {
     const { network, onNext } = this.props;
-    if (this.context.getNetworkByName(network)) {
+    if (this.context.getNetworkById(network)) {
       onNext();
     } else {
       this.setState({ error: true });

--- a/common/v2/features/Dashboard/components/TokenPanel/AddToken.tsx
+++ b/common/v2/features/Dashboard/components/TokenPanel/AddToken.tsx
@@ -50,7 +50,7 @@ export function AddToken(props: Props) {
   const [networkId, setNetworkId] = useState<NetworkId>(DEFAULT_NETWORK);
 
   const { createAssetWithID } = useContext(AssetContext);
-  const { getNetworkByName } = useContext(NetworkContext);
+  const { getNetworkById } = useContext(NetworkContext);
 
   const { setShowAddToken, scanTokens, setShowDetailsView } = props;
 
@@ -61,7 +61,7 @@ export function AddToken(props: Props) {
 
     let isValid = true;
 
-    const network = getNetworkByName(networkId);
+    const network = getNetworkById(networkId);
 
     if (symbol.length === 0) {
       setSymbolError(translateRaw('ADD_TOKEN_NO_SYMBOL'));

--- a/common/v2/features/DevTools/DevTools.tsx
+++ b/common/v2/features/DevTools/DevTools.tsx
@@ -34,12 +34,12 @@ const DevToolsInput = styled(Input)`
 
 const renderAccountForm = (
   addressBook: ExtendedAddressBook[],
-  getNetworkByName: (name: string) => Network | undefined
+  getNetworkById: (name: string) => Network | undefined
 ) => ({ values, handleChange, handleBlur, isSubmitting }: FormikProps<IRawAccount>) => {
   const detectedLabel: AddressBook | undefined = getLabelByAddressAndNetwork(
     values.address,
     addressBook,
-    getNetworkByName(values.networkId)
+    getNetworkById(values.networkId)
   );
   const label = detectedLabel ? detectedLabel.label : 'Unknown Account';
   return (
@@ -127,7 +127,7 @@ const ErrorTools = () => {
 };
 
 const DevTools = () => {
-  const { getNetworkByName } = useContext(NetworkContext);
+  const { getNetworkById } = useContext(NetworkContext);
   const { addressBook } = useContext(AddressBookContext);
   const { accounts, createAccountWithID, deleteAccount } = useContext(AccountContext);
   const dummyAccount = {
@@ -172,7 +172,7 @@ const DevTools = () => {
             setSubmitting(false);
           }}
         >
-          {renderAccountForm(addressBook, getNetworkByName)}
+          {renderAccountForm(addressBook, getNetworkById)}
         </Formik>
       </Panel>
     </React.Fragment>

--- a/common/v2/features/Settings/Settings.tsx
+++ b/common/v2/features/Settings/Settings.tsx
@@ -90,7 +90,6 @@ function renderAddressPanel() {
 
 function renderNetworkNodes() {
   const {
-    getNetworkByName,
     addNodeToNetwork,
     isNodeNameAvailable,
     getNetworkById,
@@ -101,7 +100,7 @@ function renderNetworkNodes() {
   const [networkId, setNetworkId] = useState<NetworkId>(DEFAULT_NETWORK);
   const [editNode, setEditNode] = useState<CustomNodeConfig | undefined>(undefined);
 
-  const addressBookNetworks = NetworkUtils.getDistinctNetworks(addressBook, getNetworkByName);
+  const addressBookNetworks = NetworkUtils.getDistinctNetworks(addressBook, getNetworkById);
 
   return (
     <FlippablePanel>

--- a/common/v2/features/Settings/components/AddOrEditNetworkNode.tsx
+++ b/common/v2/features/Settings/components/AddOrEditNetworkNode.tsx
@@ -283,7 +283,7 @@ export default function AddOrEditNetworkNode({
               <Column>
                 <AddressFieldset>
                   <Field name="networkId">
-                    {({ field, form }: FieldProps<string>) => (
+                    {({ field, form }: FieldProps<NetworkId>) => (
                       <SNetworkSelectDropdown
                         network={field.value}
                         onChange={e => form.setFieldValue(field.name, e)}

--- a/common/v2/features/Settings/components/AddToAddressBook.tsx
+++ b/common/v2/features/Settings/components/AddToAddressBook.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import backArrowIcon from 'common/assets/images/icn-back-arrow.svg';
 import { DashboardPanel, NetworkSelectDropdown, InputField } from 'v2/components';
-import { AddressBook } from 'v2/types';
+import { AddressBook, NetworkId } from 'v2/types';
 import { ToastContext } from 'v2/features/Toasts';
 import { translateRaw } from 'v2/translations';
 import { isValidETHAddress } from 'v2/services/EthService';
@@ -126,7 +126,7 @@ export default function AddToAddressBook({ toggleFlipped, createAddressBooks }: 
             <AddressFieldset>
               <Field
                 name="network"
-                render={({ field, form }: FieldProps<string>) => (
+                render={({ field, form }: FieldProps<NetworkId>) => (
                   <SNetworkSelectDropdown
                     network={field.value}
                     onChange={e => form.setFieldValue(field.name, e)}

--- a/common/v2/services/Store/Network/NetworkProvider.tsx
+++ b/common/v2/services/Store/Network/NetworkProvider.tsx
@@ -3,6 +3,7 @@ import isString from 'lodash/isString';
 import isEmpty from 'lodash/isEmpty';
 
 import { Network, NetworkId, NodeOptions, LSKeys } from 'v2/types';
+
 import { DataContext } from '../DataManager';
 import { NetworkUtils } from './utils';
 import { EthersJS } from '../../EthService/network/ethersJsProvider';
@@ -11,7 +12,6 @@ export interface INetworkContext {
   networks: Network[];
   updateNetwork(id: NetworkId, item: Network): void;
   getNetworkById(networkId: NetworkId): Network;
-  getNetworkByName(name: string): Network | undefined;
   getNetworkByChainId(chainId: number): Network | undefined;
   getNetworkNodes(networkId: NetworkId): NodeOptions[];
   addNodeToNetwork(node: NodeOptions, network: Network | NetworkId): void;
@@ -36,9 +36,6 @@ export const NetworkProvider: React.FC = ({ children }) => {
         return foundNetwork;
       }
       throw new Error(`No network found with network id: ${networkId}`);
-    },
-    getNetworkByName: name => {
-      return networks.find((network: Network) => network.name === name);
     },
     getNetworkByChainId: chainId => {
       return networks.find((network: Network) => network.chainId === chainId);

--- a/common/v2/services/Store/Network/NetworkProvider.tsx
+++ b/common/v2/services/Store/Network/NetworkProvider.tsx
@@ -7,6 +7,7 @@ import { Network, NetworkId, NodeOptions, LSKeys } from 'v2/types';
 import { DataContext } from '../DataManager';
 import { NetworkUtils } from './utils';
 import { EthersJS } from '../../EthService/network/ethersJsProvider';
+import { getNetworkById } from './helpers';
 
 export interface INetworkContext {
   networks: Network[];
@@ -31,7 +32,7 @@ export const NetworkProvider: React.FC = ({ children }) => {
     networks,
     updateNetwork: model.update,
     getNetworkById(networkId: NetworkId): Network {
-      const foundNetwork = networks.find((network: Network) => network.id === networkId);
+      const foundNetwork = getNetworkById(networkId, networks);
       if (foundNetwork) {
         return foundNetwork;
       }
@@ -41,7 +42,7 @@ export const NetworkProvider: React.FC = ({ children }) => {
       return networks.find((network: Network) => network.chainId === chainId);
     },
     getNetworkNodes: (networkId: NetworkId) => {
-      const foundNetwork = networks.find((network: Network) => network.id === networkId);
+      const foundNetwork = getNetworkById(networkId, networks);
       if (foundNetwork) {
         return foundNetwork.nodes;
       }
@@ -114,8 +115,7 @@ export const NetworkProvider: React.FC = ({ children }) => {
     isNodeNameAvailable: (networkId: NetworkId, nodeName: string, ignoreNames: string[] = []) => {
       if (isEmpty(networkId) || isEmpty(nodeName)) return false;
 
-      const foundNetwork = networks.find((network: Network) => network.id === networkId);
-
+      const foundNetwork = getNetworkById(networkId, networks);
       if (!foundNetwork) {
         throw new Error(`No network found with network id: ${networkId}`);
       }

--- a/common/v2/services/Store/Network/utils.ts
+++ b/common/v2/services/Store/Network/utils.ts
@@ -37,9 +37,9 @@ export abstract class NetworkUtils {
 
   public static getDistinctNetworks(
     addressBook: ExtendedAddressBook[],
-    getNetworkByName: (name: string) => Network | undefined
+    getNetworkById: (name: string) => Network
   ) {
     const addressBookNetworksIds = [...new Set(addressBook.map(a => a.network))];
-    return addressBookNetworksIds.map(addressId => getNetworkByName(addressId)!);
+    return addressBookNetworksIds.map(id => getNetworkById(id));
   }
 }


### PR DESCRIPTION
Swap `getNetworkByName` with `getNetworkById`, show network name in network dropdown instead of network id.
[ch5769]