### PR TITLE
Fix "Onboarding please understand" notification icons ratio

### DIFF
--- a/common/v2/features/NotificationsPanel/components/OnboardingPleaseUnderstandNotification.tsx
+++ b/common/v2/features/NotificationsPanel/components/OnboardingPleaseUnderstandNotification.tsx
@@ -55,7 +55,7 @@ const TipItem = styled.div`
 `;
 
 const TipIcon = styled.img`
-  width: 50px;
+  width: auto;
   height: 50px;
   margin-right: 10px;
 `;


### PR DESCRIPTION
Quick fix for Icons ration on "Onboarding please understand" notification.