### PR TITLE
Fix bug resulting in missing asset data (icons, rates & names) after screen lock, settings import, and settings reset

### DIFF
--- a/src/database/generateDefaultValues.spec.ts
+++ b/src/database/generateDefaultValues.spec.ts
@@ -5,7 +5,7 @@ import { NETWORKS_CONFIG, SCHEMA_BASE } from './data';
 import { createDefaultValues } from './generateDefaultValues';
 
 const DAI = {
-  address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+  contractAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
   ticker: 'DAI',
   decimal: 18,
   name: 'Dai Stablecoin v2.0',

--- a/src/database/generateDefaultValues.ts
+++ b/src/database/generateDefaultValues.ts
@@ -152,9 +152,13 @@ const addTokensToAssets = add(LSKeys.ASSETS)(
       decimal: a.decimal,
       ticker: a.ticker,
       networkId: id,
-      contractAddress: a.address,
+      contractAddress: a.contractAddress,
       type: 'erc20',
-      isCustom: a.isCustom
+      isCustom: a.isCustom,
+      mappings: a.mappings,
+      social: a.social,
+      whitepaper: a.whitepaper,
+      website: a.website
     });
 
     // From { ETH: { tokens: [ {<tokens>} ] }}

--- a/src/features/Settings/Import/Import.tsx
+++ b/src/features/Settings/Import/Import.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { ContentPanel } from '@components';
 import { ScreenLockContext } from '@features/ScreenLock';
-import { ISettingsContext, useSettings } from '@services/Store';
+import { useAssets, useSettings } from '@services/Store';
 import { translateRaw } from '@translations';
-import { withHook } from '@utils';
 
 import { ImportBox, ImportSuccess } from './components';
 
@@ -20,65 +19,59 @@ export interface PanelProps {
   onNext(): void;
 }
 
-export class Import extends React.Component<RouteComponentProps & ISettingsContext> {
-  public state = { step: 0 };
+export const Import = (props: RouteComponentProps) => {
+  const { assets } = useAssets();
+  const { importStorage } = useSettings();
+  const [step, setStep] = useState(0);
 
-  public render() {
-    const { history } = this.props;
-    const { step } = this.state;
-    const steps = [
-      {
-        heading: translateRaw('SETTINGS_IMPORT_HEADING'),
-        component: ImportBox,
-        backOption: history.goBack
-      },
-      {
-        heading: translateRaw('SETTINGS_IMPORT_SUCCESS_HEADING'),
-        component: ImportSuccess,
-        backOption: this.regressStep
-      }
-    ];
-    const onBack = steps[step].backOption;
-    const Step = steps[step].component;
-    return (
-      <ContentPanel
-        width={560}
-        onBack={onBack}
-        heading={steps[step].heading}
-        stepper={{
-          current: step + 1,
-          total: steps.length
-        }}
-      >
-        <Content>
-          <ScreenLockContext.Consumer>
-            {({ resetEncrypted }) => (
-              <Step
-                onNext={this.advanceStep}
-                importCache={(cache: string) => {
-                  const result = this.props.importStorage(cache);
-                  if (result) {
-                    resetEncrypted();
-                  }
-                  return result;
-                }}
-              />
-            )}
-          </ScreenLockContext.Consumer>
-        </Content>
-      </ContentPanel>
-    );
-  }
+  const { history } = props;
 
-  private advanceStep = () =>
-    this.setState(() => ({
-      step: 1
-    }));
+  const advanceStep = () => setStep(1);
 
-  private regressStep = () =>
-    this.setState((prevState: any) => ({
-      step: Math.min(0, prevState.step - 1)
-    }));
-}
+  const regressStep = () => setStep(Math.min(0, step - 1));
 
-export default withHook(useSettings)(withRouter(Import));
+  const steps = [
+    {
+      heading: translateRaw('SETTINGS_IMPORT_HEADING'),
+      component: ImportBox,
+      backOption: history.goBack
+    },
+    {
+      heading: translateRaw('SETTINGS_IMPORT_SUCCESS_HEADING'),
+      component: ImportSuccess,
+      backOption: regressStep
+    }
+  ];
+  const onBack = steps[step].backOption;
+  const Step = steps[step].component;
+  return (
+    <ContentPanel
+      width={560}
+      onBack={onBack}
+      heading={steps[step].heading}
+      stepper={{
+        current: step + 1,
+        total: steps.length
+      }}
+    >
+      <Content>
+        <ScreenLockContext.Consumer>
+          {({ resetEncrypted }) => (
+            <Step
+              onNext={advanceStep}
+              importCache={(cache: string) => {
+                const result = importStorage(cache)(assets);
+                if (result) {
+                  resetEncrypted();
+                }
+                return result;
+              }}
+            />
+          )}
+        </ScreenLockContext.Consumer>
+      </Content>
+    </ContentPanel>
+  );
+};
+
+export default withRouter(Import);

