### PR TITLE
Trigger onChange when submitting in lookup field using Enter key

### DIFF
--- a/src/components/GeneralLookupField.tsx
+++ b/src/components/GeneralLookupField.tsx
@@ -170,6 +170,7 @@ const GeneralLookupField = ({
     const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.keyCode === 13) {
         handleNewInput(inputValue.current);
+        if (onChange) onChange(inputValue.current);
       }
     };
 


### PR DESCRIPTION
Fixes an issue with the contract interaction page where you couldn't enter an ABI if you input the contract address and pressed Enter to submit.