### PR TITLE
Remove formik render from fields

### DIFF
--- a/src/features/DeFiZap/components/ZapForm.tsx
+++ b/src/features/DeFiZap/components/ZapForm.tsx
@@ -175,7 +175,6 @@ export const ZapFormUI = ({
                         value={field.value}
                         onBlur={() => {
                           form.setFieldTouched('amount');
-                          //handleGasEstimate();
                         }}
                         placeholder={'0.00'}
                       />

--- a/src/features/DeFiZap/components/ZapForm.tsx
+++ b/src/features/DeFiZap/components/ZapForm.tsx
@@ -166,30 +166,27 @@ export const ZapFormUI = ({
                 <FormFieldLabel htmlFor="amount">
                   <div>{translate('SEND_ASSETS_AMOUNT_LABEL')}</div>
                 </FormFieldLabel>
-                <Field
-                  name="amount"
-                  render={({ field, form }: FieldProps) => {
-                    return (
-                      <>
-                        <AmountInput
-                          {...field}
-                          asset={ethAsset}
-                          value={field.value}
-                          onBlur={() => {
-                            form.setFieldTouched('amount');
-                            //handleGasEstimate();
-                          }}
-                          placeholder={'0.00'}
-                        />
-                        {errors && errors.amount && touched && touched.amount ? (
-                          <InlineMessage className="SendAssetsForm-errors">
-                            {errors.amount}
-                          </InlineMessage>
-                        ) : null}
-                      </>
-                    );
-                  }}
-                />
+                <Field name="amount">
+                  {({ field, form }: FieldProps) => (
+                    <>
+                      <AmountInput
+                        {...field}
+                        asset={ethAsset}
+                        value={field.value}
+                        onBlur={() => {
+                          form.setFieldTouched('amount');
+                          //handleGasEstimate();
+                        }}
+                        placeholder={'0.00'}
+                      />
+                      {errors && errors.amount && touched && touched.amount ? (
+                        <InlineMessage className="SendAssetsForm-errors">
+                          {errors.amount}
+                        </InlineMessage>
+                      ) : null}
+                    </>
+                  )}
+                </Field>
               </FormFieldItem>
               <FormFieldSubmitButton type="submit">
                 {translateRaw('ACTION_6')}

--- a/src/features/DevTools/DevTools.tsx
+++ b/src/features/DevTools/DevTools.tsx
@@ -47,9 +47,8 @@ const renderAccountForm = (
     <Form>
       <fieldset>
         Address:{' '}
-        <Field
-          name="address"
-          render={({ field }: FieldProps<Account>) => (
+        <Field name="address">
+          {({ field }: FieldProps<Account>) => (
             <DevToolsInput
               {...field}
               onChange={handleChange}
@@ -57,24 +56,22 @@ const renderAccountForm = (
               value={values.address}
             />
           )}
-        />
+        </Field>
       </fieldset>
       <br />
       <fieldset>
         Label:{' '}
-        <Field
-          name="label"
-          render={({ field }: FieldProps<Account>) => (
+        <Field name="label">
+          {({ field }: FieldProps<Account>) => (
             <DevToolsInput {...field} onChange={handleChange} onBlur={handleBlur} value={label} />
           )}
-        />
+        </Field>
       </fieldset>
       <br />
       <fieldset>
         Network:{' '}
-        <Field
-          name="network"
-          render={({ field }: FieldProps<Account>) => (
+        <Field name="network">
+          {({ field }: FieldProps<Account>) => (
             <DevToolsInput
               {...field}
               onChange={handleChange}
@@ -82,7 +79,7 @@ const renderAccountForm = (
               value={values.networkId}
             />
           )}
-        />
+        </Field>
       </fieldset>
       <br />
       <Button type="submit" disabled={isSubmitting}>

--- a/src/features/InteractWithContracts/components/fields/AddressField.tsx
+++ b/src/features/InteractWithContracts/components/fields/AddressField.tsx
@@ -96,10 +96,8 @@ function ETHAddressField({
   // the Inputs 'value' and 'onChange' props to Formiks handlers.
   return (
     <>
-      <Field
-        name={fieldName}
-        validateOnChange={false}
-        render={({ field, form }: FieldProps) => {
+      <Field name={fieldName} validateOnChange={false}>
+        {({ field, form }: FieldProps) => {
           const value = resolvedAddress ? resolvedAddress : field.value.value;
           return (
             <Wrapper className={className}>
@@ -159,7 +157,7 @@ function ETHAddressField({
             </Wrapper>
           );
         }}
-      />
+      </Field>
     </>
   );
 }

--- a/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
+++ b/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
@@ -194,31 +194,27 @@ export const MembershipFormUI = ({
                 <FormFieldLabel htmlFor="amount">
                   <div>{translate('SEND_ASSETS_AMOUNT_LABEL')}</div>
                 </FormFieldLabel>
-                <Field
-                  name="amount"
-                  render={({ field, form }: FieldProps) => {
-                    return (
-                      <>
-                        <AmountInput
-                          {...field}
-                          disabled={true}
-                          asset={values.asset}
-                          value={field.value}
-                          onBlur={() => {
-                            form.setFieldTouched('amount');
-                            //handleGasEstimate();
-                          }}
-                          placeholder={'0.00'}
-                        />
-                        {errors && errors.amount && touched && touched.amount ? (
-                          <InlineMessage className="SendAssetsForm-errors">
-                            {errors.amount}
-                          </InlineMessage>
-                        ) : null}
-                      </>
-                    );
-                  }}
-                />
+                <Field name="amount">
+                  {({ field, form }: FieldProps) => (
+                    <>
+                      <AmountInput
+                        {...field}
+                        disabled={true}
+                        asset={values.asset}
+                        value={field.value}
+                        onBlur={() => {
+                          form.setFieldTouched('amount');
+                        }}
+                        placeholder={'0.00'}
+                      />
+                      {errors && errors.amount && touched && touched.amount ? (
+                        <InlineMessage className="SendAssetsForm-errors">
+                          {errors.amount}
+                        </InlineMessage>
+                      ) : null}
+                    </>
+                  )}
+                </Field>
               </FormFieldItem>
               <FormFieldSubmitButton
                 type="submit"

--- a/src/features/RequestAssets/RequestAssets.tsx
+++ b/src/features/RequestAssets/RequestAssets.tsx
@@ -173,10 +173,8 @@ export function RequestAssets({ history }: RouteComponentProps<{}>) {
             <AssetFields>
               <Amount>
                 <SLabel htmlFor="amount">{translate('X_AMOUNT')}</SLabel>
-                <Field
-                  name="amount"
-                  validate={validateAmount}
-                  render={({ field, form }: FieldProps<string>) => (
+                <Field name="amount" validate={validateAmount}>
+                  {({ field, form }: FieldProps<string>) => (
                     <FullWidthInput
                       data-lpignore="true"
                       value={field.value}
@@ -187,7 +185,7 @@ export function RequestAssets({ history }: RouteComponentProps<{}>) {
                       inputMode="decimal"
                     />
                   )}
-                />
+                </Field>
               </Amount>
               {errors.amount && <ErrorMessage>{errors.amount}</ErrorMessage>}
               <Asset>

--- a/src/features/Settings/components/AddToAddressBook.tsx
+++ b/src/features/Settings/components/AddToAddressBook.tsx
@@ -106,52 +106,48 @@ export default function AddToAddressBook({ toggleFlipped, createContact }: Props
           <Form>
             <AddressFieldset>
               <label htmlFor="label">{translateRaw('ACCOUNT_LIST_LABEL')}</label>
-              <Field
-                name="label"
-                render={({ field }: FieldProps<string>) => (
+              <Field name="label">
+                {({ field }: FieldProps<string>) => (
                   <InputField
                     {...field}
                     placeholder={translateRaw('ADDRESS_BOOK_NAME_OF_ADDRESS_PLACEHOLDER')}
                   />
                 )}
-              />
+              </Field>
             </AddressFieldset>
             <AddressFieldset>
               <label htmlFor="address">{translateRaw('ADDRESSBOOK_ADDRESS')}</label>
-              <Field
-                name="address"
-                render={({ field }: FieldProps<string>) => (
+              <Field name="address">
+                {({ field }: FieldProps<string>) => (
                   <InputField
                     inputError={errors && errors.address}
                     {...field}
                     placeholder={translateRaw('ADDRESSBOOK_ADDRESS_PLACEHOLDER')}
                   />
                 )}
-              />
+              </Field>
             </AddressFieldset>
             <AddressFieldset>
-              <Field
-                name="network"
-                render={({ field, form }: FieldProps<NetworkId>) => (
+              <Field name="network">
+                {({ field, form }: FieldProps<NetworkId>) => (
                   <SNetworkSelectDropdown
                     network={field.value}
                     onChange={(e) => form.setFieldValue(field.name, e)}
                   />
                 )}
-              />
+              </Field>
             </AddressFieldset>
             <AddressFieldset>
               <label htmlFor="notes">{translateRaw('ADDRESSBOOK_NOTES')}</label>
-              <Field
-                name="notes"
-                render={({ field }: FieldProps<string>) => (
+              <Field name="notes">
+                {({ field }: FieldProps<string>) => (
                   <InputField
                     {...field}
                     textarea={true}
                     placeholder={translateRaw('ADDRESSBOOK_NOTES_PLACEHOLDER')}
                   />
                 )}
-              />
+              </Field>
             </AddressFieldset>
             <AddressBookButtons>
               <Button type="button" secondary={true} onClick={toggleFlipped}>


### PR DESCRIPTION
`render` is also deprecated for `Field`.
Replace with child callback.