--- a/src/services/Store/DataManager/DataProvider.tsx
+++ b/src/services/Store/DataManager/DataProvider.tsx
@@ -75,10 +75,11 @@ export const DataProvider: React.FC = ({ children }) => {
 
   const resetAppDb = useCallback(
     (newDb = defaultValues) => {
-      resetDb(newDb); // Reset the persistence layer
+      const persistedNewDb = { ...newDb, assets: appState.assets };
+      resetDb(persistedNewDb); // Reset the persistence layer, but keep assets available due to improve data availability in-app
       dispatch({
         type: ActionT.RESET,
-        payload: { data: marshallState(newDb) } as ActionPayload<DataStore>
+        payload: { data: marshallState(persistedNewDb) } as ActionPayload<DataStore>
       }); // Reset the Context
     },
     [defaultValues]

--- a/src/services/Store/DataManager/actions.ts
+++ b/src/services/Store/DataManager/actions.ts
@@ -7,6 +7,7 @@ import {
   DataStoreEntry,
   DataStoreItem,
   DSKeys,
+  ExtendedAsset,
   ISettings,
   LocalStorage,
   LSKeys,
@@ -79,12 +80,16 @@ export function ActionFactory(model: DSKeys, dispatch: Dispatch<ActionV>, state:
     });
   };
 
-  const importStorage = (data: string) => {
+  const importStorage = (data: string) => (assets?: ExtendedAsset[]) => {
     const d = JSON.parse(data);
+    const newImport = {
+      ...d,
+      assets
+    };
     // @todo: perfom version and validity check.
     dispatch({
       type: ActionT.RESET,
-      payload: createPayload(model)(marshallState(d))
+      payload: createPayload(model)(marshallState(newImport))
     });
   };
 

--- a/src/services/Store/DataManager/utils.ts
+++ b/src/services/Store/DataManager/utils.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import isEmpty from 'ramda/src/isEmpty';
 import { ValuesType } from 'utility-types';
 
@@ -16,7 +17,6 @@ import {
   Network,
   NetworkId,
   NetworkNodes,
-  TAddress,
   TUuid
 } from '@types';
 import { makeExplorer } from '@utils';
@@ -51,10 +51,7 @@ export const mergeConfigWithLocalStorage = (
   const lsAssets = objToArray(ls[LSKeys.ASSETS]) as ExtendedAsset[];
   lsContracts.forEach((c) => config[c.networkId] && config[c.networkId].contracts.push(c));
   lsAssets.forEach(
-    (a) =>
-      a.networkId &&
-      config[a.networkId] &&
-      config[a.networkId].tokens.push({ ...a, address: a.contractAddress as TAddress })
+    (a) => a.networkId && config[a.networkId] && config[a.networkId].tokens.push(cloneDeep(a))
   );
 
   // add selected and custom nodes per network

--- a/src/services/Store/Settings/useSettings.spec.tsx
+++ b/src/services/Store/Settings/useSettings.spec.tsx
@@ -43,13 +43,13 @@ describe('useSettings', () => {
 
   it('importStorage()', () => {
     const mockExport = jest.fn().mockImplementation(() => fLocalStorage);
-    const mockImport = jest.fn();
+    const mockImport = jest.fn().mockImplementation(() => () => true);
     const { result } = renderUseAccounts({
       createActions: jest.fn(() => ({ exportStorage: mockExport, importStorage: mockImport })),
       settings: fSettings
     });
     const newLS = JSON.stringify({ ...fLocalStorage, settings: fSettings });
-    result.current.importStorage(newLS);
+    result.current.importStorage(newLS)();
     expect(mockImport).toHaveBeenCalledWith(newLS);
   });
 

--- a/src/services/Store/Settings/useSettings.tsx
+++ b/src/services/Store/Settings/useSettings.tsx
@@ -1,8 +1,7 @@
 import { useContext } from 'react';
 
-import { IRates, ISettings, LSKeys, TFiatTicker, TUuid } from '@types';
+import { ExtendedAsset, IRates, ISettings, LSKeys, TFiatTicker, TUuid } from '@types';
 
-import { useAssets } from '../Asset';
 import { DataContext } from '../DataManager';
 
 export interface ISettingsContext {
@@ -27,7 +26,6 @@ const isValidImportFunc = (importedCache: string, localStorage: string) => {
   try {
     const parsedImport = JSON.parse(importedCache);
     const parsedLocalStorage = JSON.parse(localStorage);
-
     // @todo: Do migration instead of failing
     if (parsedImport.version !== parsedLocalStorage.version) {
       throw new Error(
@@ -46,7 +44,6 @@ const isValidImportFunc = (importedCache: string, localStorage: string) => {
 
 function useSettings() {
   const { createActions, settings } = useContext(DataContext);
-  const { assets } = useAssets();
   const model = createActions(LSKeys.SETTINGS);
 
   const language = settings.language || '';
@@ -55,7 +52,7 @@ function useSettings() {
 
   const exportStorage = () => JSON.stringify(model.exportStorage());
 
-  const importStorage = (toImport: string): boolean => {
+  const importStorage = (toImport: string) => (assets?: ExtendedAsset[]): boolean => {
     const ls = exportStorage();
     if (!isValidImportFunc(toImport, String(ls))) return false;
 

--- a/src/services/Store/Settings/useSettings.tsx
+++ b/src/services/Store/Settings/useSettings.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 
 import { IRates, ISettings, LSKeys, TFiatTicker, TUuid } from '@types';
 
+import { useAssets } from '../Asset';
 import { DataContext } from '../DataManager';
 
 export interface ISettingsContext {
@@ -45,6 +46,7 @@ const isValidImportFunc = (importedCache: string, localStorage: string) => {
 
 function useSettings() {
   const { createActions, settings } = useContext(DataContext);
+  const { assets } = useAssets();
   const model = createActions(LSKeys.SETTINGS);
 
   const language = settings.language || '';
@@ -57,7 +59,7 @@ function useSettings() {
     const ls = exportStorage();
     if (!isValidImportFunc(toImport, String(ls))) return false;
 
-    model.importStorage(toImport);
+    model.importStorage(toImport)(assets);
     return true;
   };
 

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,7 +1,6 @@
 import { Omit, Overwrite, Subtract } from 'utility-types';
 
-import { TAddress } from './address';
-import { Asset, TTicker } from './asset';
+import { ExtendedAsset, TTicker } from './asset';
 import { BlockExplorer } from './blockExplorer';
 import { Contract } from './contract';
 import { DPathFormats } from './dPath';
@@ -10,11 +9,9 @@ import { NetworkId } from './networkId';
 import { NodeOptions } from './node';
 import { TUuid } from './uuid';
 
-type AssetPropsMissingInLegacy = Pick<Asset, 'networkId'> | Pick<Asset, 'contractAddress'>;
-interface AssetPropsInLegacy {
-  address: TAddress;
-}
-export type AssetLegacy = Subtract<Asset, AssetPropsMissingInLegacy> & AssetPropsInLegacy;
+type AssetPropsMissingInLegacy = Pick<ExtendedAsset, 'networkId'>;
+
+export type AssetLegacy = Subtract<ExtendedAsset, AssetPropsMissingInLegacy>;
 export type ContractLegacy = Omit<Contract, 'networkId'> & { uuid?: TUuid };
 
 export interface Network {


### PR DESCRIPTION
[ch7317]

### Description
Fixed some bugs that result in missing asset data (icons, rates & other asset data) after screen lock & refresh, settings import, and settings hard reset.

### Changes
- Pass & handle existing assets as props when refreshing local storage.
- Refactor settings import to functional component just cause.
- Expanded `AssetLegacy` type to cover optional `ExtendedAsset` params.