### PR TITLE
Resize AssetIcon

### DIFF
--- a/common/v2/components/AssetIcon.tsx
+++ b/common/v2/components/AssetIcon.tsx
@@ -22,7 +22,7 @@ function getIconUrl(uuid: TUuid, assetIconsManifest: CoinGeckoManifest) {
 
 const SImg = styled('img')`
   height: ${(p: { size: string }) => p.size};
-  width: auto;
+  width: ${(p: { size: string }) => p.size};
 `;
 
 interface Props {


### PR DESCRIPTION
### Description
Changes the width of AssetIcon to be the same as the height, to make the images square.

Old:
![image](https://user-images.githubusercontent.com/29407814/81514146-3ce31280-92e2-11ea-83e5-112831e6c9ba.png)

New:
![image](https://user-images.githubusercontent.com/29407814/81514150-42d8f380-92e2-11ea-9f1c-9b55fcdedc23.png)
