### PR TITLE
Add tag on subscription

### DIFF
--- a/common/api/emails.ts
+++ b/common/api/emails.ts
@@ -8,6 +8,7 @@ export default function subscribeToMailingList(email: string) {
 
   return axios.post(url, {
     email_address: email,
-    status: 'subscribed'
+    status: 'subscribed',
+    tags: ['mycrypto.com']
   });
 }


### PR DESCRIPTION
This adds a tag when a user signs up using the form in the footer.