### PR TITLE
DPath Scanner: Generate Fresh Address

### DIFF
--- a/src/components/WalletUnlock/DeterministicAccountList.tsx
+++ b/src/components/WalletUnlock/DeterministicAccountList.tsx
@@ -43,7 +43,7 @@ export default function DeterministicAccountList(props: DeterministicAccountList
   const { finishedAccounts, asset, isComplete, onUnlock } = props;
   const [selectedAccounts, setSelectedAccounts] = useState([] as ISelectedAccount[]);
   const accountsToUse = uniqBy(prop('address'), finishedAccounts).filter(
-    ({ balance }) => balance && !balance.isZero()
+    ({ isFreshAddress, balance }) => (balance && !balance.isZero()) || isFreshAddress
   );
   const handleSubmit = () => {
     onUnlock(selectedAccounts);
@@ -81,6 +81,8 @@ export default function DeterministicAccountList(props: DeterministicAccountList
     <>
       <>
         {`Scanned Total: ${finishedAccounts.length}`}
+        <br />
+        {`isComplete: ${isComplete}`}
         <br />
         {!isComplete && (
           <>

--- a/src/components/WalletUnlock/Ledger.tsx
+++ b/src/components/WalletUnlock/Ledger.tsx
@@ -135,7 +135,11 @@ const LedgerDecrypt = ({ formData, onUnlock }: OwnProps) => {
           {`Test Generate Fresh Address`}
         </Button>
         {freshAddressIndex > DEFAULT_GAP_TO_SCAN_FOR && (
-          <p>{`You cant generate more than ${DEFAULT_GAP_TO_SCAN_FOR} fresh accounts for now.`}</p>
+          <p>
+            {translateRaw('DPATH_GENERATE_FRESH_ADDRESS_GAP_ERROR', {
+              $gap: DEFAULT_GAP_TO_SCAN_FOR.toString()
+            })}
+          </p>
         )}
         <br />
         <AssetDropdown

--- a/src/components/WalletUnlock/Ledger.tsx
+++ b/src/components/WalletUnlock/Ledger.tsx
@@ -10,14 +10,16 @@ import {
   EXT_URLS,
   LEDGER_DERIVATION_PATHS,
   DEFAULT_NUM_OF_ACCOUNTS_TO_SCAN,
-  DEFAULT_GAP_TO_SCAN_FOR
+  DEFAULT_GAP_TO_SCAN_FOR,
+  DPathsList
 } from '@config';
 import {
   NetworkContext,
   getNetworkById,
   getAssetByUUID,
   AssetContext,
-  useDeterministicWallet
+  useDeterministicWallet,
+  getDPaths
 } from '@services';
 
 import ledgerIcon from '@assets/images/icn-ledger-nano-large.svg';
@@ -32,23 +34,30 @@ interface OwnProps {
 // const WalletService = WalletFactory(WalletId.LEDGER_NANO_S);
 
 const LedgerDecrypt = ({ formData, onUnlock }: OwnProps) => {
-  const dpaths = uniqBy(prop('value'), LEDGER_DERIVATION_PATHS);
+  const { networks } = useContext(NetworkContext);
+  const { assets } = useContext(AssetContext);
+  const network = getNetworkById(formData.network, networks);
+  const dpaths = uniqBy(prop('value'), [
+    ...getDPaths([network], WalletId.LEDGER_NANO_S),
+    ...LEDGER_DERIVATION_PATHS
+  ]);
+  const defaultDPath = network.dPaths[WalletId.LEDGER_NANO_S] || DPathsList.ETH_LEDGER;
   const numOfAccountsToCheck = DEFAULT_NUM_OF_ACCOUNTS_TO_SCAN;
   const extendedDPaths = dpaths.map((dpath) => ({
     ...dpath,
     offset: 0,
     numOfAddresses: numOfAccountsToCheck
   }));
-  const { networks } = useContext(NetworkContext);
-  const { assets } = useContext(AssetContext);
-  const network = getNetworkById(formData.network, networks);
   const baseAsset = getAssetByUUID(assets)(network.baseAsset) as ExtendedAsset;
   const [assetToUse, setAssetToUse] = useState(baseAsset);
-  const { state, requestConnection, updateAsset, addDPaths } = useDeterministicWallet(
-    extendedDPaths,
-    WalletId.LEDGER_NANO_S_NEW,
-    DEFAULT_GAP_TO_SCAN_FOR
-  );
+  const {
+    state,
+    requestConnection,
+    updateAsset,
+    addDPaths,
+    generateFreshAddress
+  } = useDeterministicWallet(extendedDPaths, WalletId.LEDGER_NANO_S_NEW, DEFAULT_GAP_TO_SCAN_FOR);
+  const [freshAddressIndex, setFreshAddressIndex] = useState(0);
   // @todo -> Figure out which assets to display in dropdown. Dropdown is heavy with 900+ assets in it. Loads slow af.
   const filteredAssets = assets.filter(({ uuid }) => MOONPAY_ASSET_UUIDS.includes(uuid)); // @todo - fix this.
 
@@ -78,6 +87,20 @@ const LedgerDecrypt = ({ formData, onUnlock }: OwnProps) => {
     ]);
   };
 
+  const handleFreshAddressGeneration = () => {
+    if (freshAddressIndex > DEFAULT_GAP_TO_SCAN_FOR) {
+      return;
+    }
+    const freshAddressGenerationSuccess = generateFreshAddress({
+      ...defaultDPath,
+      offset: freshAddressIndex,
+      numOfAddresses: 1
+    });
+    if (freshAddressGenerationSuccess) {
+      setFreshAddressIndex(freshAddressIndex + 1);
+    }
+  };
+
   if (!network) {
     // @todo: make this better.
     return <UnsupportedNetwork walletType={translateRaw('x_Ledger')} network={network} />;
@@ -104,6 +127,17 @@ const LedgerDecrypt = ({ formData, onUnlock }: OwnProps) => {
         <Button onClick={() => handleDPathAddition()}>
           {`Test Add Custom Derivation Path: ${testDPathAddition.value} - ${testDPathAddition.label} `}
         </Button>
+        <br />
+        <Button
+          disabled={!state.completed || freshAddressIndex > DEFAULT_GAP_TO_SCAN_FOR}
+          onClick={() => handleFreshAddressGeneration()}
+        >
+          {`Test Generate Fresh Address`}
+        </Button>
+        {freshAddressIndex > DEFAULT_GAP_TO_SCAN_FOR && (
+          <p>{`You cant generate more than ${DEFAULT_GAP_TO_SCAN_FOR} fresh accounts for now.`}</p>
+        )}
+        <br />
         <AssetDropdown
           selectedAsset={assetToUse}
           assets={filteredAssets}

--- a/src/services/WalletService/deterministic/DeterministicWalletService.tsx
+++ b/src/services/WalletService/deterministic/DeterministicWalletService.tsx
@@ -10,10 +10,14 @@ import {
 } from '@services/Store/BalanceService';
 import { bigify } from '@utils';
 
+import { LedgerUSB, Wallet, getDeterministicWallets } from '..';
 import { LedgerU2F, Trezor, MnemonicPhrase, WalletResult } from '../wallets';
 import { KeyInfo } from '../wallets/HardwareWallet';
-import { LedgerUSB, Wallet, getDeterministicWallets } from '..';
 import { IDeterministicWalletService, DWAccountDisplay, ExtendedDPath } from './types';
+
+interface IPrefetchBundle {
+  [key: string]: KeyInfo;
+}
 
 interface EventHandlers {
   handleInit(session: Wallet, asset: ExtendedAsset): void;
@@ -72,10 +76,6 @@ export const DeterministicWalletService = ({
   const triggerComplete = () => {
     handleComplete();
   };
-
-  interface IPrefetchBundle {
-    [key: string]: KeyInfo;
-  }
 
   const getAccounts = async (session: Wallet, dpaths: ExtendedDPath[]) => {
     if (session.prefetch) {

--- a/src/services/WalletService/deterministic/__snapshots__/helpers.test.ts.snap
+++ b/src/services/WalletService/deterministic/__snapshots__/helpers.test.ts.snap
@@ -1,0 +1,907 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deterministic wallets helpers - findFinishedZeroBalanceAccounts returns first account display item with 0 balance 1`] = `
+Array [
+  Object {
+    "address": "0xDDd23cdC6474751C217F625033bDa2AB72A49244",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 0,
+      "path": "m/44'/60'/160720'/0'/0",
+    },
+  },
+  Object {
+    "address": "0x91DD690A5A87aAEd42B20826Cd442A0f371502d6",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 0,
+      "path": "m/44'/1'/0'/0/0",
+    },
+  },
+  Object {
+    "address": "0x73C4Ed979C3918D682E9CD7E80DFF3709E5f6d0c",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 1,
+      "path": "m/44'/60'/0'/0/1",
+    },
+  },
+  Object {
+    "address": "0x09F6f9916F2677f790Dd2288a163aEe05b7bD7E9",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 1,
+      "path": "m/44'/60'/160720'/0'/1",
+    },
+  },
+  Object {
+    "address": "0xBf6a683aF641AD7E939166dd2BE9A904F9721496",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 1,
+      "path": "m/44'/1'/0'/0/1",
+    },
+  },
+  Object {
+    "address": "0xf63f66c71e1Afd220Ad768c9d7Cd96d7F69B5998",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 2,
+      "path": "m/44'/60'/0'/0/2",
+    },
+  },
+  Object {
+    "address": "0x04725bF6D10046C9b6C7F6f60A52c966efD06b56",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 2,
+      "path": "m/44'/60'/0'/2",
+    },
+  },
+  Object {
+    "address": "0x1F7108949B12efD73Fd3F31EB66f319d2FF0a48D",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 2,
+      "path": "m/44'/60'/160720'/0'/2",
+    },
+  },
+  Object {
+    "address": "0x2D70Fbc9e12f8c0a361AB8dAA053f27B0420AbBe",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 2,
+      "path": "m/44'/1'/0'/0/2",
+    },
+  },
+  Object {
+    "address": "0x86Efe81CE7B56b3134d35f2c93D8cb6fFb10157f",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 3,
+      "path": "m/44'/60'/0'/0/3",
+    },
+  },
+  Object {
+    "address": "0xdD344f9BB3dfD7A4928361356f625be3a1Fd6876",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 3,
+      "path": "m/44'/60'/160720'/0'/3",
+    },
+  },
+  Object {
+    "address": "0x20a858b9249cc929d46DCDF7eaC6fd9bff9a5825",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 3,
+      "path": "m/44'/1'/0'/0/3",
+    },
+  },
+  Object {
+    "address": "0xe333E5697aF7e2Bf6c311307cdFb309C04F6A929",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x7e061Ac5099de7Df87E2773c0439C92a554f843C",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/160720'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x97c79DE11B0220c1d9F2Be401273AEB61F032b82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/1'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0xe333E5697aF7e2Bf6c311307cdFb309C04F6A929",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x7e061Ac5099de7Df87E2773c0439C92a554f843C",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/160720'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x97c79DE11B0220c1d9F2Be401273AEB61F032b82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/1'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x7172D60F40E309e9027C80Ec0D6aFEC470820072",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 5,
+      "path": "m/44'/60'/0'/0/5",
+    },
+  },
+  Object {
+    "address": "0xFDE49f07d985c2EbDf77D573e5FA8A579c37aA10",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 5,
+      "path": "m/44'/60'/160720'/0'/5",
+    },
+  },
+  Object {
+    "address": "0x9b19985D94e7dE8bd4cD2D2584dF8FCd284303Ca",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 5,
+      "path": "m/44'/1'/0'/0/5",
+    },
+  },
+  Object {
+    "address": "0x92060Cfedfeddb31Bf81e6078A854259cF7328eEc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 9,
+      "path": "m/44'/60'/0'/9",
+    },
+  },
+  Object {
+    "address": "0x92060Cfedfeddb31Bf81e6078A854259cF7328eEc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 9,
+      "path": "m/44'/60'/0'/9",
+    },
+  },
+  Object {
+    "address": "0x8D73d070FF18Ea7be141449566372c2197680d54",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 10,
+      "path": "m/44'/60'/0'/10",
+    },
+  },
+  Object {
+    "address": "0x60661C489061Bc191393654B214b27F3EB44f9Bc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 11,
+      "path": "m/44'/60'/0'/11",
+    },
+  },
+  Object {
+    "address": "0x6bA9E98E60f46118CEa276c02fde4713f1b90D82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 12,
+      "path": "m/44'/60'/0'/12",
+    },
+  },
+  Object {
+    "address": "0x456a8DB471b7006359FF57CF1257Fbb73A2F7760",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 13,
+      "path": "m/44'/60'/0'/13",
+    },
+  },
+]
+`;
+
+exports[`deterministic wallets helpers - sortAccountDisplayItems sorts account display items correctly based on index 1`] = `
+Array [
+  Object {
+    "address": "0x298Fe5fDca148135442fa7fA3C24042F038D3B5a",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 0,
+      "path": "m/44'/60'/0'/0/0",
+    },
+  },
+  Object {
+    "address": "0xb2bb2b958AFa2e96dab3f3Ce7162b87daEa39017",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 0,
+      "path": "m/44'/60'/0'/0",
+    },
+  },
+  Object {
+    "address": "0xDDd23cdC6474751C217F625033bDa2AB72A49244",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 0,
+      "path": "m/44'/60'/160720'/0'/0",
+    },
+  },
+  Object {
+    "address": "0x91DD690A5A87aAEd42B20826Cd442A0f371502d6",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 0,
+      "path": "m/44'/1'/0'/0/0",
+    },
+  },
+  Object {
+    "address": "0x73C4Ed979C3918D682E9CD7E80DFF3709E5f6d0c",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 1,
+      "path": "m/44'/60'/0'/0/1",
+    },
+  },
+  Object {
+    "address": "0x8d84C8E14Ee8B755419F6764985437905eB6176E",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 1,
+      "path": "m/44'/60'/0'/1",
+    },
+  },
+  Object {
+    "address": "0x09F6f9916F2677f790Dd2288a163aEe05b7bD7E9",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 1,
+      "path": "m/44'/60'/160720'/0'/1",
+    },
+  },
+  Object {
+    "address": "0xBf6a683aF641AD7E939166dd2BE9A904F9721496",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 1,
+      "path": "m/44'/1'/0'/0/1",
+    },
+  },
+  Object {
+    "address": "0xf63f66c71e1Afd220Ad768c9d7Cd96d7F69B5998",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 2,
+      "path": "m/44'/60'/0'/0/2",
+    },
+  },
+  Object {
+    "address": "0x04725bF6D10046C9b6C7F6f60A52c966efD06b56",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 2,
+      "path": "m/44'/60'/0'/2",
+    },
+  },
+  Object {
+    "address": "0x1F7108949B12efD73Fd3F31EB66f319d2FF0a48D",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 2,
+      "path": "m/44'/60'/160720'/0'/2",
+    },
+  },
+  Object {
+    "address": "0x2D70Fbc9e12f8c0a361AB8dAA053f27B0420AbBe",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 2,
+      "path": "m/44'/1'/0'/0/2",
+    },
+  },
+  Object {
+    "address": "0x86Efe81CE7B56b3134d35f2c93D8cb6fFb10157f",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 3,
+      "path": "m/44'/60'/0'/0/3",
+    },
+  },
+  Object {
+    "address": "0xB7CBC4e1979E3F42cBb603E837b0af5547AF5EC4",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 3,
+      "path": "m/44'/60'/0'/3",
+    },
+  },
+  Object {
+    "address": "0xdD344f9BB3dfD7A4928361356f625be3a1Fd6876",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 3,
+      "path": "m/44'/60'/160720'/0'/3",
+    },
+  },
+  Object {
+    "address": "0x20a858b9249cc929d46DCDF7eaC6fd9bff9a5825",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 3,
+      "path": "m/44'/1'/0'/0/3",
+    },
+  },
+  Object {
+    "address": "0xe333E5697aF7e2Bf6c311307cdFb309C04F6A929",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x255b2b3A1234561D4f32D0ED4a012b73fc32C08a",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x7e061Ac5099de7Df87E2773c0439C92a554f843C",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/160720'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x97c79DE11B0220c1d9F2Be401273AEB61F032b82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 5,
+        "offset": 0,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/1'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0xe333E5697aF7e2Bf6c311307cdFb309C04F6A929",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x255b2b3A1234561D4f32D0ED4a012b73fc32C08a",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x7e061Ac5099de7Df87E2773c0439C92a554f843C",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 4,
+      "path": "m/44'/60'/160720'/0'/4",
+    },
+  },
+  Object {
+    "address": "0x97c79DE11B0220c1d9F2Be401273AEB61F032b82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 4,
+      "path": "m/44'/1'/0'/0/4",
+    },
+  },
+  Object {
+    "address": "0x7172D60F40E309e9027C80Ec0D6aFEC470820072",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Default (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/0'/0",
+      },
+      "index": 5,
+      "path": "m/44'/60'/0'/0/5",
+    },
+  },
+  Object {
+    "address": "0xd60Fb617f1A7d0Ae7F7a1231d5350B9029471aE2",
+    "balance": "15557790000000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 5,
+      "path": "m/44'/60'/0'/5",
+    },
+  },
+  Object {
+    "address": "0xFDE49f07d985c2EbDf77D573e5FA8A579c37aA10",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETC)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/60'/160720'/0'",
+      },
+      "index": 5,
+      "path": "m/44'/60'/160720'/0'/5",
+    },
+  },
+  Object {
+    "address": "0x9b19985D94e7dE8bd4cD2D2584dF8FCd284303Ca",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Testnet (ETH)",
+        "numOfAddresses": 2,
+        "offset": 4,
+        "value": "m/44'/1'/0'/0",
+      },
+      "index": 5,
+      "path": "m/44'/1'/0'/0/5",
+    },
+  },
+  Object {
+    "address": "0x28be4A0Adddd4cf084Fa7132FaE061e1CC225436",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 6,
+      "path": "m/44'/60'/0'/6",
+    },
+  },
+  Object {
+    "address": "0xba34a49E3B03a58832bc4d2ba1DF8000b1301e93",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 7,
+      "path": "m/44'/60'/0'/7",
+    },
+  },
+  Object {
+    "address": "0x87DC0cddd4495Aa854BcA2521691c3DFb0f1396c",
+    "balance": "1000000",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 8,
+      "path": "m/44'/60'/0'/8",
+    },
+  },
+  Object {
+    "address": "0x92060Cfedfeddb31Bf81e6078A854259cF7328eEc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 6,
+        "offset": 4,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 9,
+      "path": "m/44'/60'/0'/9",
+    },
+  },
+  Object {
+    "address": "0x92060Cfedfeddb31Bf81e6078A854259cF7328eEc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 9,
+      "path": "m/44'/60'/0'/9",
+    },
+  },
+  Object {
+    "address": "0x8D73d070FF18Ea7be141449566372c2197680d54",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 10,
+      "path": "m/44'/60'/0'/10",
+    },
+  },
+  Object {
+    "address": "0x60661C489061Bc191393654B214b27F3EB44f9Bc",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 11,
+      "path": "m/44'/60'/0'/11",
+    },
+  },
+  Object {
+    "address": "0x6bA9E98E60f46118CEa276c02fde4713f1b90D82",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 12,
+      "path": "m/44'/60'/0'/12",
+    },
+  },
+  Object {
+    "address": "0x456a8DB471b7006359FF57CF1257Fbb73A2F7760",
+    "balance": "0",
+    "pathItem": Object {
+      "baseDPath": Object {
+        "label": "Ledger (ETH)",
+        "numOfAddresses": 5,
+        "offset": 9,
+        "value": "m/44'/60'/0'",
+      },
+      "index": 13,
+      "path": "m/44'/60'/0'/13",
+    },
+  },
+]
+`;

--- a/src/services/WalletService/deterministic/helpers.test.ts
+++ b/src/services/WalletService/deterministic/helpers.test.ts
@@ -4,7 +4,11 @@ import { clone } from 'ramda';
 import { TAddress } from '@types';
 
 import { fixtures } from './__mocks__';
-import { processFinishedAccounts as process } from './helpers';
+import {
+  processFinishedAccounts as process,
+  sortAccountDisplayItems,
+  findFinishedZeroBalanceAccounts
+} from './helpers';
 import { DWAccountDisplay } from './types';
 
 interface TInputToSerialize {
@@ -55,5 +59,19 @@ describe('deterministic wallets helpers - processFinishedAccounts', () => {
       GAP_TO_USE
     );
     expect(output).toStrictEqual(fixtures.processFinishedAccountsCustomDPathsPending);
+  });
+});
+
+describe('deterministic wallets helpers - sortAccountDisplayItems', () => {
+  it('sorts account display items correctly based on index', () => {
+    const outputArr = sortAccountDisplayItems(fixtures.finishedAccountsDone);
+    expect(outputArr).toMatchSnapshot();
+  });
+});
+
+describe('deterministic wallets helpers - findFinishedZeroBalanceAccounts', () => {
+  it('returns first account display item with 0 balance', () => {
+    const outputArr = findFinishedZeroBalanceAccounts(fixtures.finishedAccountsDone);
+    expect(outputArr).toMatchSnapshot();
   });
 });

--- a/src/services/WalletService/deterministic/helpers.ts
+++ b/src/services/WalletService/deterministic/helpers.ts
@@ -1,4 +1,5 @@
 import { DWAccountDisplay, ExtendedDPath } from './types';
+import { bigify } from '@utils/bigify';
 
 export const processFinishedAccounts = (
   finishedAccounts: DWAccountDisplay[],
@@ -40,4 +41,14 @@ export const processFinishedAccounts = (
   );
 
   return { newGapItems: addNewItems, customDPathItems: customDPathsDetected };
+};
+
+export const sortAccountDisplayItems = (accounts: DWAccountDisplay[]): DWAccountDisplay[] =>
+  accounts.sort((a, b) => a.pathItem.index - b.pathItem.index);
+
+export const findFinishedZeroBalanceAccounts = (
+  accounts: DWAccountDisplay[]
+): DWAccountDisplay[] => {
+  const sortedAccounts = sortAccountDisplayItems(accounts);
+  return sortedAccounts.filter(({ balance }) => balance && bigify(balance.toString()).isZero());
 };

--- a/src/services/WalletService/deterministic/reducer.ts
+++ b/src/services/WalletService/deterministic/reducer.ts
@@ -3,6 +3,7 @@ import { ValuesType, Overwrite } from 'utility-types';
 import { TAction } from '@types';
 
 import { DeterministicWalletState, TDWActionError } from './types';
+import { isSameAddress } from '@utils';
 
 export enum DWActionTypes {
   CONNECTION_REQUEST = 'CONNECTION_REQUEST',
@@ -16,7 +17,8 @@ export enum DWActionTypes {
   UPDATE_ASSET = 'UPDATE_ASSET',
   RELOAD_QUEUES = 'RELOAD_QUEUES',
   TRIGGER_COMPLETE = 'TRIGGER_COMPLETE',
-  ADD_CUSTOM_DPATHS = 'ADD_CUSTOM_DPATHS'
+  ADD_CUSTOM_DPATHS = 'ADD_CUSTOM_DPATHS',
+  DESIGNATE_FRESH_ADDRESS = 'DESIGNATE_FRESH_ADDRESS'
 }
 
 // @todo convert to FSA compatible action type
@@ -132,6 +134,18 @@ const DeterministicWalletReducer = (
         ...state,
         completed: false,
         customDPaths: [...state.customDPaths, ...dpaths]
+      };
+    }
+    case DWActionTypes.DESIGNATE_FRESH_ADDRESS: {
+      const { address } = payload;
+      const newFinishedAccounts = state.finishedAccounts.map((finishedAccount) => {
+        return isSameAddress(finishedAccount.address, address)
+          ? { ...finishedAccount, isFreshAddress: true }
+          : { ...finishedAccount };
+      });
+      return {
+        ...state,
+        finishedAccounts: newFinishedAccounts
       };
     }
     case DWActionTypes.TRIGGER_COMPLETE: {

--- a/src/services/WalletService/deterministic/types.ts
+++ b/src/services/WalletService/deterministic/types.ts
@@ -16,6 +16,7 @@ export interface DWAccountDisplay {
     index: number;
   };
   balance: BigNumber | undefined;
+  isFreshAddress?: boolean;
 }
 
 export interface ExtendedDPath extends DPath {
@@ -49,6 +50,7 @@ export interface IUseDeterministicWallet {
   ): void;
   updateAsset(asset: ExtendedAsset): void;
   addDPaths(dpaths: ExtendedDPath[]): void;
+  generateFreshAddress(defaultDPath: ExtendedDPath): boolean;
 }
 
 export interface IDeterministicWalletService {

--- a/src/translations/lang/en.json
+++ b/src/translations/lang/en.json
@@ -1005,6 +1005,7 @@
     "ERROR_TRANSACTION_FEE_USE_LOWER": "Please note the transaction fee of $fee. It's recommended to use a lower transaction fee unless you need this transaction to be confirmed swiftly.",
     "PROTECTED_TX_TIMELINE_TAGS": "The labels for this address are: $tags",
     "WARNING_TRANSACTION_FEE": "The transaction fee of $fee seems to be greater than the amount you are sending ($amount). It's recommended to use a lower transaction fee unless you need this transaction to be confirmed swiftly.",
-    "POWERED_BY": "Powered By"
+    "POWERED_BY": "Powered By",
+    "DPATH_GENERATE_FRESH_ADDRESS_GAP_ERROR": "You cant generate more than $gap fresh accounts. Add some assets to the existing fresh addresses to open up more!"
   }
 }


### PR DESCRIPTION
[ch5950]

### Description
Allows a user to generate fresh addresses using their ledger device (logic can be used across all HD wallet account types).

_Note: For now, it's limited up to an amount of `DEFAULT_GAP_TO_SCAN` which is currently set to 5. There are 2 reasons for this:_
_1) It allows us to not have to check new dpaths to generate the address and fetch it's balance (since the address/balance will already be in the useDeterministicWallet state)._
_2) It allows us to somewhat cap the number of empty addresses users add to their dashboard (which should help to cap infrastructure overhead)._