### PR TITLE
Run validation scripts in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-## WINDOWS-PREBUILD START ##
+  ## WINDOWS-PREBUILD START ##
   pre-build-and-build-windows:
     name: Build el:win
     runs-on: ${{ matrix.os }}
@@ -69,18 +69,15 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
-      - name: yarn tslint
-        run: yarn tslint
+      - name: yarn validate
+        run: yarn validate
 
-      - name: yarn tscheck
-        run: yarn tscheck
+      - name: yarn test:coverage
+        run: yarn test:coverage
 
-      - name: yarn test:coverage -- --maxWorkers=2
-        run: yarn test:coverage -- --maxWorkers=2
-
-##    NOT WORKING
-#     - name: yarn report-coverage
-#       run: yarn report-coverage
+      ##    NOT WORKING
+      #     - name: yarn report-coverage
+      #       run: yarn report-coverage
 
       - name: yarn build:electron:windows
         run: yarn build:electron:windows
@@ -95,74 +92,69 @@ jobs:
       - name: Save windows_${{ steps.version.outputs.VERSION }}_MyCrypto.exe to artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: "windows_${{ steps.version.outputs.VERSION }}_MyCrypto.exe"
-          path: "dist/electron-builds/MyCrypto Setup ${{ steps.version.outputs.VERSION }}.exe"
-# ## WINDOWS-PREBUILD END ##
+          name: 'windows_${{ steps.version.outputs.VERSION }}_MyCrypto.exe'
+          path: 'dist/electron-builds/MyCrypto Setup ${{ steps.version.outputs.VERSION }}.exe'
+  # ## WINDOWS-PREBUILD END ##
 
   pre-build:
     name: Pre-build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [
-          macOS-latest
-          # ubuntu-latest
-        ]
+        os: [macOS-latest]
+    # ubuntu-latest
     env:
       ELECTRON_CACHE: $HOME/.cache/electron
       ELECTRON_BUILDER_CACHE: $HOME/.cache/electron-builder
     steps:
-    - name: Retrieves project from the git branch
-      uses: actions/checkout@v1
+      - name: Retrieves project from the git branch
+        uses: actions/checkout@v1
 
-#     - name: Slack Notification
-#       if: matrix.os == 'ubuntu-latest'
-#       uses: rtCamp/action-slack-notify@master
-#       env:
-# #         SLACK_CHANNEL: general
-#         SLACK_COLOR: '#3278BD'
-# #         SLACK_ICON: https://github.com/rtCamp.png?size=48
-#         SLACK_MESSAGE: 'Post Content :rocket:'
-#         SLACK_TITLE: Post Title
-#         SLACK_USERNAME: rtCamp
-#         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      #     - name: Slack Notification
+      #       if: matrix.os == 'ubuntu-latest'
+      #       uses: rtCamp/action-slack-notify@master
+      #       env:
+      # #         SLACK_CHANNEL: general
+      #         SLACK_COLOR: '#3278BD'
+      # #         SLACK_ICON: https://github.com/rtCamp.png?size=48
+      #         SLACK_MESSAGE: 'Post Content :rocket:'
+      #         SLACK_TITLE: Post Title
+      #         SLACK_USERNAME: rtCamp
+      #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//' )"
-      id: nvm
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//' )"
+        id: nvm
 
-    - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - run: node --version; npm --version; yarn --version
+      - run: node --version; npm --version; yarn --version
 
-    - name: Cache node modules
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        ## Check cache based on yarn.lock hashfile
-        key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          ## Check cache based on yarn.lock hashfile
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
 
-    - name: Install Dependencies
-      ## If no cache is found, install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: yarn install
+      - name: Install Dependencies
+        ## If no cache is found, install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install
 
-    - name: yarn tslint
-      run: yarn tslint
+      - name: yarn validate
+        run: yarn validate
 
-    - name: yarn tscheck
-      run: yarn tscheck
+      - name: yarn test:coverage
+        run: yarn test:coverage
 
-    - name: yarn test:coverage -- --maxWorkers=2
-      run: yarn test:coverage -- --maxWorkers=2
-
-##    NOT WORKING
-#     - name: yarn report-coverage
-#       run: yarn report-coverage
+  ##    NOT WORKING
+  #     - name: yarn report-coverage
+  #       run: yarn report-coverage
 
   electron-osx:
     name: Build el:osx
@@ -177,51 +169,51 @@ jobs:
       ELECTRON_BUILDER_CACHE: $HOME/.cache/electron-builder
 
     steps:
-    - name: Retrieves project from the git branch
-      uses: actions/checkout@v1
+      - name: Retrieves project from the git branch
+        uses: actions/checkout@v1
 
-    - name: Retrieve node version from .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//')"
-      id: nvm
+      - name: Retrieve node version from .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//')"
+        id: nvm
 
