### PR TITLE
Update E2E_BASE_URL to reflect s3 changes

### DIFF
--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set E2E_BASE_URL
         if: github.ref == 'refs/heads/master'
         run: |
-          E2E_BASE_URL=$( echo https://mycryptobuilds.com/# )
+          E2E_BASE_URL=$( echo https://mycryptobuilds.com/master/# )
           echo $E2E_BASE_URL
           echo "::set-env name=E2E_BASE_URL::$E2E_BASE_URL"
 


### PR DESCRIPTION
GHA runs are failing on mater: https://github.com/MyCryptoHQ/MyCrypto/runs/928976417?check_suite_focus=true

S3 staging urls have changed.
Update the github actions to set the correct value for E2E_BASE_URL
eg. `<staging_url>/master/#`

