### PR TITLE
Limit mycryptobuilds CI push handler to master branch

### DIFF
--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -12,7 +12,7 @@ on:
       - '*'
   push:
     branches:
-      - '*'
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
E2E needs a `mycryptobuilds` url to run against.
We use the PR number to reference the specific build.
Limit the `push` event to `master` branch. 