### PR TITLE
Scan tokens ux improvements

### DIFF
--- a/common/v2/config/index.ts
+++ b/common/v2/config/index.ts
@@ -32,7 +32,6 @@ export {
   WEB3_WALLETS,
   getWalletConfig
 } from './wallets';
-import type { IWalletConfig } from './wallets';
 export { KB_HELP_ARTICLE, HELP_ARTICLE, getKBHelpArticle } from './helpArticles';
 export {
   DEFAULT_NETWORK_FOR_FALLBACK,
@@ -44,4 +43,4 @@ export {
 export { Fiats } from './fiats';
 export { IS_ACTIVE_FEATURE } from './isActiveFeature';
 export { ROUTE_PATHS } from './routePaths';
-export type { IWalletConfig };
+export { IWalletConfig } from './wallets';

--- a/common/v2/features/AddAccount/AddAccountFlow.tsx
+++ b/common/v2/features/AddAccount/AddAccountFlow.tsx
@@ -6,7 +6,7 @@ import { useUpdateEffect } from 'v2/vendor';
 import { ROUTE_PATHS, WALLETS_CONFIG, IWalletConfig } from 'v2/config';
 import { WalletId, IStory } from 'v2/types';
 import { ExtendedContentPanel, WalletList } from 'v2/components';
-import { StoreContext, AccountContext } from 'v2/services/Store';
+import { StoreContext } from 'v2/services/Store';
 
 import { NotificationsContext, NotificationTemplates } from '../NotificationsPanel';
 import { FormDataActionType as ActionType } from './types';
@@ -15,7 +15,7 @@ import { formReducer, initialState } from './AddAccountForm.reducer';
 import './AddAccountFlow.scss';
 
 export const getStory = (storyName: WalletId): IStory => {
-  return getStories().filter(selected => selected.name === storyName)[0];
+  return getStories().filter((selected) => selected.name === storyName)[0];
 };
 
 export const getStorySteps = (storyName: WalletId) => {
@@ -40,9 +40,8 @@ export const isValidWalletId = (id: WalletId | string | undefined) => {
 const AddAccountFlow = withRouter(({ history, match }) => {
   const [step, setStep] = useState(0); // The current Step inside the Wallet Story.
   const [formData, updateFormState] = useReducer(formReducer, initialState); // The data that we want to save at the end.
-  const { scanTokens, addAccount, accounts } = useContext(StoreContext);
+  const { scanAccountTokens, addAccount, accounts } = useContext(StoreContext);
   const { displayNotification } = useContext(NotificationsContext);
-  const { getAccountByAddressAndNetworkName } = useContext(AccountContext);
 
   const storyName: WalletId = formData.accountType; // The Wallet Story that we are tracking.
   const isDefaultView = storyName === undefined;
@@ -60,9 +59,13 @@ const AddAccountFlow = withRouter(({ history, match }) => {
   // If add account succeeds, accounts is updated and we can return to dashboard
   useEffect(() => {
     const { network, address } = formData;
-    if (!!getAccountByAddressAndNetworkName(address, network)) {
+    if (!accounts) return;
+    const newAccount = accounts.find(
+      (account) => account.address === address && account.networkId === network
+    );
+    if (!!newAccount) {
       displayNotification(NotificationTemplates.walletAdded, { address });
-      scanTokens();
+      scanAccountTokens(newAccount);
       history.push(ROUTE_PATHS.DASHBOARD.path);
     }
   }, [accounts]);

--- a/common/v2/services/Store/StoreProvider.tsx
+++ b/common/v2/services/Store/StoreProvider.tsx
@@ -70,7 +70,8 @@ interface State {
   ): (getAssetRate: (asset: Asset) => number | undefined) => number;
   assetTickers(targetAssets?: StoreAsset[]): TTicker[];
   assetUUIDs(targetAssets?: StoreAsset[]): any[];
-  scanTokens(asset?: ExtendedAsset): Promise<void[]>;
+  scanAccountTokens(account: StoreAccount, asset?: ExtendedAsset): Promise<void>;
+  scanTokens(asset?: ExtendedAsset): Promise<void>;
   deleteAccountFromCache(account: IAccount): void;
   restoreDeletedAccount(accountId: TUuid): void;
   addAccount(
@@ -97,6 +98,7 @@ export const StoreProvider: React.FC = ({ children }) => {
     addNewTransactionToAccount,
     getAccountByAddressAndNetworkName,
     updateAccountAssets,
+    updateAllAccountsAssets,
     updateAccountsBalances,
     deleteAccount,
     createAccountWithID
@@ -301,12 +303,10 @@ export const StoreProvider: React.FC = ({ children }) => {
     assetUUIDs: (targetAssets = state.assets()) => {
       return [...new Set(targetAssets.map((a: StoreAsset) => a.uuid))];
     },
+    scanAccountTokens: async (account: StoreAccount, asset?: ExtendedAsset) =>
+      updateAccountAssets(account, asset ? [...assets, asset] : assets),
     scanTokens: async (asset?: ExtendedAsset) =>
-      Promise.all(
-        accounts
-          .map((account) => updateAccountAssets(account, asset ? [...assets, asset] : assets))
-          .map((p) => p.catch((e) => console.debug(e)))
-      ),
+      updateAllAccountsAssets(accounts, asset ? [...assets, asset] : assets),
     deleteAccountFromCache: (account) => {
       setAccountRestore((prevState) => ({ ...prevState, [account.uuid]: account }));
       deleteAccount(account);

--- a/common/v2/types/index.ts
+++ b/common/v2/types/index.ts
@@ -39,7 +39,7 @@ export {
   StoreAsset,
   AssetWithDetails
 } from './asset';
-export { IRawAccount, IAccount, StoreAccount } from './account';
+export { StoreAccount, IRawAccount, IAccount } from './account';
 export { AddressBook, ExtendedAddressBook } from './addressBook';
 export { Contract, ExtendedContract } from './contract';
 export { Network, NetworkLegacy, AssetLegacy, ContractLegacy, NetworkNodes } from './network';

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "fork-ts-checker-webpack-plugin": "3.1.1",
     "friendly-errors-webpack-plugin": "1.7.0",
     "html-webpack-plugin": "3.2.0",
-    "husky": "4.0.9",
+    "husky": "4.0.10",
     "image-webpack-loader": "6.0.0",
     "isomorphic-fetch": "2.2.1",
     "jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "fork-ts-checker-webpack-plugin": "3.1.1",
     "friendly-errors-webpack-plugin": "1.7.0",
     "html-webpack-plugin": "3.2.0",
-    "husky": "4.0.10",
+    "husky": "4.2.5",
     "image-webpack-loader": "6.0.0",
     "isomorphic-fetch": "2.2.1",
     "jest": "24.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9775,10 +9775,10 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-husky@4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.0.9.tgz#ded9e4f957dd8358649330da84906b6bf2e367e9"
-  integrity sha512-zaH0INH9MZBH8smr6nPdzv7pjchOZPN/AKdhkuV4zut9SyF0+pUy1ZCBzhz2uPe7Cp75YzD92ewU2ytIZ0GjUQ==
+husky@4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.0.10.tgz#659b52c404d3163b943a73f6c1d454708c0226d8"
+  integrity sha512-Ptm4k2DqOwxeK/kzu5RaJmNRoGvESrgDXObFcZ8aJZcyXyMBHhM2FqZj6zYKdetadmP3wCwxEHCBuB9xGlRp8A==
   dependencies:
     chalk "^3.0.0"
     ci-info "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,6 +5627,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -6129,6 +6137,11 @@ commoner@^0.10.1:
     private "^0.1.6"
     q "^1.1.2"
     recast "^0.11.17"
+
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
 component-classes@^1.2.5:
   version "1.2.6"
@@ -8552,7 +8565,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-versions@^3.0.0:
+find-versions@^3.0.0, find-versions@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
@@ -9775,14 +9788,16 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-husky@4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.0.10.tgz#659b52c404d3163b943a73f6c1d454708c0226d8"
-  integrity sha512-Ptm4k2DqOwxeK/kzu5RaJmNRoGvESrgDXObFcZ8aJZcyXyMBHhM2FqZj6zYKdetadmP3wCwxEHCBuB9xGlRp8A==
+husky@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.5.tgz#2b4f7622673a71579f901d9885ed448394b5fa36"
+  integrity sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==
   dependencies:
-    chalk "^3.0.0"
+    chalk "^4.0.0"
     ci-info "^2.0.0"
+    compare-versions "^3.6.0"
     cosmiconfig "^6.0.0"
+    find-versions "^3.2.0"
     opencollective-postinstall "^2.0.2"
     pkg-dir "^4.2.0"
     please-upgrade-node "^3.2.0"


### PR DESCRIPTION
[ch5875]

### Description
After adding an account, scan tokens only on the account being added. Change `scanTokens()` to use `model.updateAll` in provider instead of `model.update` to reduce overall "glitchiness".

##### Steps to Test:
1) Add accounts back to back with network tab open. After each add, you should only see a couple of new network requests instead of hundreds ;)
2) With 10+ accounts on your dashboard, click the `Scan Tokens` button with network tab open. This should result in 100-200 new network calls as opposed to the previous ~500-700 that were being conducted.