### PR TITLE
Ensure window.open is always called with noreferrer

### DIFF
--- a/src/components/NewAppReleaseModal.tsx
+++ b/src/components/NewAppReleaseModal.tsx
@@ -3,14 +3,14 @@ import { Panel, Button, Icon, Typography } from '@mycrypto/ui';
 import styled from 'styled-components';
 import semver from 'semver';
 
-import Modal from './Modal';
 import { BREAK_POINTS, COLORS } from '@theme';
+import { TURL } from '@types';
 import { GITHUB_RELEASE_NOTES_URL, OS, VERSION as currentVersion } from '@config';
-import { getFeaturedOS, useAnalytics } from '@utils';
+import { getFeaturedOS, useAnalytics, openLink } from '@utils';
 import { ANALYTICS_CATEGORIES, GithubService } from '@services/ApiService';
 import translate from '@translations';
 
-// Legacy
+import Modal from './Modal';
 import closeIcon from '@assets/images/icn-close.svg';
 import updateIcon from '@assets/images/icn-update.svg';
 import updateImportantIcon from '@assets/images/icn-important-update.svg';
@@ -161,8 +161,8 @@ const NewAppReleaseModal: FC<Props> = (props) => {
         const isCritical = name.toLowerCase().includes('[critical]');
         const newVersionUrl = releaseUrls[featuredOS];
         if (semver.lt(currentVersion, newVersion)) {
-          setState((preState) => ({
-            ...preState,
+          setState((prevState) => ({
+            ...prevState,
             isOpen: true,
             newVersion,
             newVersionUrl,
@@ -190,7 +190,7 @@ const NewAppReleaseModal: FC<Props> = (props) => {
   }, [state, trackNowRightNow]);
 
   const downloadRelease = useCallback(() => {
-    window.open(state.newVersionUrl, '_self');
+    openLink(state.newVersionUrl as TURL, '_self');
     trackGetNewVersion({
       eventParams: {
         current_version: currentVersion,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
-import { NetworkId } from '@types';
+import { NetworkId, TURL } from '@types';
 
 export const INFURA_API_KEY = 'c02fff6b5daa434d8422b8ece54c7286';
 
@@ -6,7 +6,7 @@ export const MYC_API_MAINNET = 'https://api.mycryptoapi.com/eth';
 
 export const DEFI_RESERVE_MAPPING_URL = 'https://defi.mycryptoapi.com';
 
-export const GITHUB_RELEASE_NOTES_URL = 'https://github.com/MyCryptoHQ/MyCrypto/releases/latest';
+export const GITHUB_RELEASE_NOTES_URL = 'https://github.com/MyCryptoHQ/MyCrypto/releases/latest' as TURL;
 
 // The URL for Token Info API requests.
 export const TOKEN_INFO_URL = 'https://api.mycryptoapi.com/tokens';

--- a/src/config/data.tsx
+++ b/src/config/data.tsx
@@ -1,5 +1,6 @@
 import React from 'react'; // For ANNOUNCEMENT_MESSAGE jsx
 
+import { TURL } from '@types';
 import { makeExplorer } from '@services/EthService/utils/makeExplorer';
 import packageJson from '../../package.json';
 import translate from '@translations';
@@ -49,7 +50,7 @@ export const gasEstimateCacheTime = 60000;
 export const MINIMUM_PASSWORD_LENGTH = 12;
 
 export const SUPPORT_EMAIL = 'support@mycrypto.com';
-export const LATEST_NEWS_URL = 'https://medium.com/@mycrypto';
+export const LATEST_NEWS_URL = 'https://medium.com/@mycrypto' as TURL;
 export const CRYPTOSCAMDB = 'https://cryptoscamdb.org';
 
 // Handler address will change if the trade contract changes.
@@ -61,7 +62,7 @@ export const DEX_BASE_URL = 'https://api-v2.dex.ag/';
 
 export const MOONPAY_PUBLIC_API_KEY = 'pk_live_Fi1kufUL8EflbE49vbZRKa71S2a4Y1D';
 export const MOONPAY_API_QUERYSTRING = `?apiKey=${MOONPAY_PUBLIC_API_KEY}&colorCode=%23163150`;
-export const BUY_MYCRYPTO_WEBSITE = 'https://buy.mycrypto.com';
+export const BUY_MYCRYPTO_WEBSITE = 'https://buy.mycrypto.com' as TURL;
 export const MOONPAY_SIGNER_API = 'https://moonpay.mycryptoapi.com/sign';
 
 export const LETS_ENCRYPT_URL = 'https://letsencrypt.org/';

--- a/src/config/helpArticles.ts
+++ b/src/config/helpArticles.ts
@@ -1,3 +1,5 @@
+import { TURL } from '@types';
+
 const KB_URL = 'https://support.mycrypto.com';
 
 export enum KB_HELP_ARTICLE {
@@ -28,4 +30,4 @@ export enum HELP_ARTICLE {
   LEDGER = 'https://support.ledger.com/hc/en-us/articles/360008268594'
 }
 
-export const getKBHelpArticle = (article: KB_HELP_ARTICLE) => `${KB_URL}/${article}`;
+export const getKBHelpArticle = (article: KB_HELP_ARTICLE) => `${KB_URL}/${article}` as TURL;

--- a/src/features/BuyAssets/BuyAssetsForm.tsx
+++ b/src/features/BuyAssets/BuyAssetsForm.tsx
@@ -7,8 +7,8 @@ import { useHistory } from 'react-router-dom';
 
 import translate, { translateRaw } from '@translations';
 import { SPACING, COLORS, FONT_SIZE } from '@theme';
-import { IAccount, StoreAccount, Asset } from '@types';
-import { ETHUUID, MOONPAY_ASSET_UUIDS } from '@utils';
+import { IAccount, StoreAccount, Asset, TURL } from '@types';
+import { ETHUUID, MOONPAY_ASSET_UUIDS, openLink } from '@utils';
 import { ROUTE_PATHS, MOONPAY_API_QUERYSTRING, BUY_MYCRYPTO_WEBSITE } from '@config';
 import { AccountDropdown, AssetDropdown, InlineMessage, ContentPanel } from '@components';
 import { isAccountInNetwork } from '@services/Store/Account/helpers';
@@ -92,14 +92,14 @@ export const BuyAssetsForm = () => {
           const redirectQueryParams = `?currencyCode=${values.asset.ticker}&walletAddress=${
             values.account.address
           }&signature=${encodeURIComponent(signature)}`;
-          window.open(`${BUY_MYCRYPTO_WEBSITE}${redirectQueryParams}`, '_blank');
+          openLink(`${BUY_MYCRYPTO_WEBSITE}${redirectQueryParams}` as TURL);
         })
         .catch((err) => {
           console.debug('err detected: ', err);
-          window.open(`${BUY_MYCRYPTO_WEBSITE}`, '_blank');
+          openLink(BUY_MYCRYPTO_WEBSITE);
         });
     } else {
-      window.open(`${BUY_MYCRYPTO_WEBSITE}`, '_blank');
+      openLink(BUY_MYCRYPTO_WEBSITE);
     }
   };
 

--- a/src/features/Dashboard/components/ActionTile.tsx
+++ b/src/features/Dashboard/components/ActionTile.tsx
@@ -3,8 +3,10 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
 import { Button, Typography } from '@mycrypto/ui';
 
-import { isUrl } from '@utils';
+import { isUrl, openLink } from '@utils';
 import { BREAK_POINTS, COLORS, FONT_SIZE, SPACING } from '@theme';
+import { TURL } from '@types';
+
 import { Action } from '../types';
 
 const SContainer = styled('div')`
@@ -96,10 +98,13 @@ const SDescription = styled('div')`
 
 type Props = RouteComponentProps<{}> & Action;
 function ActionTile({ icon, faded, title, description, link, history }: Props) {
-  const goToExternalLink = (url: string) => window.open(url, '_blank');
-  const goToAppRouter = (path: string) => history.push(path);
-
-  const action = isUrl(link) ? goToExternalLink : goToAppRouter;
+  const action = (dest: string | TURL) => {
+    if (isUrl(dest)) {
+      openLink(dest); // go to external url
+    } else {
+      history.push(dest); // go to app route
+    }
+  };
 
   return (
     <SContainer>

--- a/src/features/Dashboard/components/WalletBreakdown/NoAssets.tsx
+++ b/src/features/Dashboard/components/WalletBreakdown/NoAssets.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import translate from '@translations';
 import { ANALYTICS_CATEGORIES } from '@services';
 import { COLORS } from '@theme';
+import { BUY_MYCRYPTO_WEBSITE } from '@config';
+import { openLink } from '@utils';
 
 import addIcon from '@assets/images/icn-add-assets.svg';
 import useAnalytics from '@utils/useAnalytics';
@@ -49,10 +51,9 @@ const NoAssetsDescription = styled.div`
 `;
 
 const openLinkBuyMyCrypto = (trackCallback: ReturnType<typeof useAnalytics>) => {
-  const url = 'buy.mycrypto.com';
-  window.open(`https://${url}`, '_blank');
+  openLink(BUY_MYCRYPTO_WEBSITE);
   trackCallback({
-    actionName: `Link ${url} clicked`
+    actionName: `Link ${BUY_MYCRYPTO_WEBSITE} clicked`
   });
 };
 

--- a/src/features/Dashboard/types.ts
+++ b/src/features/Dashboard/types.ts
@@ -1,7 +1,8 @@
+import { TURL } from '@types';
 export interface Action {
   icon: string;
   faded?: boolean;
   title: string;
   description: string;
-  link: string;
+  link: string | TURL;
 }

--- a/src/features/DownloadApp/DownloadApp.tsx
+++ b/src/features/DownloadApp/DownloadApp.tsx
@@ -7,12 +7,11 @@ import styled from 'styled-components';
 import { ExtendedContentPanel } from '@components';
 import { ANALYTICS_CATEGORIES, GithubService } from '@services/ApiService';
 import { GITHUB_RELEASE_NOTES_URL, DOWNLOAD_MYCRYPTO_LINK, OS } from '@config';
-import { getFeaturedOS, useAnalytics } from '@utils';
-import { AppDownloadItem } from './types';
+import { getFeaturedOS, useAnalytics, openLink } from '@utils';
 import translate from '@translations';
-
-// Legacy
 import desktopAppIcon from '@assets/images/icn-desktop-app.svg';
+
+import { AppDownloadItem } from './types';
 
 const DownloadAppWrapper = styled.div`
   display: flex;
@@ -156,7 +155,7 @@ const DownloadApp: FC<RouteComponentProps> = ({ history }) => {
   const openDownloadLink = useCallback(
     (item: AppDownloadItem) => {
       const target = item.link === DEFAULT_LINK ? '_blank' : '_self';
-      window.open(item.link, target);
+      openLink(item.link, target);
 
       trackDownloadDesktop({
         actionName: `${item.name} download button clicked`

--- a/src/features/DownloadApp/types.ts
+++ b/src/features/DownloadApp/types.ts
@@ -1,5 +1,6 @@
+import { TURL } from '@types';
 export interface AppDownloadItem {
   OS: string;
   name: string;
-  link: string;
+  link: TURL;
 }

--- a/src/features/Home/components/DownloadAppPanel.tsx
+++ b/src/features/Home/components/DownloadAppPanel.tsx
@@ -6,11 +6,10 @@ import translate from '@translations';
 import { BREAK_POINTS } from '@theme';
 import { GITHUB_RELEASE_NOTES_URL as DEFAULT_LINK } from '@config';
 import { ANALYTICS_CATEGORIES } from '@services';
-import { openLink } from '@utils';
+import { openLink, useAnalytics } from '@utils';
 import { TURL } from '@types';
 
 import champagneIcon from '@assets/images/icn-champagne-2.svg';
-import { useAnalytics } from '@utils';
 
 const { SCREEN_SM, SCREEN_MD, SCREEN_XXL } = BREAK_POINTS;
 

--- a/src/features/Home/components/DownloadAppPanel.tsx
+++ b/src/features/Home/components/DownloadAppPanel.tsx
@@ -6,6 +6,8 @@ import translate from '@translations';
 import { BREAK_POINTS } from '@theme';
 import { GITHUB_RELEASE_NOTES_URL as DEFAULT_LINK } from '@config';
 import { ANALYTICS_CATEGORIES } from '@services';
+import { openLink } from '@utils';
+import { TURL } from '@types';
 
 import champagneIcon from '@assets/images/icn-champagne-2.svg';
 import { useAnalytics } from '@utils';
@@ -93,7 +95,7 @@ const Image = styled.img`
 
 interface Props {
   OSName: string;
-  downloadLink: string;
+  downloadLink: TURL;
 }
 
 export default function DownloadAppPanel({ OSName, downloadLink }: Props) {
@@ -122,7 +124,7 @@ export default function DownloadAppPanel({ OSName, downloadLink }: Props) {
   );
 }
 
-const openDownloadLink = (link: string) => {
+const openDownloadLink = (link: TURL) => {
   const target = link === DEFAULT_LINK ? '_blank' : '_self';
-  window.open(link, target);
+  openLink(link, target);
 };

--- a/src/features/Home/components/PeaceOfMindPanel.tsx
+++ b/src/features/Home/components/PeaceOfMindPanel.tsx
@@ -8,12 +8,11 @@ import { COLORS, BREAK_POINTS } from '@theme';
 import { GITHUB_RELEASE_NOTES_URL as DEFAULT_LINK } from '@config';
 import { ANALYTICS_CATEGORIES } from '@services';
 import { TURL } from '@types';
-import { openLink } from '@utils';
+import { openLink, useAnalytics } from '@utils';
 
 import vaultIcon from '@assets/images/icn-vault2.svg';
 import protectIcon from '@assets/images/icn-protect.svg';
 import openSourceIcon from '@assets/images/icn-opensource.svg';
-import { useAnalytics } from '@utils';
 
 const { SCREEN_SM, SCREEN_MD, SCREEN_XL, SCREEN_XXL } = BREAK_POINTS;
 const { GREYISH_BROWN } = COLORS;

--- a/src/features/Home/components/PeaceOfMindPanel.tsx
+++ b/src/features/Home/components/PeaceOfMindPanel.tsx
@@ -7,6 +7,8 @@ import translate from '@translations';
 import { COLORS, BREAK_POINTS } from '@theme';
 import { GITHUB_RELEASE_NOTES_URL as DEFAULT_LINK } from '@config';
 import { ANALYTICS_CATEGORIES } from '@services';
+import { TURL } from '@types';
+import { openLink } from '@utils';
 
 import vaultIcon from '@assets/images/icn-vault2.svg';
 import protectIcon from '@assets/images/icn-protect.svg';
@@ -168,7 +170,7 @@ const ContentItem: React.FC<ContentItemProps> = (props) => {
 };
 
 interface PeaceOfMindPanelProps {
-  downloadLink: string;
+  downloadLink: TURL;
 }
 
 export default function PeaceOfMindPanel(props: PeaceOfMindPanelProps) {
@@ -214,7 +216,7 @@ export default function PeaceOfMindPanel(props: PeaceOfMindPanelProps) {
   );
 }
 
-const openDownloadLink = (link: string) => {
+const openDownloadLink = (link: TURL) => {
   const target = link === DEFAULT_LINK ? '_blank' : '_self';
-  window.open(link, target);
+  openLink(link, target);
 };

--- a/src/features/Layout/Header/Header.tsx
+++ b/src/features/Layout/Header/Header.tsx
@@ -10,8 +10,8 @@ import { BREAK_POINTS, COLORS, MIN_CONTENT_PADDING } from '@theme';
 import { ANALYTICS_CATEGORIES, SettingsContext } from '@services';
 import { ROUTE_PATHS, LATEST_NEWS_URL, getKBHelpArticle, KB_HELP_ARTICLE } from '@config';
 import translate, { languages } from '@translations';
+import { openLink } from '@utils';
 
-// Legacy
 import logo from '@assets/images/logo-mycrypto.svg';
 import { ScreenLockContext } from '@features/ScreenLock/ScreenLockProvider';
 import { useAnalytics } from '@utils';
@@ -331,14 +331,14 @@ export function Header({ drawerVisible, toggleDrawerVisible, setDrawerScreen, hi
     trackHeader({
       actionName: 'Latest news clicked'
     });
-    window.open(LATEST_NEWS_URL, '_blank');
+    openLink(LATEST_NEWS_URL);
   };
 
   const openHelpSupportPage = (): void => {
     trackHeader({
       actionName: 'Help & Support clicked'
     });
-    window.open(getKBHelpArticle(KB_HELP_ARTICLE.HOME), '_blank');
+    openLink(getKBHelpArticle(KB_HELP_ARTICLE.HOME));
   };
 
   return (

--- a/src/features/Layout/Header/Header.tsx
+++ b/src/features/Layout/Header/Header.tsx
@@ -10,11 +10,10 @@ import { BREAK_POINTS, COLORS, MIN_CONTENT_PADDING } from '@theme';
 import { ANALYTICS_CATEGORIES, SettingsContext } from '@services';
 import { ROUTE_PATHS, LATEST_NEWS_URL, getKBHelpArticle, KB_HELP_ARTICLE } from '@config';
 import translate, { languages } from '@translations';
-import { openLink } from '@utils';
+import { openLink, useAnalytics } from '@utils';
 
 import logo from '@assets/images/logo-mycrypto.svg';
 import { ScreenLockContext } from '@features/ScreenLock/ScreenLockProvider';
-import { useAnalytics } from '@utils';
 
 const { BLUE_BRIGHT } = COLORS;
 

--- a/src/services/ApiService/Github/types.ts
+++ b/src/services/ApiService/Github/types.ts
@@ -1,5 +1,6 @@
+import { TURL } from '@types';
 export interface ReleaseURLs {
-  [key: string]: string;
+  [key: string]: TURL;
 }
 
 export interface ReleaseInfo {

--- a/src/utils/__tests__/openLink.spec.ts
+++ b/src/utils/__tests__/openLink.spec.ts
@@ -1,0 +1,32 @@
+import { openLink } from '@utils';
+import { TURL } from '@types';
+
+describe('opneLink', () => {
+  const { open } = window;
+  const url = 'https://example.com' as TURL;
+
+  beforeEach(() => {
+    delete window.open;
+    window.open = jest.fn();
+  });
+
+  afterEach(() => {
+    window.open = open;
+  });
+
+  it('calls window.open with _noreferrer', () => {
+    openLink(url);
+    expect(window.open).toBeCalledTimes(1);
+    expect(window.open).toBeCalledWith(url, '_blank', '_noreferrer');
+  });
+
+  it('sets the default target to _blank', () => {
+    openLink(url);
+    expect(window.open).toBeCalledWith(url, '_blank', '_noreferrer');
+  });
+
+  it('accepts a custom target', () => {
+    openLink(url, '_self');
+    expect(window.open).toBeCalledWith(url, '_self', '_noreferrer');
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -65,3 +65,4 @@ export { sanitizeDecimalSeparator } from './sanitizeDecimalSeparator';
 export { trimEllipsis } from './trimEllipsis';
 export * from './encryption';
 export { default as useAnalytics } from './useAnalytics';
+export { openLink } from './openLink';

--- a/src/utils/isUrl.ts
+++ b/src/utils/isUrl.ts
@@ -1,4 +1,6 @@
-export const isUrl = (url: string): boolean => {
+import { TURL } from '@types';
+
+export const isUrl = (url: string): url is TURL => {
   const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
   const localhostDomainRE = /^localhost[\:?\d]*(?:[^\:?\d]\S*)?$/;
   const nonLocalhostDomainRE = /^[^\s\.]+\.\S{2,}$/;

--- a/src/utils/openLink.ts
+++ b/src/utils/openLink.ts
@@ -1,0 +1,10 @@
+import { TURL } from '@types';
+
+/**
+ * @Security utility function for all 'window.open' calls
+ * so we are sure that '_noreferrer' is set for each call.
+ */
+
+export const openLink = (url: TURL, target = '_blank') => {
+  window.open(url, target, '_noreferrer');
+};


### PR DESCRIPTION
[ch6211]

- create and tests `openLink` utility to make sure `window.open` is always called with `noreferrer`.
- replace all `window.open` calls to use the utility
- update `isUrl` to also be a Typeguard.