### PR TITLE
Make jest ignore dist directory

### DIFF
--- a/jest_config/jest.config.json
+++ b/jest_config/jest.config.json
@@ -4,7 +4,7 @@
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleDirectories": ["node_modules", "src"],
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "worker.ts", "worker.tsx"],
-  "modulePathIgnorePatterns": ["<rootDir>/dist"],
+  "modulePathIgnorePatterns": ["<rootDir>/dist", "<rootDir>/src/types", "<rootDir>/src/assets"],
   "moduleNameMapper": {
     "shared/(.*)": "<rootDir>/shared/$1",
     "test-utils": "<rootDir>/jest_config/test-utils",
@@ -14,7 +14,12 @@
     "\\.worker.(ts|tsx)": "<rootDir>/jest_config/__mocks__/workerMock.js",
     "^@(.+)$": ["<rootDir>/node_modules/$0", "<rootDir>/src/$1"]
   },
-  "testPathIgnorePatterns": ["/node_modules/", "<rootDir>/dist", "<rootDir>/__tests__"],
+  "testPathIgnorePatterns": [
+    "/node_modules/",
+    "<rootDir>/dist",
+    "<rootDir>/__tests__",
+    "/*\\.(stories)/"
+  ],
   "coveragePathIgnorePatterns": ["/node_modules/", "/containers/", "/vendor/", "/spec/"],
   "setupFiles": [
     "<rootDir>/jest_config/setupJest.js",

--- a/jest_config/jest.config.json
+++ b/jest_config/jest.config.json
@@ -4,6 +4,7 @@
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleDirectories": ["node_modules", "src"],
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "worker.ts", "worker.tsx"],
+  "modulePathIgnorePatterns": ["<rootDir>/dist"],
   "moduleNameMapper": {
     "shared/(.*)": "<rootDir>/shared/$1",
     "test-utils": "<rootDir>/jest_config/test-utils",
@@ -13,8 +14,8 @@
     "\\.worker.(ts|tsx)": "<rootDir>/jest_config/__mocks__/workerMock.js",
     "^@(.+)$": ["<rootDir>/node_modules/$0", "<rootDir>/src/$1"]
   },
-  "testPathIgnorePatterns": ["node_modules", "dist", "<rootDir>/__tests__"],
-  "coveragePathIgnorePatterns": ["node_modules", "components", "containers", "vendor", "spec"],
+  "testPathIgnorePatterns": ["/node_modules/", "<rootDir>/dist", "<rootDir>/__tests__"],
+  "coveragePathIgnorePatterns": ["/node_modules/", "/containers/", "/vendor/", "/spec/"],
   "setupFiles": [
     "<rootDir>/jest_config/setupJest.js",
     "<rootDir>/jest_config/__mocks__/localStorage.ts",


### PR DESCRIPTION
In an attempt to reduce memory usage:

- Use modulePathIgnorePatterns to remove jest warning:
jest-haste-map: Haste module naming collision: MyCrypto
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/package.json
    * <rootDir>/dist/electron-js/package.json
- Use regex pattern for testPath and coveragePath ignore


## Steps to reproduce on `master`:
1. Run `yarn build:electron:osx`
2. `/dist` folder will contain `__mocks__` and `src` dirs.
3. Run `yarn test` and you will see the jest warning displayed.
   misc: If you `rm -rf dist` while the test jest will cry.
4. Repeat on branch and the warning should be gone. 
