### PR TITLE
Slightly change handling for acc balance lookups

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -42,3 +42,5 @@ export const EXCLUDED_ASSETS = [
   '1e917c91-e52b-5997-af67-2ffd01843701',
   '17da00cc-4901-5e04-87e0-f7e3cf9b382a'
 ];
+
+export const ETH_SCAN_BATCH_SIZE = 300;

--- a/src/services/RatesProvider.tsx
+++ b/src/services/RatesProvider.tsx
@@ -32,7 +32,7 @@ interface ReserveMappingListObject {
 }
 
 const DEFAULT_FIAT_RATE = 0;
-const POLLING_INTERVAL = 60000;
+const POLLING_INTERVAL = 90000;
 
 const ASSET_RATES_URL = 'https://api.coingecko.com/api/v3/simple/price';
 const buildAssetQueryUrl = (assets: string[], currencies: string[]) => `

--- a/src/services/Store/BalanceService.tsx
+++ b/src/services/Store/BalanceService.tsx
@@ -9,13 +9,11 @@ import { default as BN } from 'bignumber.js';
 import { bigNumberify } from 'ethers/utils';
 import { BigNumber as EthScanBN } from '@ethersproject/bignumber';
 
-import { ETHSCAN_NETWORKS } from '@config';
+import { ETHSCAN_NETWORKS, ETH_SCAN_BATCH_SIZE } from '@config';
 import { TAddress, StoreAccount, StoreAsset, Asset, Network, TBN } from '@types';
 import { ProviderHandler } from '@services/EthService';
 
 export type BalanceMap<T = BN> = EthScanBalanceMap<T>;
-
-const ETH_SCAN_BATCH_SIZE = 300;
 
 const getAssetAddresses = (assets: Asset[] = []): (string | undefined)[] => {
   return assets.map((a) => a.contractAddress).filter((a) => a);


### PR DESCRIPTION
### Description
Changes handling for acc balance lookups so that it better handles errors :3.

### What changed
Basically, it'll catch failed batch calls from ethscan and just feed back and empty object so that it doesn't fail out of the entire token scan from 1 failed lookup.

Also introduced the batch-size variable to limit size of lookups. This should decrease timeouts & errors but the tradeoff is it increases # of lookups.

Going to see what I can do to tweak load on our infra a little bit