### PR TITLE
SC should not pass props to DOM element

### DIFF
--- a/src/components/CollapsibleTable.tsx
+++ b/src/components/CollapsibleTable.tsx
@@ -32,7 +32,7 @@ interface CollapsedGroups {
 }
 
 interface Flippable {
-  isFlipped?: boolean;
+  $isFlipped?: boolean;
 }
 
 interface Props extends CollapsibleTableData {
@@ -117,7 +117,7 @@ GroupHeading.defaultProps = {
 const GroupHeadingCaret = styled(Icon)<Flippable>`
   margin-left: 0.5em;
   ${(props) =>
-    props.isFlipped &&
+    props.$isFlipped &&
     `
     svg {
       transform: rotateX(180deg)
@@ -176,7 +176,7 @@ export class CollapsibleTable extends Component<Props, State> {
           // The element being iterated on is a group heading.
           <GroupHeading key={index} onClick={this.toggleCollapseGroup.bind(this, cardData)}>
             {cardData}
-            <GroupHeadingCaret icon="navDownCaret" isFlipped={collapsedGroups[cardData]} />
+            <GroupHeadingCaret icon="navDownCaret" $isFlipped={collapsedGroups[cardData]} />
           </GroupHeading>
         ) : (
           // The element being iterated on is table data.


### PR DESCRIPTION
When user has an account with transactions and views the dashboard in mobile mode, there is the following error:
```
Warning: React does not recognize the `isFlipped` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isflipped` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Use SC transient props to remove the error:
https://styled-components.com/docs/api#transient-props
