### PR TITLE
Add query params for verify message page

### DIFF
--- a/src/features/SignAndVerifyMessage/VerifyMessage.tsx
+++ b/src/features/SignAndVerifyMessage/VerifyMessage.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Button } from '@mycrypto/ui';
+import { parse } from 'query-string';
 
 import { InputField } from '@components';
 import { verifySignedMessage } from '@services/EthService';
 import { BREAK_POINTS, COLORS } from '@theme';
 import translate, { translateRaw } from '@translations';
 import { ISignedMessage } from '@types';
+import { VerifyParams } from '@features/SignAndVerifyMessage/types';
 
 const { SCREEN_XS } = BREAK_POINTS;
 const { WHITE, SUCCESS_GREEN } = COLORS;
@@ -20,6 +22,7 @@ const Content = styled.div`
 interface VerifyButtonProps {
   disabled?: boolean;
 }
+
 const VerifyButton = styled(Button)<VerifyButtonProps>`
   ${(props) => props.disabled && 'opacity: 0.4;'}
 
@@ -73,6 +76,28 @@ export default function VerifyMessage() {
     setError(undefined);
     setSignedMessage(null);
   };
+
+  useEffect(() => {
+    const { address, message: queryMessage, signature } = parse(location.search) as {
+      [key in VerifyParams]?: string;
+    };
+
+    if (address && queryMessage && signature) {
+      setMessage(
+        JSON.stringify(
+          {
+            address,
+            msg: queryMessage,
+            sig: signature,
+            version: '2'
+          },
+          null,
+          2
+        )
+      );
+      handleVerifySignedMessage();
+    }
+  }, []);
 
   return (
     <Content>

--- a/src/features/SignAndVerifyMessage/VerifyMessage.tsx
+++ b/src/features/SignAndVerifyMessage/VerifyMessage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Button } from '@mycrypto/ui';
 import { parse } from 'query-string';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { InputField } from '@components';
 import { verifySignedMessage } from '@services/EthService';
@@ -49,7 +50,11 @@ const signatureExample: ISignedMessage = {
 };
 const signaturePlaceholder = JSON.stringify(signatureExample, null, 2);
 
-export default function VerifyMessage() {
+interface Props {
+  setShowSubtitle(show: boolean): void;
+}
+
+const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ location }) => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
   const [signedMessage, setSignedMessage] = useState<ISignedMessage | null>(null);
@@ -123,4 +128,6 @@ export default function VerifyMessage() {
       )}
     </Content>
   );
-}
+};
+
+export default withRouter(VerifyMessage);

--- a/src/features/SignAndVerifyMessage/VerifyMessage.tsx
+++ b/src/features/SignAndVerifyMessage/VerifyMessage.tsx
@@ -59,9 +59,11 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
   const [error, setError] = useState<string | undefined>(undefined);
   const [signedMessage, setSignedMessage] = useState<ISignedMessage | null>(null);
 
-  const handleVerifySignedMessage = () => {
+  const handleClick = () => handleVerifySignedMessage();
+
+  const handleVerifySignedMessage = (json?: string) => {
     try {
-      const parsedSignature: ISignedMessage = JSON.parse(message);
+      const parsedSignature: ISignedMessage = JSON.parse(json ?? message);
       const isValid = verifySignedMessage(parsedSignature);
 
       if (!isValid) {
@@ -88,19 +90,19 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
     };
 
     if (address && queryMessage && signature) {
-      setMessage(
-        JSON.stringify(
-          {
-            address,
-            msg: queryMessage,
-            sig: signature,
-            version: '2'
-          },
-          null,
-          2
-        )
+      const json = JSON.stringify(
+        {
+          address,
+          msg: queryMessage,
+          sig: signature,
+          version: '2'
+        },
+        null,
+        2
       );
-      handleVerifySignedMessage();
+
+      setMessage(json);
+      handleVerifySignedMessage(json);
     }
   }, []);
 
@@ -115,7 +117,7 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
         height="150px"
         inputError={error}
       />
-      <VerifyButton disabled={!message} onClick={handleVerifySignedMessage}>
+      <VerifyButton disabled={!message} onClick={handleClick}>
         {translate('MSG_VERIFY')}
       </VerifyButton>
       {signedMessage && (

--- a/src/features/SignAndVerifyMessage/types.ts
+++ b/src/features/SignAndVerifyMessage/types.ts
@@ -1,0 +1,1 @@
+export type VerifyParams = 'address' | 'message' | 'signature';


### PR DESCRIPTION
This adds support for using query params `message`, `address` and `signature` to verify messages.