### PR TITLE
Implement eth-scan for legacy token scanner

### DIFF
--- a/common/libs/nodes/tokenBalanceProxy.ts
+++ b/common/libs/nodes/tokenBalanceProxy.ts
@@ -73,7 +73,7 @@ export const tokenBalanceHandler: ProxyHandler<IProvider> = {
     if (propKey.toString() === 'getTokenBalance') {
       return (address: string, token: Token) => tokenBalanceShim(address, token);
     } else if (propKey.toString() === 'getTokenBalances') {
-      const network = getShepherdNetwork();
+      const network = getShepherdNetwork().replace(/WEB3_/i, '');
 
       return (address: string, tokens: Token[]) => {
         if (ETH_SCAN_NETWORKS.includes(network)) {

--- a/common/libs/nodes/tokenBalanceProxy.ts
+++ b/common/libs/nodes/tokenBalanceProxy.ts
@@ -2,6 +2,7 @@ import { Token } from 'shared/types/network';
 import ERC20 from 'libs/erc20';
 import { TokenValue } from 'libs/units';
 import { IProvider } from 'mycrypto-shepherd/dist/lib/types';
+import { getTokensBalance } from '@mycrypto/eth-scan';
 
 export const tokenBalanceHandler: ProxyHandler<IProvider> = {
   get(target, propKey) {
@@ -21,60 +22,18 @@ export const tokenBalanceHandler: ProxyHandler<IProvider> = {
         }));
     };
 
-    const splitBatches = (address: string, tokens: Token[]) => {
-      const batchSize = 10;
-      type SplitBatch = { address: string; tokens: Token[] }[];
-      const splitBatch: SplitBatch = [];
-      for (let i = 0; i < tokens.length; i++) {
-        const arrIdx = Math.ceil((i + 1) / batchSize) - 1;
-        const token = tokens[i];
-
-        if (!splitBatch[arrIdx]) {
-          splitBatch.push({ address, tokens: [token] });
-        } else {
-          splitBatch[arrIdx] = { address, tokens: [...splitBatch[arrIdx].tokens, token] };
-        }
-      }
-      return splitBatch;
-    };
-
-    const tokenBalancesShim = (address: string, tokens: Token[]) => {
-      const sendCallRequests: (...rpcArgs: any[]) => Promise<string[]> = Reflect.get(
-        target,
-        'sendCallRequests'
-      );
-
-      return sendCallRequests(
-        tokens.map(t => ({
-          to: t.address,
-          data: ERC20.balanceOf.encodeInput({ _owner: address })
-        }))
-      ).then(response =>
-        response.map(item => {
-          if (item) {
-            return {
-              balance: TokenValue(item),
-              error: null
-            };
-          } else {
-            return {
-              balance: TokenValue('0'),
-              error: 'Invalid object shape'
-            };
-          }
-        })
-      );
-    };
-
     if (propKey.toString() === 'getTokenBalance') {
       return (address: string, token: Token) => tokenBalanceShim(address, token);
     } else if (propKey.toString() === 'getTokenBalances') {
       return (address: string, tokens: Token[]) =>
-        Promise.all(
-          splitBatches(address, tokens).map(({ address: addr, tokens: tkns }) =>
-            tokenBalancesShim(addr, tkns)
-          )
-        ).then(res => res.reduce((acc, curr) => [...acc, ...curr], []));
+        getTokensBalance(target, address, tokens.map(token => token.address)).then(results => {
+          return Object.entries(results).map(([, balance]) => {
+            return {
+              balance: TokenValue(balance.toHexString()),
+              error: null
+            };
+          });
+        });
     } else {
       return Reflect.get(target, propKey);
     }

--- a/common/libs/nodes/tokenBalanceProxy.ts
+++ b/common/libs/nodes/tokenBalanceProxy.ts
@@ -77,16 +77,21 @@ export const tokenBalanceHandler: ProxyHandler<IProvider> = {
 
       return (address: string, tokens: Token[]) => {
         if (ETH_SCAN_NETWORKS.includes(network)) {
-          return getTokensBalance(target, address, tokens.map(token => token.address)).then(
-            results => {
+          return getTokensBalance(target, address, tokens.map(token => token.address))
+            .then(results => {
               return Object.entries(results).map(([, balance]) => {
                 return {
                   balance: TokenValue(balance.toHexString()),
                   error: null
                 };
               });
-            }
-          );
+            })
+            .catch(error =>
+              tokens.map(() => ({
+                balance: TokenValue('0'),
+                error: `Caught error: ${error}`
+              }))
+            );
         }
 
         return Promise.all(

--- a/common/libs/nodes/tokenBalanceProxy.ts
+++ b/common/libs/nodes/tokenBalanceProxy.ts
@@ -3,6 +3,9 @@ import ERC20 from 'libs/erc20';
 import { TokenValue } from 'libs/units';
 import { IProvider } from 'mycrypto-shepherd/dist/lib/types';
 import { getTokensBalance } from '@mycrypto/eth-scan';
+import { getShepherdNetwork } from './index';
+
+const ETH_SCAN_NETWORKS: string[] = ['ETH', 'Ropsten', 'Kovan', 'Rinkeby', 'Goerli'];
 
 export const tokenBalanceHandler: ProxyHandler<IProvider> = {
   get(target, propKey) {
@@ -22,18 +25,76 @@ export const tokenBalanceHandler: ProxyHandler<IProvider> = {
         }));
     };
 
+    const splitBatches = (address: string, tokens: Token[]) => {
+      const batchSize = 10;
+      type SplitBatch = { address: string; tokens: Token[] }[];
+      const splitBatch: SplitBatch = [];
+      for (let i = 0; i < tokens.length; i++) {
+        const arrIdx = Math.ceil((i + 1) / batchSize) - 1;
+        const token = tokens[i];
+
+        if (!splitBatch[arrIdx]) {
+          splitBatch.push({ address, tokens: [token] });
+        } else {
+          splitBatch[arrIdx] = { address, tokens: [...splitBatch[arrIdx].tokens, token] };
+        }
+      }
+      return splitBatch;
+    };
+
+    const tokenBalancesShim = (address: string, tokens: Token[]) => {
+      const sendCallRequests: (...rpcArgs: any[]) => Promise<string[]> = Reflect.get(
+        target,
+        'sendCallRequests'
+      );
+
+      return sendCallRequests(
+        tokens.map(t => ({
+          to: t.address,
+          data: ERC20.balanceOf.encodeInput({ _owner: address })
+        }))
+      ).then(response =>
+        response.map(item => {
+          if (item) {
+            return {
+              balance: TokenValue(item),
+              error: null
+            };
+          } else {
+            return {
+              balance: TokenValue('0'),
+              error: 'Invalid object shape'
+            };
+          }
+        })
+      );
+    };
+
     if (propKey.toString() === 'getTokenBalance') {
       return (address: string, token: Token) => tokenBalanceShim(address, token);
     } else if (propKey.toString() === 'getTokenBalances') {
-      return (address: string, tokens: Token[]) =>
-        getTokensBalance(target, address, tokens.map(token => token.address)).then(results => {
-          return Object.entries(results).map(([, balance]) => {
-            return {
-              balance: TokenValue(balance.toHexString()),
-              error: null
-            };
-          });
-        });
+      const network = getShepherdNetwork();
+
+      return (address: string, tokens: Token[]) => {
+        if (ETH_SCAN_NETWORKS.includes(network)) {
+          return getTokensBalance(target, address, tokens.map(token => token.address)).then(
+            results => {
+              return Object.entries(results).map(([, balance]) => {
+                return {
+                  balance: TokenValue(balance.toHexString()),
+                  error: null
+                };
+              });
+            }
+          );
+        }
+
+        return Promise.all(
+          splitBatches(address, tokens).map(({ address: addr, tokens: tkns }) =>
+            tokenBalancesShim(addr, tkns)
+          )
+        ).then(res => res.reduce((acc, curr) => [...acc, ...curr], []));
+      };
     } else {
       return Reflect.get(target, propKey);
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "4.48.0",
     "@ledgerhq/hw-transport-u2f": "4.46.0",
     "@ledgerhq/hw-transport-webusb": "4.56.0",
+    "@mycrypto/eth-scan": "https://github.com/MyCryptoHQ/eth-scan.git#6fac6550624b126adfdf4407ca65145f54d03e9c",
     "@parity/qr-signer": "0.3.1",
     "@unstoppabledomains/resolution": "1.3.6",
     "axios": "0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,103 @@
     rskjs-util "^1.0.3"
     safe-buffer "^5.2.0"
 
+"@ethersproject/abi@^5.0.0-beta.146":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.2.tgz#7fe8f080aa1483fe32cd27bb5b8f2019266af1e2"
+  integrity sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==
+  dependencies:
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/hash" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/properties" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/address@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.2.tgz#80d0ddfb7d4bd0d32657747fa4bdd2defef2e00a"
+  integrity sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/rlp" "^5.0.0"
+    bn.js "^4.4.0"
+
+"@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.0.0-beta.135":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.5.tgz#31bd7e75aad46ace345fae69b1f5bb120906af1b"
+  integrity sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    bn.js "^4.4.0"
+
+"@ethersproject/bytes@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.3.tgz#b3769963ae0188a35713d343890a903bda20af9c"
+  integrity sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==
+  dependencies:
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/constants@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.2.tgz#f7ac0b320e2bbec1a5950da075015f8bc4e8fed1"
+  integrity sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.0"
+
+"@ethersproject/hash@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.2.tgz#6d69558786961836d530b8b4a8714eac5388aec7"
+  integrity sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/keccak256" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+    "@ethersproject/strings" "^5.0.0"
+
+"@ethersproject/keccak256@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.2.tgz#7ed4a95bb45ee502cf4532223833740a83602797"
+  integrity sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@^5.0.0":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.4.tgz#09fa4765b5691233e3afb6617cb38a700f9dd2e4"
+  integrity sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw==
+
+"@ethersproject/properties@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.2.tgz#2facb62d2f2d968c7b3d0befa5bcc884cc565d3b"
+  integrity sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==
+  dependencies:
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/rlp@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.2.tgz#d6b550a2ac5e484f15f0f63337e522004d2e78cd"
+  integrity sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
+"@ethersproject/strings@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.2.tgz#1753408c3c889813fd0992abd76393e3e47a2619"
+  integrity sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.0"
+    "@ethersproject/constants" "^5.0.0"
+    "@ethersproject/logger" "^5.0.0"
+
 "@hot-loader/react-dom@16.8.6":
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"
@@ -1026,6 +1123,14 @@
   version "4.61.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.61.0.tgz#bbcba49d7a7a4e20d6584bbfc10ed93b212c804c"
   integrity sha512-AObEnA+tgzKEwY306i6FOT/hlc+zjF817Bty/IxG3f2wPJFRK9cJuD3Ijl4pfJP2pt7KubN4YbRGXREXhEsknQ==
+
+"@mycrypto/eth-scan@https://github.com/MyCryptoHQ/eth-scan.git#6fac6550624b126adfdf4407ca65145f54d03e9c":
+  version "2.1.0"
+  resolved "https://github.com/MyCryptoHQ/eth-scan.git#6fac6550624b126adfdf4407ca65145f54d03e9c"
+  dependencies:
+    "@ethersproject/abi" "^5.0.0-beta.146"
+    "@ethersproject/bignumber" "^5.0.0-beta.135"
+    isomorphic-unfetch "^3.0.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -7979,6 +8084,14 @@ isomorphic-fetch@2.2.1, isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic-unfetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz#de6d80abde487b17de2c400a7ef9e5ecc2efb362"
+  integrity sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==
+  dependencies:
+    node-fetch "^2.2.0"
+    unfetch "^4.0.0"
+
 isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
@@ -8411,6 +8524,11 @@ js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
+js-sha3@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-sha3@^0.3.1:
   version "0.3.1"
@@ -9793,7 +9911,7 @@ node-fetch@^1.0.1, node-fetch@^1.6.0:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.6.0:
+node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -14318,6 +14436,11 @@ undefsafe@^2.0.2:
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
+unfetch@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
## Description

This implements [`eth-scan`](https://github.com/MyCryptoHQ/eth-scan) in legacy. This (hopefully) fixes some issues with the token scanner not being able to fetch tokens. It uses a customized version of `eth-scan`, which adds support for Shepherd.

## Changes

* Replaced the token fetch logic with `eth-scan`.

## Steps to Test

1. Unlock your account
2. Click the button to scan for tokens
3. Check if the token balances are loaded as usual