### PR TITLE
Use declarative injection of jest-dom/extend-expect

### DIFF
--- a/jest_config/jest.config.json
+++ b/jest_config/jest.config.json
@@ -20,6 +20,7 @@
     "<rootDir>/jest_config/__mocks__/localStorage.ts",
     "jest-canvas-mock"
   ],
+  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
   "automock": false,
   "collectCoverage": true
 }

--- a/jest_config/test-utils.ts
+++ b/jest_config/test-utils.ts
@@ -1,7 +1,6 @@
 // Setup react-testing-library
 // https://testing-library.com/docs/react-testing-library/setup#custom-render
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { noOp } from '@utils';
 
 // Mock features used by react-slider


### PR DESCRIPTION
Following [course video](https://mycrypto.atlassian.net/wiki/spaces/TS/pages/553910303/Configure+Jest+for+Testing+JavaScript+Applications#Support-a-Test-Utilities-File-with-Jest-moduleDirectories-10%3A57) use `jest.config.json` file to inject `extend-expect` 