### PR TITLE
Update dist pathname to dist/web

### DIFF
--- a/.drawbridgerc
+++ b/.drawbridgerc
@@ -2,7 +2,7 @@
     "environments": {
         "develop": {
             "gitUrl": "git@github.com:MyCryptoHQ/MyCrypto.git",
-            "distFolder": "dist/prod",
+            "distFolder": "dist/web",
             "buildCommand": "rm -rf node_modules && yarn && yarn build"
         },
         "beta": {

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "build:storybook": "build-storybook",
     "tscheck": "tsc",
     "start": " yarn run dev",
-    "serve": "ws -d dist/prod/ --spa index.html",
+    "serve": "ws -d dist/web/ --spa index.html",
     "prod": "npm run build && npm run serve",
     "precommit": "lint-staged",
     "formatAll": "find ./src/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",


### PR DESCRIPTION
1. We changed the output dir to `dist/web`.
Replace the previous references to `dist/prod`.
2. Prefer `yarn` over `npm` to run commands.