### PR TITLE
Fixes an issue with networks unindexable by name

### DIFF
--- a/src/services/EthService/network/__tests__/helpers.spec.ts
+++ b/src/services/EthService/network/__tests__/helpers.spec.ts
@@ -1,0 +1,51 @@
+import { fNetworks } from '@fixtures';
+import { WalletId } from '@types';
+
+import {
+  createCustomNodeProvider,
+  createFallbackNetworkProviders,
+  getDPath,
+  getDPaths
+} from '../helpers';
+
+describe('getDPaths', () => {
+  it('correctly handles wallet-specified dpaths', () => {
+    const actual = getDPaths(fNetworks, WalletId.LEDGER_NANO_S);
+    expect(actual).toStrictEqual([
+      {
+        label: 'Ledger (ETH)',
+        value: "m/44'/60'/0'"
+      }
+    ]);
+  });
+});
+
+describe('getDPath', () => {
+  it('correctly handles wallet-specified getDPath', () => {
+    const actual = getDPath(fNetworks[0], WalletId.LEDGER_NANO_S);
+    expect(actual).toStrictEqual({
+      label: 'Ledger (ETH)',
+      value: "m/44'/60'/0'"
+    });
+  });
+});
+
+describe('createFallbackNetworkProviders', () => {
+  const fallbackProvider = createFallbackNetworkProviders(fNetworks[0]);
+  it('creates a baseProvider with the network', () => {
+    expect(fallbackProvider).toHaveProperty('ready');
+  });
+
+  // Fallback provider includes a list of providers to fallback to,
+  // which is the main difference between fallback provider and typical ethers.js provider
+  it('extends the baseProvider to be a valid fallbackProvider', () => {
+    expect(fallbackProvider.providers).toHaveLength(2);
+  });
+});
+
+describe('createCustomNodeProvider', () => {
+  it('creates a baseProvider with the network', () => {
+    const provider = createCustomNodeProvider(fNetworks[0]);
+    expect(provider).toHaveProperty('ready');
+  });
+});


### PR DESCRIPTION
### Description
ethers.js allows you to add networks using network id for some networks, but not for networks that are unsupported. Noticed this issue first while looking into #3532. 