-    - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - name: Cache node modules
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        ## Check cache based on yarn.lock hashfile
-        key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          ## Check cache based on yarn.lock hashfile
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
 
-    - name: Install Dependencies
-      ## If no cache is found, install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: yarn install
+      - name: Install Dependencies
+        ## If no cache is found, install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install
 
-    - name: yarn build:electron:osx
-      run: yarn build:electron:osx
+      - name: yarn build:electron:osx
+        run: yarn build:electron:osx
 
-    - name: ls -la dist/electron-builds
-      run: ls -la dist/electron-builds
+      - name: ls -la dist/electron-builds
+        run: ls -la dist/electron-builds
 
-    - name: Read app version
-      id: version
-      run:  echo "##[set-output name=VERSION;]$(cat package.json | grep -m1 version | sed 's/...version....//' | sed 's/.\{2\}$//')"
+      - name: Read app version
+        id: version
+        run: echo "##[set-output name=VERSION;]$(cat package.json | grep -m1 version | sed 's/...version....//' | sed 's/.\{2\}$//')"
 
-    - name: "Save standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip to artifacts"
-      uses: actions/upload-artifact@v1
-      with:
-        name: "standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip"
-        path: "dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}-mac.zip"
-    - name: "Save mac_${{ steps.version.outputs.VERSION }}_MyCrypto.dmg to artifacts"
-      uses: actions/upload-artifact@v1
-      with:
-        name: "mac_${{ steps.version.outputs.VERSION }}_MyCrypto.dmg"
-        path: "dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}.dmg"
+      - name: 'Save standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip to artifacts'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
+          path: 'dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}-mac.zip'
+      - name: 'Save mac_${{ steps.version.outputs.VERSION }}_MyCrypto.dmg to artifacts'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'mac_${{ steps.version.outputs.VERSION }}_MyCrypto.dmg'
+          path: 'dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}.dmg'
 
   electron-linux:
     name: Build el:linux
@@ -231,59 +223,58 @@ jobs:
     strategy:
       matrix:
         os: [
-          ## Uncomment to run linux build on macOS
-          macOS-latest
-          # ubuntu-latest
-        ]
+            ## Uncomment to run linux build on macOS
+            macOS-latest,
+          ]
+    # ubuntu-latest
     env:
       ELECTRON_CACHE: $HOME/.cache/electron
       ELECTRON_BUILDER_CACHE: $HOME/.cache/electron-builder
 
     steps:
-    - name: Retrieves project from the git branch
-      uses: actions/checkout@v1
+      - name: Retrieves project from the git branch
+        uses: actions/checkout@v1
 
-    - name: Retrieve node version from .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//')"
-      id: nvm
+      - name: Retrieve node version from .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat package.json | grep '\"node\":' | sed 's/^ *//;s/ *$//;s/\"node\":\ \"//;s/\",//')"
+        id: nvm
 
-    - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
-    - name: Cache node modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        ## Check cache based on yarn.lock hashfile
-        key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          ## Check cache based on yarn.lock hashfile
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
 
-    - name: Install Dependencies
-      ## If no cache is found, install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: yarn install
+      - name: Install Dependencies
+        ## If no cache is found, install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install
 
-    - name: yarn build:electron:linux
-      run: yarn build:electron:linux
+      - name: yarn build:electron:linux
+        run: yarn build:electron:linux
 
-    - name: ls -la dist/electron-builds
-      run: ls -la dist/electron-builds
+      - name: ls -la dist/electron-builds
+        run: ls -la dist/electron-builds
 
-    - name: Read app version
-      id: version
-      run:  echo "##[set-output name=VERSION;]$(cat package.json | grep -m1 version | sed 's/...version....//' | sed 's/.\{2\}$//')"
+      - name: Read app version
+        id: version
+        run: echo "##[set-output name=VERSION;]$(cat package.json | grep -m1 version | sed 's/...version....//' | sed 's/.\{2\}$//')"
 
-    - name: "Save linux-i386_${{ steps.version.outputs.VERSION }}_MyCrypto.AppImage to artifacts"
-      uses: actions/upload-artifact@v1
-      with:
-        name: "linux-i386_${{ steps.version.outputs.VERSION }}_MyCrypto.AppImage"
-        path: "dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}-i386.AppImage"
+      - name: 'Save linux-i386_${{ steps.version.outputs.VERSION }}_MyCrypto.AppImage to artifacts'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'linux-i386_${{ steps.version.outputs.VERSION }}_MyCrypto.AppImage'
+          path: 'dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}-i386.AppImage'
 
