### PR TITLE
Preserve document.domain for electron

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import 'what-input'; // @todo: Investigate utility of dependency; Used in sass/s
 import React from 'react';
 import { render } from 'react-dom';
 
-import { consoleAdvertisement, IS_STAGING, IS_PROD, getRootDomain } from '@utils';
+import { consoleAdvertisement, IS_STAGING, IS_ELECTRON, IS_PROD, getRootDomain } from '@utils';
 
 import Root from './Root';
 
@@ -25,7 +25,11 @@ import Root from './Root';
  *     https://developer.mozilla.org/en-US/docs/Web/API/Document/domain)
  * 4. Since we need run 3 environments we dynamically set the domain to the appropriate hostname.
  */
-document.domain = getRootDomain(document.location.hostname);
+
+// There is no location.hostname in electron renderer.
+if (!IS_ELECTRON) {
+  document.domain = getRootDomain(document.location.hostname);
+}
 
 // disables drag-and-drop due to potential security issues by Cure53 recommendation
 const doNothing = (event: DragEvent) => {


### PR DESCRIPTION
Building for electron renders a white page with the following error:
```
Uncaught DOMException: Failed to set the 'domain' property on 'Document': '' is an empty domain.
    at Object.<anonymous> (file:///Applications/MyCrypto.app/Contents/Resources/app.asar/main.7896c1edf3a5be136203.js:1:1587510)
```

Since electron builds have no `location.hostname` we remove the setting when building `electron`.