### PR TITLE
Remove base asset filtering on accounts update

### DIFF
--- a/src/services/Store/BalanceService.tsx
+++ b/src/services/Store/BalanceService.tsx
@@ -146,7 +146,9 @@ export const getAccountsAssetsBalances = async (accounts: StoreAccount[]) => {
     assets:
       (updatedAccount &&
         updatedAccount.assets &&
-        updatedAccount.assets.filter(({ balance }) => !filterZeroBN(balance))) ||
+        updatedAccount.assets.filter(
+          ({ balance, type }) => !filterZeroBN(balance) || type === 'base'
+        )) ||
       []
   }));
 


### PR DESCRIPTION
When I wanted to add funds to a Zap the app crashed because on account update we filtered out base asset if its balance was zero. (I had erc20 tokens but no ETH)

Fixed that by not filtering base asset which is essential on some flows.