### PR TITLE
Mock react-inlinesvg for jest

### DIFF
--- a/jest_config/__mocks__/react-inlinesvg.tsx
+++ b/jest_config/__mocks__/react-inlinesvg.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+/**
+ * We use react-inlingsvg in the app and rely on `fileMock` to stub svg file requests in jest
+ * Because of the stub, the dependency throughs an `isomorphic-fetch` error requesting an `absolute url`.
+ * Mock the component returned by the dependency to silence the error.
+ * ref. https://github.com/gilbarbara/react-inlinesvg/issues/140
+ */
+
+const svgMock = ({ src }) => <svg id={src} />;
+
+export default svgMock;


### PR DESCRIPTION
Run `yarn test` and see that there are no more errors related to `react-inlinesvg`