### PR TITLE
Disable dependency caching on Windows CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,18 @@ jobs:
       - name: Work around for Windows Server 2019
         run: set path=%path%;'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin'
 
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          ## Check cache based on yarn.lock hashfile
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+      # DISABLED FOR NOW BECAUSE IT WAS BEING UNSTABLE
+      #- name: Cache node modules
+      #  id: cache
+      #  uses: actions/cache@v2
+      #  with:
+      #    path: node_modules
+      ## Check cache based on yarn.lock hashfile
+      #    key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
         ## If no cache is found, install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        ##if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
       - name: yarn validate


### PR DESCRIPTION
To see if it works without since it seems to be unstable and causing issues