### PR TITLE
Sanitize decimal separator

### DIFF
--- a/common/v2/components/AmountInput.tsx
+++ b/common/v2/components/AmountInput.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import { Input } from '@mycrypto/ui';
 
-import { Asset } from 'v2/types';
-import { TSymbol } from 'v2/types/symbols';
+import { Asset, TSymbol } from 'v2/types';
+import { sanitizeDecimalSeparator } from 'v2/utils';
 
 import AssetIcon from './AssetIcon';
 import Typography from './Typography';
+
 interface Props {
   disabled?: boolean;
   asset: Asset;
@@ -31,7 +32,10 @@ function AmountInput({ asset, value, onChange, onBlur, placeholder, ...props }: 
       {...props}
       inputMode="decimal"
       value={value}
-      onChange={onChange}
+      onChange={(e) => {
+        e.target.value = sanitizeDecimalSeparator(e.target.value);
+        onChange(e);
+      }}
       onBlur={onBlur}
       placeholder={placeholder}
       iconSide={'right'}

--- a/common/v2/components/GasSelector.tsx
+++ b/common/v2/components/GasSelector.tsx
@@ -123,6 +123,7 @@ export default function GasSelector(props: Props) {
           label={<CustomLabel>{translateRaw('OFFLINE_STEP2_LABEL_3')}</CustomLabel>}
           value={gasPrice}
           onChange={handleGasPriceChange}
+          inputMode="decimal"
         />
       </FieldWrapper>
       <FieldWrapper>
@@ -131,6 +132,7 @@ export default function GasSelector(props: Props) {
           value={gasLimit}
           onChange={handleGasLimitChange}
           disabled={isAutoGasSet}
+          inputMode="decimal"
         />
       </FieldWrapper>
       <FieldWrapper>
@@ -138,6 +140,7 @@ export default function GasSelector(props: Props) {
           label={<CustomLabel>{translateRaw('OFFLINE_STEP2_LABEL_5')}</CustomLabel>}
           value={nonce}
           onChange={handleNonceChange}
+          inputMode="decimal"
         />
       </FieldWrapper>
     </Wrapper>

--- a/common/v2/components/InputField.tsx
+++ b/common/v2/components/InputField.tsx
@@ -5,9 +5,10 @@ import { Icon } from '@mycrypto/ui';
 import { COLORS } from 'v2/theme';
 import { InlineMessage, Spinner } from 'v2/components';
 import { InlineMessageType } from 'v2/types';
+import { sanitizeDecimalSeparator } from 'v2/utils';
 
 const MainWrapper = styled.div<WrapperProps>`
-  margin-bottom: ${props => props.marginBottom};
+  margin-bottom: ${(props) => props.marginBottom};
   width: 100%;
 `;
 
@@ -22,7 +23,7 @@ const Label = styled.p`
   text-align: left;
   font-weight: normal;
   margin-bottom: 9px;
-  color: ${props => props.theme.text};
+  color: ${(props) => props.theme.text};
 `;
 
 interface CustomInputProps {
@@ -37,42 +38,42 @@ interface CustomInputProps {
 
 const CustomInput = styled.input<CustomInputProps>`
   width: 100%;
-  background: ${props => props.theme.controlBackground};
-  border: 0.125em solid ${props => props.theme.controlBorder};
+  background: ${(props) => props.theme.controlBackground};
+  border: 0.125em solid ${(props) => props.theme.controlBorder};
   border-radius: 0.125em;
-  padding: ${props => (props.showEye || props.customIcon ? '12px 36px 12px 12px' : '12px 12px')};
+  padding: ${(props) => (props.showEye || props.customIcon ? '12px 36px 12px 12px' : '12px 12px')};
   display: flex;
   :focus-within {
     outline: none;
-    box-shadow: ${props => props.theme.outline};
+    box-shadow: ${(props) => props.theme.outline};
   }
   ::placeholder {
     color: ${COLORS.GREY_LIGHT};
     opacity: 1;
   }
-  border-color: ${props => (props.inputError && props.inputErrorBorder ? COLORS.PASTEL_RED : '')};
-  ${props => props.height && `height: ${props.height}`};
+  border-color: ${(props) => (props.inputError && props.inputErrorBorder ? COLORS.PASTEL_RED : '')};
+  ${(props) => props.height && `height: ${props.height}`};
 `;
 
 const CustomTextArea = styled.textarea<CustomInputProps>`
   width: 100%;
-  background: ${props => props.theme.controlBackground};
-  border: 0.125em solid ${props => props.theme.controlBorder};
+  background: ${(props) => props.theme.controlBackground};
+  border: 0.125em solid ${(props) => props.theme.controlBorder};
   border-radius: 0.125em;
-  padding: ${props => (props.showEye ? '12px 36px 12px 12px' : '12px 12px')};
+  padding: ${(props) => (props.showEye ? '12px 36px 12px 12px' : '12px 12px')};
   display: flex;
   :focus-within {
     outline: none;
-    box-shadow: ${props => props.theme.outline};
+    box-shadow: ${(props) => props.theme.outline};
   }
   ::placeholder {
     color: ${COLORS.GREY_LIGHT};
     opacity: 1;
   }
-  border-color: ${props => (props.inputError ? COLORS.PASTEL_RED : '')};
-  resize: ${props => (props.resizable ? 'default' : 'none')};
-  ${props => props.height && `height: ${props.height}`};
-  ${props => props.maxHeight && `max-height: ${props.maxHeight}`};
+  border-color: ${(props) => (props.inputError ? COLORS.PASTEL_RED : '')};
+  resize: ${(props) => (props.resizable ? 'default' : 'none')};
+  ${(props) => props.height && `height: ${props.height}`};
+  ${(props) => props.maxHeight && `max-height: ${props.maxHeight}`};
 `;
 
 const InputWrapper = styled.div`
@@ -215,7 +216,14 @@ export class InputField extends Component<Props> {
             <CustomInput
               name={name}
               value={value}
-              onChange={onChange}
+              onChange={(e) => {
+                if (!onChange) return;
+
+                if (inputMode === 'decimal') {
+                  e.target.value = sanitizeDecimalSeparator(e.target.value);
+                }
+                onChange(e);
+              }}
               onBlur={onBlur}
               onFocus={onFocus}
               inputError={inputError}

--- a/common/v2/features/Home/components/TestimonialsPanel.tsx
+++ b/common/v2/features/Home/components/TestimonialsPanel.tsx
@@ -4,11 +4,13 @@ import Slider from 'react-slick';
 import styled from 'styled-components';
 
 import { BREAK_POINTS, COLORS } from 'v2/theme';
+
 import './SliderImports.scss';
 
 import sparkles1Icon from 'common/assets/images/icn-sparkles-1.svg';
 import sparkles2Icon from 'common/assets/images/icn-sparkles-2.svg';
 import sparkles3Icon from 'common/assets/images/icn-sparkles-3.svg';
+import moreIcon from 'common/assets/images/icn-more.svg';
 
 const { SCREEN_XS, SCREEN_SM, SCREEN_XXL } = BREAK_POINTS;
 const { GREYISH_BROWN } = COLORS;
@@ -34,7 +36,7 @@ const MainPanel = styled(Panel)`
     .slick-prev {
       z-index: 9999;
       left: 0px;
-      background: url(/common/assets/images/icn-more.svg) top left;
+      background: url(${moreIcon}) top left;
       background-size: cover;
       background-repeat: no-repeat;
       transform: translate(0, -50%) rotate(180deg);
@@ -50,7 +52,7 @@ const MainPanel = styled(Panel)`
 
     .slick-next {
       right: 0px;
-      background: url(/common/assets/images/icn-more.svg) top left;
+      background: url(${moreIcon}) top left;
       background-size: cover;
       background-repeat: no-repeat;
 

--- a/common/v2/features/ReceiveAssets/ReceiveAssets.tsx
+++ b/common/v2/features/ReceiveAssets/ReceiveAssets.tsx
@@ -11,7 +11,7 @@ import {
 } from 'v2/services/EthService/utils/formatters';
 import { ContentPanel, QRCode, AccountDropdown, AssetDropdown } from 'v2/components';
 import { AssetContext, getNetworkById, StoreContext } from 'v2/services/Store';
-import { isValidAmount } from 'v2/utils';
+import { isValidAmount, sanitizeDecimalSeparator } from 'v2/utils';
 import { IAccount as IIAccount, StoreAccount } from 'v2/types';
 import { ROUTE_PATHS } from 'v2/config';
 import translate, { translateRaw } from 'v2/translations';
@@ -113,17 +113,17 @@ export function ReceiveAssets({ history }: RouteComponentProps<{}>) {
   const network = getNetworkById(networkId, networks);
   const filteredAssets = network
     ? assets
-        .filter(asset => asset.networkId === network.id)
-        .filter(asset => asset.type === 'base' || asset.type === 'erc20')
+        .filter((asset) => asset.networkId === network.id)
+        .filter((asset) => asset.type === 'base' || asset.type === 'erc20')
     : [];
-  const assetOptions = filteredAssets.map(asset => ({
+  const assetOptions = filteredAssets.map((asset) => ({
     label: asset.name,
     id: asset.uuid,
     ...asset
   }));
 
   const [chosenAssetName, setAssetName] = useState(filteredAssets[0].name);
-  const selectedAsset = filteredAssets.find(asset => asset.name === chosenAssetName);
+  const selectedAsset = filteredAssets.find((asset) => asset.name === chosenAssetName);
 
   const initialValues = {
     amount: '',
@@ -189,7 +189,9 @@ export function ReceiveAssets({ history }: RouteComponentProps<{}>) {
                     <FullWidthInput
                       data-lpignore="true"
                       value={field.value}
-                      onChange={({ target: { value } }) => form.setFieldValue(field.name, value)}
+                      onChange={({ target: { value } }) =>
+                        form.setFieldValue(field.name, sanitizeDecimalSeparator(value))
+                      }
                       placeholder="0.00"
                       inputMode="decimal"
                     />
@@ -206,7 +208,7 @@ export function ReceiveAssets({ history }: RouteComponentProps<{}>) {
                       selectedAsset={field.value}
                       assets={assetOptions}
                       searchable={true}
-                      onSelect={option => {
+                      onSelect={(option) => {
                         form.setFieldValue(field.name, option);
                         if (option.name) {
                           setAssetName(option.name);

--- a/common/v2/utils/index.ts
+++ b/common/v2/utils/index.ts
@@ -61,3 +61,4 @@ export { bigify } from './bigify';
 export { useTxMulti } from './useTxMulti';
 export { withProtectTxProvider } from './withProtectTxProvider';
 export { default as useScreenSize } from './useScreenSize';
+export { sanitizeDecimalSeparator } from './sanitizeDecimalSeparator';

--- a/common/v2/utils/sanitizeDecimalSeparator.ts
+++ b/common/v2/utils/sanitizeDecimalSeparator.ts
@@ -1,0 +1,1 @@
+export const sanitizeDecimalSeparator = (decimal: string): string => decimal.replace(',', '.');


### PR DESCRIPTION
Using `inputMode="decimal"` forces numeric keyboard with an only country-specific decimal separator on iOS devices. For countries with comma as a decimal separator, this makes it impossible to enter a valid amount since only decimal dot is allowed. This PR fixes this behavior by changing the decimal comma to decimal dot on input change.
[ch5719]