-    - name: "Save linus-x86-64_${{ steps.version.outputs.VERSION }}-MyCrypto.AppImage to artifacts"
-      uses: actions/upload-artifact@v1
-      with:
-        name: "linus-x86-64_${{ steps.version.outputs.VERSION }}-MyCrypto.AppImage"
-        path: "dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}.AppImage"
-
+      - name: 'Save linus-x86-64_${{ steps.version.outputs.VERSION }}-MyCrypto.AppImage to artifacts'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'linus-x86-64_${{ steps.version.outputs.VERSION }}-MyCrypto.AppImage'
+          path: 'dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}.AppImage'
 ##   TODO: Add "build electron:windows from Mac or Linux"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@mycrypto/unlock-scan": "0.1.0",
     "@unstoppabledomains/resolution": "1.3.5",
     "@walletconnect/browser": "1.0.0-beta.39",
-    "aes-js": "3.1.1",    
+    "aes-js": "3.1.1",
     "apollo-boost": "0.4.7",
     "axios": "0.18.1",
     "bignumber.js": "9.0.0",
@@ -223,9 +223,9 @@
     "build:electron:osx": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=osx node webpack_config/buildElectron.js",
     "build:electron:windows": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=windows node webpack_config/buildElectron.js",
     "build:electron:linux": "cross-env NODE_ENV=production BUILD_ELECTRON=true webpack --config webpack_config/electron.production.js && cross-env ELECTRON_OS=linux node webpack_config/buildElectron.js",
-    "test:coverage": "jest --config=jest_config/jest.config.json --coverage",
-    "test": "jest --config=jest_config/jest.config.json",
-    "test:single": "jest --config=jest_config/jest.config.json --coverage=false --watch",
+    "test": "jest --config=jest_config/jest.config.json --maxWorkers=2",
+    "test:coverage": "yarn test --coverage",
+    "test:single": "yarn test --coverage=false --watch",
     "report-coverage": " cat ./coverage/lcov.info | coveralls",
     "pretest": "check-node-version --package",
     "predev": "check-node-version --package",
@@ -236,7 +236,6 @@
     "dev:electron:renderer": "webpack-dev-server --config webpack_config/electron-renderer.development.js",
     "storybook": "start-storybook -p 3001 --ci",
     "build:storybook": "build-storybook",
-    "tslint": "tslint --project .",
     "tscheck": "tsc",
     "start": " yarn run dev",
     "serve": "ws -d dist/prod/ --spa index.html",
@@ -246,14 +245,16 @@
     "prettier:diff": "prettier --write --config ./.prettierrc --list-different \"src/**/*.ts\" \"src/**/*.tsx\"",
     "update:tokens": "parse-eth-tokens --networks all --output ./src/database/data/tokens --exclude 0x5a276Aeb77bCfDAc8Ac6f31BBC7416AE1A85eEF2,0x0027449Bf0887ca3E431D263FFDeFb244D95b555",
     "lint:css": "stylelint ./src/**/*.tsx",
+    "lint:ts": "tslint --project .",
     "node:scripts:tsc": "tsc --project tsconfig.scripts.json",
-    "translations:extract": "npm run node:scripts:tsc && node node-scripts/translations/translations-extract.js"
+    "translations:extract": "npm run node:scripts:tsc && node node-scripts/translations/translations-extract.js",
+    "validate": "npm-run-all --parallel lint:css lint:ts tscheck"
   },
   "lint-staged": {
     "!(node-scripts)/**/*.{ts,tsx}": [
       "prettier --write --config ./.prettierrc --config-precedence file-override",
       "yarn lint:css",
-      "yarn tslint",
+      "yarn lint:ts",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "mini-css-extract-plugin": "0.9.0",
     "nock": "11.7.2",
     "node-sass": "4.13.0",
+    "npm-run-all": "4.1.5",
     "parse-eth-tokens": "0.3.0",
     "prettier": "2.0.4",
     "raw-loader": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13843,7 +13843,7 @@ npm-packlist@^1.1.6:
     npm-bundled "^1.0.1"
     npm-normalize-package-bin "^1.0.1"
 
-npm-run-all@^4.1.5:
+npm-run-all@4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
   integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6953,7 +6953,7 @@ cross-env@6.0.3:
   dependencies:
     cross-spawn "^7.0.0"
 
-cross-spawn@6.0.5, cross-spawn@^6.0.0:
+cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -13025,6 +13025,11 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -13838,6 +13843,21 @@ npm-packlist@^1.1.6:
     npm-bundled "^1.0.1"
     npm-normalize-package-bin "^1.0.1"
 
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -14640,6 +14660,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -17348,7 +17373,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==


### PR DESCRIPTION
Following static test videos use npm-run-all to run linting and tsc in parallel.
28s for `yarn lint:css && yarn lint:ts && yarn tscheck` vs 18.14s for `npm-run-all lint:css lint:ts tscheck`