### PR TITLE
Handle rc url

### DIFF
--- a/src/features/MigrateLS/MigrateLS.tsx
+++ b/src/features/MigrateLS/MigrateLS.tsx
@@ -53,7 +53,7 @@ const MigrateLS = ({
   const [reload, setReload] = useState(false);
 
   // We only need to get the iFrame src url once
-  const src = useMemo(() => getIFrameSrc(window), []);
+  const src = useMemo(() => getIFrameSrc(window.document), []);
 
   const [{ storage, iframeRef, uiState, canDestroy, canReset }, dispatch] = useReducer(
     MigrateLSReducer,

--- a/src/features/MigrateLS/helpers.test.tsx
+++ b/src/features/MigrateLS/helpers.test.tsx
@@ -2,26 +2,20 @@ import { getIFrameSrc, getLS } from './helpers';
 
 describe('getIFrameSrc()', () => {
   test('it returns the landing page dev port by default', () => {
-    const win = { location: { hostname: '' } } as Window;
-    const res = getIFrameSrc(win);
+    const doc = { domain: '' } as Document;
+    const res = getIFrameSrc(doc);
     expect(res).toEqual('https://localhost:8000');
   });
 
   test('it returns the correct url for landing staging', () => {
-    const win = { location: { hostname: 'mycryptobuilds.com' } } as Window;
-    const res = getIFrameSrc(win);
+    const doc = { domain: 'mycryptobuilds.com' } as Document;
+    const res = getIFrameSrc(doc);
     expect(res).toEqual('https://landing.mycryptobuilds.com');
   });
 
   test('it returns the correct url for production', () => {
-    const win = { location: { hostname: 'mycrypto.com' } } as Window;
-    const res = getIFrameSrc(win);
-    expect(res).toEqual('https://beta.mycrypto.com');
-  });
-
-  test('it returns the correct url for rc.app', () => {
-    const win = { location: { hostname: 'rc.app.mycrypto.com' } } as Window;
-    const res = getIFrameSrc(win);
+    const doc = { domain: 'mycrypto.com' } as Document;
+    const res = getIFrameSrc(doc);
     expect(res).toEqual('https://beta.mycrypto.com');
   });
 });
@@ -29,7 +23,7 @@ describe('getIFrameSrc()', () => {
 describe('getLS', () => {
   test('it can find the correct DBkey', () => {
     const frame = ({
-      contentWindow: { localStorage: { MYC_Storage: { version: 'v1.0.0' } } }
+      contentDocument: { localStorage: { MYC_Storage: { version: 'v1.0.0' } } }
     } as any) as HTMLIFrameElement;
     const res = getLS(frame);
     expect(res).toEqual(frame.contentWindow?.localStorage.MYC_Storage);
@@ -37,7 +31,7 @@ describe('getLS', () => {
 
   test('it returns undefined if key is absent', () => {
     const frame = ({
-      contentWindow: { localStorage: { wrong_storage: { version: 'v1.0.0' } } }
+      contentDocument: { localStorage: { wrong_storage: { version: 'v1.0.0' } } }
     } as any) as HTMLIFrameElement;
 
     const res = getLS(frame);
@@ -46,7 +40,7 @@ describe('getLS', () => {
 
   test('it returns undefined if localStorage is absent', () => {
     const frame = ({
-      contentWindow: {}
+      contentDocument: {}
     } as any) as HTMLIFrameElement;
 
     const res = getLS(frame);

--- a/src/features/MigrateLS/helpers.ts
+++ b/src/features/MigrateLS/helpers.ts
@@ -2,19 +2,18 @@ import { prop, path } from '@vendor';
 import { TURL } from '@types';
 import { getCurrentDBConfig } from '@database';
 
-const getHostName: (obj: Window) => string | undefined = path(['location', 'hostname']);
-
+const getDomain: (obj: Document) => string | undefined = prop('domain');
 export const DBName = prop('main', getCurrentDBConfig());
 
 /**
  * Retrieve the url of the landing page according to current execution envirionment
+ * Relies on setting document.domain in src/index.tsx
  * @param hostname : TURL
  */
-export const getIFrameSrc = (win: Window) => {
-  const hostname = getHostName(win);
-  switch (hostname) {
+export const getIFrameSrc = (doc: Document) => {
+  const domain = getDomain(doc);
+  switch (domain) {
     case 'mycrypto.com':
-    case 'rc.app.mycrypto.com':
       return 'https://beta.mycrypto.com' as TURL;
     case 'mycryptobuilds.com':
       return 'https://landing.mycryptobuilds.com' as TURL;

--- a/src/utils/getRootDomain.spec.ts
+++ b/src/utils/getRootDomain.spec.ts
@@ -23,3 +23,9 @@ test('it handles multiple sub-domains', () => {
   const res = getRootDomain(hostname);
   expect(res).toEqual('root.com');
 });
+
+test('it handles multiple rc hostname', () => {
+  const hostname = 'rc.app.mycrypto.com';
+  const res = getRootDomain(hostname);
+  expect(res).toEqual('mycrypto.com');
+});


### PR DESCRIPTION
For MigrateLS we also need to account for `rc.app.mycrypto.com`.
This will allow us to use the migration functionality once the landing is on `beta.mycrypto.com`

Close #3449 