### PR TITLE
Replace formik render with child callback function

### DIFF
--- a/src/components/ContractLookupField.stories.tsx
+++ b/src/components/ContractLookupField.stories.tsx
@@ -25,14 +25,12 @@ export default { title: 'ContractLookupField' };
 
 export const defaultState = () => (
   <div className="sb-container" style={{ width: '100%', maxWidth: '300px' }}>
-    <Formik
-      initialValues={initialFormikValues}
-      onSubmit={() => undefined}
-      render={({ values }) => (
+    <Formik initialValues={initialFormikValues} onSubmit={() => undefined}>
+      {({ values }) => (
         <Form>
           <ContractLookupField {...props} value={values.address} />
         </Form>
       )}
-    />
+    </Formik>
   </div>
 );

--- a/src/components/GeneralLookupField.stories.tsx
+++ b/src/components/GeneralLookupField.stories.tsx
@@ -30,15 +30,13 @@ export default { title: 'GeneralLookupField' };
 export const defaultState = () => {
   return (
     <div className="sb-container" style={{ width: '100%', maxWidth: '300px' }}>
-      <Formik
-        initialValues={initialFormikValues}
-        onSubmit={() => undefined}
-        render={({ values }) => (
+      <Formik initialValues={initialFormikValues} onSubmit={() => undefined}>
+        {({ values }) => (
           <Form>
             <GeneralLookupField {...customProps} value={values.address} />
           </Form>
         )}
-      />
+      </Formik>
     </div>
   );
 };

--- a/src/components/WalletUnlock/ViewOnly.tsx
+++ b/src/components/WalletUnlock/ViewOnly.tsx
@@ -50,10 +50,8 @@ export function ViewOnlyDecrypt({ formData, onUnlock }: Props) {
   return (
     <div className="Panel">
       <div className="Panel-title">{translateRaw('INPUT_PUBLIC_ADDRESS_LABEL')}</div>
-      <Formik
-        initialValues={initialFormikValues}
-        onSubmit={onSubmit}
-        render={({ errors, touched, values, setFieldError, setFieldTouched, setFieldValue }) => (
+      <Formik initialValues={initialFormikValues} onSubmit={onSubmit}>
+        {({ errors, touched, values, setFieldError, setFieldTouched, setFieldValue }) => (
           <FormWrapper>
             <ContactLookupField
               name="address"
@@ -77,7 +75,7 @@ export function ViewOnlyDecrypt({ formData, onUnlock }: Props) {
             </ButtonWrapper>
           </FormWrapper>
         )}
-      />
+      </Formik>
     </div>
   );
 }

--- a/src/features/BuyAssets/BuyAssetsForm.tsx
+++ b/src/features/BuyAssets/BuyAssetsForm.tsx
@@ -114,7 +114,8 @@ export const BuyAssetsForm = () => {
         initialValues={initialFormikValues}
         validationSchema={BuyFormSchema}
         onSubmit={(vals) => handleSubmission(vals, SubmissionType.SEND_TO_SELF)}
-        render={({ values, errors, touched, setFieldValue }) => {
+      >
+        {({ values, errors, touched, setFieldValue }) => {
           const relevantAccounts = accounts.filter((account) => {
             return values.asset && values.asset.networkId
               ? isAccountInNetwork(account, values.asset.networkId)
@@ -183,7 +184,7 @@ export const BuyAssetsForm = () => {
             </Form>
           );
         }}
-      />
+      </Formik>
     </ContentPanel>
   );
 };

--- a/src/features/DeFiZap/components/ZapForm.tsx
+++ b/src/features/DeFiZap/components/ZapForm.tsx
@@ -134,7 +134,8 @@ export const ZapFormUI = ({
             onComplete({ ...fields, gasPrice: standard.toString() });
           });
         }}
-        render={({ values, errors, touched, setFieldValue }) => {
+      >
+        {({ values, errors, touched, setFieldValue }) => {
           const handleNonceEstimate = async (account: IAccount) => {
             const nonce: number = await getNonce(values.network, account.address);
             setFieldValue('nonce', nonce);
@@ -199,7 +200,7 @@ export const ZapFormUI = ({
             </Form>
           );
         }}
-      />
+      </Formik>
     </div>
   );
 };

--- a/src/features/InteractWithContracts/components/Interact.tsx
+++ b/src/features/InteractWithContracts/components/Interact.tsx
@@ -264,7 +264,8 @@ function Interact(props: CombinedProps) {
       validationSchema={FormSchema}
       // Hack as we don't really use Formik for this flow
       onSubmit={() => undefined}
-      render={({ values, errors, touched, setFieldValue, setFieldError, setFieldTouched }) => {
+    >
+      {({ values, errors, touched, setFieldValue, setFieldError, setFieldTouched }) => {
         useEffect(() => {
           if (
             !getNetworkById(networkIdFromUrl, networks) ||
@@ -408,7 +409,7 @@ function Interact(props: CombinedProps) {
           </>
         );
       }}
-    />
+    </Formik>
   );
 }
 

--- a/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
+++ b/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
@@ -107,7 +107,8 @@ export const MembershipFormUI = ({
         initialValues={initialFormikValues}
         validationSchema={MembershipFormSchema}
         onSubmit={noOp}
-        render={({ values, errors, touched, setFieldValue }) => {
+      >
+        {({ values, errors, touched, setFieldValue }) => {
           const handleNonceEstimate = async (account: IAccount) => {
             const nonce: number = await getNonce(values.network, account.address);
             setFieldValue('nonce', nonce);
@@ -235,7 +236,7 @@ export const MembershipFormUI = ({
             </Form>
           );
         }}
-      />
+      </Formik>
     </div>
   );
 };

--- a/src/features/RequestAssets/RequestAssets.tsx
+++ b/src/features/RequestAssets/RequestAssets.tsx
@@ -148,13 +148,8 @@ export function RequestAssets({ history }: RouteComponentProps<{}>) {
       onBack={() => history.push(ROUTE_PATHS.DASHBOARD.path)}
       mobileMaxWidth="100%;"
     >
-      <Formik
-        initialValues={initialValues}
-        onSubmit={noOp}
-        render={({
-          values: { amount, recipientAddress },
-          errors
-        }: FormikProps<typeof initialValues>) => (
+      <Formik initialValues={initialValues} onSubmit={noOp}>
+        {({ values: { amount, recipientAddress }, errors }: FormikProps<typeof initialValues>) => (
           <Form>
             <Fieldset>
               <SLabel htmlFor="recipientAddress">{translate('X_RECIPIENT')}</SLabel>
@@ -278,7 +273,7 @@ export function RequestAssets({ history }: RouteComponentProps<{}>) {
             )}
           </Form>
         )}
-      />
+      </Formik>
     </ContentPanel>
   );
 }


### PR DESCRIPTION
`Formik render={}` is deprecated.
Replace with child callback function e.g
```
<Formik>{(props) => (<>{//...etc}</>)}</Formik>
```