### PR TITLE
Update CI to zip & save standalone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,11 +204,6 @@ jobs:
         id: version
         run: echo "##[set-output name=VERSION;]$(cat package.json | grep -m1 version | sed 's/...version....//' | sed 's/.\{2\}$//')"
 
-      - name: 'Save standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip to artifacts'
-        uses: actions/upload-artifact@v1
-        with:
-          name: 'standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
-          path: 'dist/electron-builds/MyCrypto-${{ steps.version.outputs.VERSION }}-mac.zip'
       - name: 'Save mac_${{ steps.version.outputs.VERSION }}_MyCrypto.dmg to artifacts'
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -35,6 +35,15 @@ jobs:
 
     - name: yarn build:downloadable
       run: yarn build:downloadable
+
+    - name: Zip Folder
+      run: zip -r dist/download/standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip dist/download/.
+
+    - name: 'Save standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip to artifacts'
+      uses: actions/upload-artifact@v1
+      with:
+        name: 'standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
+        path: 'dist/download/standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
     
     - name: yarn build:storybook
       if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request' 

--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -36,14 +36,14 @@ jobs:
     - name: yarn build:downloadable
       run: yarn build:downloadable
 
-    - name: Zip Folder
-      run: zip -r dist/download/standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip dist/download/.
+    - name: Zip standalone build folder
+      run: zip -r ./standalone_mycrypto.zip dist/download/
 
-    - name: 'Save standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip to artifacts'
+    - name: 'Save standalone_mycrypto.zip to artifacts'
       uses: actions/upload-artifact@v1
       with:
-        name: 'standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
-        path: 'dist/download/standalone_${{ steps.version.outputs.VERSION }}_MyCrypto.zip'
+        name: 'standalone_mycrypto.zip'
+        path: 'dist/download/standalone_mycrypto.zip'
     
     - name: yarn build:storybook
       if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request' 

--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -42,6 +42,7 @@ jobs:
     - name: 'Save standalone_mycrypto.zip to artifacts'
       uses: actions/upload-artifact@v1
       with:
+        name: 'standalone_mycrypto'
         path: 'dist/download/standalone_mycrypto.zip'
     
     - name: yarn build:storybook

--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -42,7 +42,6 @@ jobs:
     - name: 'Save standalone_mycrypto.zip to artifacts'
       uses: actions/upload-artifact@v1
       with:
-        name: 'standalone_mycrypto.zip'
         path: 'dist/download/standalone_mycrypto.zip'
     
     - name: yarn build:storybook

--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -37,7 +37,7 @@ jobs:
       run: yarn build:downloadable
 
     - name: Zip standalone build folder
-      run: zip -r ./standalone_mycrypto.zip dist/download/
+      run: zip -r dist/download/standalone_mycrypto.zip dist/download/
 
     - name: 'Save standalone_mycrypto.zip to artifacts'
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
### Description
Uploads the standalone `yarn build:downloadable` to artifacts so that people can download them. The previous standalone build was a zipped up mac electron build for some reason. This one uses `yarn build:downloadable`