### PR TITLE
Remove unused dep jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "isomorphic-fetch": "2.2.1",
     "jest": "24.9.0",
     "jest-canvas-mock": "2.2.0",
-    "jquery": "3.4.1",
     "lint-staged": "9.5.0",
     "lodash-webpack-plugin": "0.11.5",
     "mini-css-extract-plugin": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11352,11 +11352,6 @@ jpeg-js@^0.3.4:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
   integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
 
-jquery@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 js-base64@^2.1.8:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"


### PR DESCRIPTION
Dependency bot asks us to update jquery. https://github.com/MyCryptoHQ/MyCrypto/pull/3232

Since it is listed under devDependencies and our tests still run after removal so I'm removing 