### PR TITLE
Added txType to analytics when account is added to LS

### DIFF
--- a/common/v2/services/ApiService/Analytics/constants.ts
+++ b/common/v2/services/ApiService/Analytics/constants.ts
@@ -22,7 +22,8 @@ export enum ANALYTICS_CATEGORIES {
   NOTIFICATION = 'Notification',
   SETTINGS = 'Settings',
   WALLET_BREAKDOWN = 'Wallet breakdown',
-  AD = 'Ad'
+  AD = 'Ad',
+  TX_HISTORY = 'Tx History'
 }
 
 /* Previous Params from 'develop'

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -56,7 +56,7 @@ export const AccountProvider: React.FC = ({ children }) => {
         'stage' in newTxWithoutNetwork &&
         [ITxStatus.SUCCESS, ITxStatus.FAILED].includes(newTxWithoutNetwork.stage)
       ) {
-        AnalyticsService.instance.track(ANALYTICS_CATEGORIES.AD, `Tx Made`, {
+        AnalyticsService.instance.track(ANALYTICS_CATEGORIES.TX_HISTORY, `Tx Made`, {
           txType: (newTxWithoutNetwork && newTxWithoutNetwork.txType) || ITxType.UNKNOWN,
           txStatus: newTxWithoutNetwork.stage
         });

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -11,12 +11,15 @@ import {
   Asset,
   AssetBalanceObject,
   LSKeys,
-  TUuid
+  TUuid,
+  ITxStatus,
+  ITxType
 } from 'v2/types';
 import { DataContext } from '../DataManager';
 import { SettingsContext } from '../Settings';
 import { getAccountByAddressAndNetworkName } from './helpers';
 import { getAllTokensBalancesOfAccount } from '../BalanceService';
+import { AnalyticsService, ANALYTICS_CATEGORIES } from 'v2/services/ApiService/Analytics';
 
 export interface IAccountContext {
   accounts: IAccount[];
@@ -48,6 +51,11 @@ export const AccountProvider: React.FC = ({ children }) => {
     updateAccount: (uuid, a) => model.update(uuid, a),
     addNewTransactionToAccount: (accountData, newTransaction) => {
       const { network, ...newTxWithoutNetwork } = newTransaction;
+      if ('stage' in newTxWithoutNetwork && newTxWithoutNetwork.stage === ITxStatus.SUCCESS) {
+        AnalyticsService.instance.track(ANALYTICS_CATEGORIES.AD, `Tx Made`, {
+          txType: (newTxWithoutNetwork && newTxWithoutNetwork.txType) || ITxType.UNKNOWN
+        });
+      }
       const newAccountData = {
         ...accountData,
         transactions: [

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -51,9 +51,13 @@ export const AccountProvider: React.FC = ({ children }) => {
     updateAccount: (uuid, a) => model.update(uuid, a),
     addNewTransactionToAccount: (accountData, newTransaction) => {
       const { network, ...newTxWithoutNetwork } = newTransaction;
-      if ('stage' in newTxWithoutNetwork && newTxWithoutNetwork.stage === ITxStatus.SUCCESS) {
+      if (
+        'stage' in newTxWithoutNetwork &&
+        [ITxStatus.SUCCESS, ITxStatus.FAILED].includes(newTxWithoutNetwork.stage)
+      ) {
         AnalyticsService.instance.track(ANALYTICS_CATEGORIES.AD, `Tx Made`, {
-          txType: (newTxWithoutNetwork && newTxWithoutNetwork.txType) || ITxType.UNKNOWN
+          txType: (newTxWithoutNetwork && newTxWithoutNetwork.txType) || ITxType.UNKNOWN,
+          txStatus: newTxWithoutNetwork.stage
         });
       }
       const newAccountData = {

--- a/common/v2/services/Store/Account/AccountProvider.tsx
+++ b/common/v2/services/Store/Account/AccountProvider.tsx
@@ -3,6 +3,8 @@ import unionBy from 'lodash/unionBy';
 import BigNumber from 'bignumber.js';
 import * as R from 'ramda';
 
+import { AnalyticsService, ANALYTICS_CATEGORIES } from 'v2/services/ApiService/Analytics';
+
 import {
   IRawAccount,
   IAccount,
@@ -19,7 +21,6 @@ import { DataContext } from '../DataManager';
 import { SettingsContext } from '../Settings';
 import { getAccountByAddressAndNetworkName } from './helpers';
 import { getAllTokensBalancesOfAccount } from '../BalanceService';
-import { AnalyticsService, ANALYTICS_CATEGORIES } from 'v2/services/ApiService/Analytics';
 
 export interface IAccountContext {
   accounts: IAccount[];

--- a/common/v2/types/transactionFlow.ts
+++ b/common/v2/types/transactionFlow.ts
@@ -101,6 +101,7 @@ export enum ITxStatus {
 }
 
 export enum ITxType {
+  UNKNOWN = 'UNKNOWN',
   STANDARD = 'STANDARD',
   SWAP = 'SWAP',
   DEFIZAP = 'DEFIZAP',


### PR DESCRIPTION
### Description
This allows us to record _only_ the type of tx (Standard, DefiZap, Swap, Contract Interaction, Contract Deploy, Membership Purchase, or Unknown if missing on the flow) being saved to account object so that we can know what features people are using MyCrypto for.