### PR TITLE
Add support for signing messages with Trezor (Legacy)

### DIFF
--- a/common/components/WalletDecrypt/disables.ts
+++ b/common/components/WalletDecrypt/disables.ts
@@ -22,9 +22,8 @@ export const DISABLE_WALLETS: { [key in WalletMode]: DisabledWallets } = {
     }
   },
   [WalletMode.UNABLE_TO_SIGN]: {
-    wallets: [SecureWalletName.TREZOR, SecureWalletName.SAFE_T, MiscWalletName.VIEW_ONLY],
+    wallets: [SecureWalletName.SAFE_T, MiscWalletName.VIEW_ONLY],
     reasons: {
-      [SecureWalletName.TREZOR]: 'This wallet can’t sign messages',
       [SecureWalletName.SAFE_T]: 'This wallet can’t sign messages',
       [MiscWalletName.VIEW_ONLY]: 'This wallet can’t sign messages'
     }

--- a/common/libs/wallet/deterministic/trezor.ts
+++ b/common/libs/wallet/deterministic/trezor.ts
@@ -74,8 +74,21 @@ export class TrezorWallet extends HardwareWallet {
     });
   }
 
-  public signMessage() {
-    return Promise.reject(new Error('Signing via Trezor not yet supported.'));
+  public async signMessage(message: string): Promise<string> {
+    if (!message) {
+      throw Error('No message to sign');
+    }
+
+    const response = await TrezorConnect.ethereumSignMessage({
+      message,
+      path: this.getPath()
+    });
+
+    if (response.error || !response.success) {
+      throw Error(response.error);
+    }
+
+    return response.payload.signature;
   }
 
   public displayAddress(): Promise<boolean> {

--- a/common/typescript/trezor-connect.d.ts
+++ b/common/typescript/trezor-connect.d.ts
@@ -41,13 +41,10 @@ declare module 'trezor-connect' {
 
     export function ethereumSignTransaction(signTransactionMessage): any;
 
-    export function signMessage(
-      path: Path,
-      message: string,
-      cb: (res: Response<MessageSignature>) => void,
-      coin?: string,
-      minFirmware?: string
-    ): any;
+    export function ethereumSignMessage(params: {
+      path: string;
+      message: string;
+    }): Promise<Response<{ payload: MessageSignature }>>;
 
     export function ethereumGetAddress(pathObj): any;
   }


### PR DESCRIPTION
## Description

This PR adds support for singing transactions with Trezor devices.

## Steps to Test

1. Go to Sign page on MyCrypto
2. Sign a message using the Trezor option
3. Copy the signed message and make sure it succesfully verifies