### PR TITLE
Add support for signing messages with Trezor

### DIFF
--- a/src/features/SignAndVerifyMessage/stories.tsx
+++ b/src/features/SignAndVerifyMessage/stories.tsx
@@ -7,7 +7,8 @@ import {
   PrivateKeyDecrypt,
   Web3ProviderDecrypt,
   Web3ProviderInstall,
-  WalletConnectDecrypt
+  WalletConnectDecrypt,
+  TrezorDecrypt
 } from '@components';
 
 export const getStories = (): IStory[] => [
@@ -18,6 +19,10 @@ export const getStories = (): IStory[] => [
   {
     name: WalletId.LEDGER_NANO_S,
     steps: [LedgerNanoSDecrypt]
+  },
+  {
+    name: WalletId.TREZOR,
+    steps: [TrezorDecrypt]
   },
   {
     name: WalletId.WALLETCONNECT,

--- a/src/services/WalletService/deterministic/trezor.ts
+++ b/src/services/WalletService/deterministic/trezor.ts
@@ -73,8 +73,21 @@ export class TrezorWallet extends HardwareWallet {
     });
   }
 
-  public signMessage() {
-    return Promise.reject(new Error('Signing via Trezor not yet supported.'));
+  public async signMessage(message: string): Promise<string> {
+    if (!message) {
+      throw Error('No message to sign');
+    }
+
+    const response = await TrezorConnect.ethereumSignMessage({
+      message,
+      path: this.getPath()
+    });
+
+    if (!response.success) {
+      throw Error('Failed to sign message');
+    }
+
+    return response.payload.signature;
   }
 
   public displayAddress(): Promise<boolean> {

--- a/src/types/vendor/trezor-connect.d.ts
+++ b/src/types/vendor/trezor-connect.d.ts
@@ -1,3 +1,8 @@
+/**
+ * TODO: These declarations are pretty broken since `Path` is not defined. Adding a definition for
+ * `Path`, e.g. `type Path = string | number[];` results in other code being broken, so this should
+ * be fixed in the future.
+ */
 declare module 'trezor-connect' {
   interface TxSignature {
     r: number;
@@ -49,18 +54,6 @@ declare module 'trezor-connect' {
     path: string | number[];
   }
 
-  interface ErrorResponse {
-    success: false;
-    error: string;
-  }
-
-  type SuccessResponse<T> = {
-    success: true;
-    error: undefined;
-  } & T;
-
-  type Response<T> = ErrorResponse | SuccessResponse<T>;
-
   interface EthereumGetAddressPayload {
     address: string;
     path: number[];
@@ -76,14 +69,10 @@ declare module 'trezor-connect' {
     }): Promise<TrezorData<GetPublicKeyPayload[]>>;
 
     export function ethereumSignTransaction(signTransactionMessage): any;
-
-    export function signMessage(
-      path: Path,
-      message: string,
-      cb: (res: Response<MessageSignature>) => void,
-      coin?: string,
-      minFirmware?: string
-    ): any;
+    export function ethereumSignMessage(params: {
+      path: string | number[];
+      message: string;
+    }): Promise<TrezorData<MessageSignature>>;
 
     export function ethereumGetAddress(pathObj): Promise<TrezorData<EthereumGetAddressPayload>>;
   }


### PR DESCRIPTION
## Description

This PR adds support for singing transactions with Trezor devices. This is the same code as #3469, adapted to work with beta.

## Steps to Test

1. Go to Sign page on MyCrypto
2. Sign a message using the Trezor option
3. Copy the signed message and make sure it succesfully verifies