### PR TITLE
Fix timestamp for transactions on status page

### DIFF
--- a/src/components/TransactionFlow/TxReceipt.tsx
+++ b/src/components/TransactionFlow/TxReceipt.tsx
@@ -459,7 +459,7 @@ export const TxReceiptUI = ({
             {displayTxReceipt &&
               (timestamp !== 0 ? (
                 <div>
-                  {<TimeElapsed value={timestamp * 1000} />}
+                  {<TimeElapsed value={timestamp} />}
                   <br /> {localTimestamp}
                 </div>
               ) : (


### PR DESCRIPTION
This fixes the timestamp shown on the transaction status page. Currently, the time is multiplied by `1000` which results in a date far into the future ([example](https://mycryptobuilds.com/c0809e40e763a9dad7af0b695f23604cde8a4241/#/tx-status/?hash=0xc38e5a4e49d87b4e99a370efdb4c026f2cf5a8edcb09150e2d5771172220bc9a)). `date-fns` works with normal (second-based) Unix timestamps instead of the default millisecond-based timestamps that JavaScript uses, so the time shouldn't be multiplied.

Fixed example: https://mycryptobuilds.com/pr/3533/#/tx-status/?hash=0xc38e5a4e49d87b4e99a370efdb4c026f2cf5a8edcb09150e2d5771172220bc9a