### PR TITLE
Footer affiliate links

### DIFF
--- a/common/v2/config/links.ts
+++ b/common/v2/config/links.ts
@@ -84,8 +84,12 @@ const affiliateLinks: IExtUrl[] = [
     url: 'https://shop.trezor.io/?offer_id=10&aff_id=1735' as TURL
   },
   {
-    name: 'ETHER_CARD_REFERRAL',
-    url: 'https://ether.cards/?utm_source=mycrypto&utm_medium=cpm&utm_campaign=site' as TURL
+    name: 'QUIKNODE_REFERRAL',
+    url: 'https://quiknode.io?tap_a=67226-09396e&tap_s=860550-6c3251' as TURL
+  },
+  {
+    name: 'UNSTOPPABLEDOMAINS_REFERRAL',
+    url: 'https://unstoppabledomains.com/r/a9d9ea4bc07e4fc' as TURL
   }
 ];
 

--- a/common/v2/config/links.ts
+++ b/common/v2/config/links.ts
@@ -89,7 +89,11 @@ const affiliateLinks: IExtUrl[] = [
   },
   {
     name: 'UNSTOPPABLEDOMAINS_REFERRAL',
-    url: 'https://unstoppabledomains.com/r/a9d9ea4bc07e4fc' as TURL
+    url: 'https://unstoppabledomains.com/r/mycrypto' as TURL
+  },
+  {
+    name: 'COINBASE_REFERRAL',
+    url: 'https://coinbase-consumer.sjv.io/RVmkN' as TURL
   }
 ];
 

--- a/common/v2/features/Layout/Footer/components/Linkset.tsx
+++ b/common/v2/features/Layout/Footer/components/Linkset.tsx
@@ -40,24 +40,29 @@ const LINK_COLUMNS = [
     heading: translateRaw('NEW_FOOTER_TEXT_11'),
     links: [
       {
-        title: 'Ledger',
+        title: 'Get a Ledger',
         link: EXT_URLS.LEDGER_REFERRAL.url,
         analytics_event: 'Ledger Wallet'
       },
       {
-        title: 'Trezor',
+        title: 'Get a Trezor',
         link: EXT_URLS.TREZOR_REFERRAL.url,
         analytics_event: 'TREZOR'
+      },
+      {
+        title: 'Get Quiknode',
+        link: EXT_URLS.QUIKNODE_REFERRAL.url,
+        analytics_event: 'Quiknode'
+      },
+      {
+        title: 'Buy ETH on Coinbase',
+        link: EXT_URLS.COINBASE_REFERRAL.url,
+        analytics_event: 'Coinbase'
       },
       {
         title: 'Unstoppable Domains',
         link: EXT_URLS.UNSTOPPABLEDOMAINS_REFERRAL.url,
         analytics_event: 'UnstoppableDomains'
-      },
-      {
-        title: 'Quiknode',
-        link: EXT_URLS.QUIKNODE_REFERRAL.url,
-        analytics_event: 'Quiknode'
       }
     ]
   },

--- a/common/v2/features/Layout/Footer/components/Linkset.tsx
+++ b/common/v2/features/Layout/Footer/components/Linkset.tsx
@@ -40,7 +40,7 @@ const LINK_COLUMNS = [
     heading: translateRaw('NEW_FOOTER_TEXT_11'),
     links: [
       {
-        title: 'Ledger Wallet',
+        title: 'Ledger',
         link: EXT_URLS.LEDGER_REFERRAL.url,
         analytics_event: 'Ledger Wallet'
       },
@@ -50,9 +50,14 @@ const LINK_COLUMNS = [
         analytics_event: 'TREZOR'
       },
       {
-        title: 'Ether.cards',
-        link: EXT_URLS.ETHER_CARD_REFERRAL.url,
-        analytics_event: 'ether.card'
+        title: 'Unstoppable Domains',
+        link: EXT_URLS.UNSTOPPABLEDOMAINS_REFERRAL.url,
+        analytics_event: 'UnstoppableDomains'
+      },
+      {
+        title: 'Quiknode',
+        link: EXT_URLS.QUIKNODE_REFERRAL.url,
+        analytics_event: 'Quiknode'
       }
     ]
   },


### PR DESCRIPTION
[CH5884]

## Description

* Removed EtherCards and added UnstoppableDomains and Quiknode ref links

<img width="818" alt="Screenshot 2020-04-24 at 17 49 08" src="https://user-images.githubusercontent.com/2313704/80237024-ea53f600-8653-11ea-910a-c7da740ad01a.png">

## Changes

* Added links for affiliate programs
* Remove ether.cards affiliate link

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
- [ ] If your code adds new text to the UI, the added text is [translatable](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributing---Translatable-strings)
