### PR TITLE
Stop assuming base asset is present

### DIFF
--- a/src/services/Store/utils.ts
+++ b/src/services/Store/utils.ts
@@ -2,9 +2,11 @@ import { bigNumberify, BigNumber } from 'ethers/utils';
 
 import { TAddress, NetworkId, Asset, StoreAccount } from '@types';
 
-// Every StoreAccount has a base asset and a balance
-const getAccountBaseBalance = (account: StoreAccount) =>
-  account.assets.find((as) => as.type === 'base')!.balance;
+// Assume StoreAccount baseAsset balance to be 0 if asset does not exist.
+const getAccountBaseBalance = (account: StoreAccount) => {
+  const baseAsset = account.assets.find((as) => as.type === 'base');
+  return baseAsset ? baseAsset.balance : bigNumberify(0);
+};
 
 const getAccountTokenBalance = (account: StoreAccount, token: Asset): BigNumber => {
   const erc20 = account.assets.find((as) => as.uuid === token.uuid);


### PR DESCRIPTION
### Description
Stops assuming that baseAsset is always present in an account. If it's not present, return balance of 0.