### PR TITLE
Membership options changes for release

### DIFF
--- a/src/components/TransactionFlow/TxReceipt.stories.tsx
+++ b/src/components/TransactionFlow/TxReceipt.stories.tsx
@@ -135,7 +135,7 @@ export const transactionReceiptDeFiZap = wrapInProvider(
   </div>
 );
 
-const membershipSelected = MEMBERSHIP_CONFIG[IMembershipId.threemonths];
+const membershipSelected = MEMBERSHIP_CONFIG[IMembershipId.twelvemonths];
 
 export const transactionReceiptMembership = wrapInProvider(
   <div className="sb-container" style={{ maxWidth: '620px' }}>

--- a/src/features/PurchaseMembership/components/MembershipEducation.tsx
+++ b/src/features/PurchaseMembership/components/MembershipEducation.tsx
@@ -187,9 +187,14 @@ const MembershipEducation = withRouter(({ history }) => {
         </ListContainer>
         <Title>{translate('WHAT_IT_COST')}</Title>
         <PlanContainer>
-          {Object.keys(MEMBERSHIP_CONFIG).map((key) => (
-            <MembershipPlanCard key={key} plan={MEMBERSHIP_CONFIG[key as IMembershipId]} />
-          ))}
+          {Object.values(MEMBERSHIP_CONFIG)
+            .filter(({ disabled }) => !disabled)
+            .map((membershipConfig) => (
+              <MembershipPlanCard
+                key={membershipConfig.key}
+                plan={MEMBERSHIP_CONFIG[membershipConfig.key as IMembershipId]}
+              />
+            ))}
         </PlanContainer>
         <SButton onClick={handleSubmit}>{translate('BUY_MEMBERSHIP_NOW')}</SButton>
         <Disclaimer>{translate('MEMBERSHIP_NOTE')}</Disclaimer>

--- a/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
+++ b/src/features/PurchaseMembership/components/MembershipPurchaseForm.tsx
@@ -80,7 +80,7 @@ export const MembershipFormUI = ({
 }: UIProps) => {
   const { getAssetByUUID } = useAssets();
   const { defaultAccount } = useContext(StoreContext);
-  const defaultMembership = MEMBERSHIP_CONFIG[IMembershipId.sixmonths];
+  const defaultMembership = MEMBERSHIP_CONFIG[IMembershipId.twelvemonths];
   const defaultAsset = (getAssetByUUID(defaultMembership.assetUUID as TUuid) || {}) as Asset;
   const initialFormikValues: MembershipSimpleTxFormFull = {
     membershipSelected: defaultMembership,

--- a/src/features/PurchaseMembership/components/MembershipSelector.test.tsx
+++ b/src/features/PurchaseMembership/components/MembershipSelector.test.tsx
@@ -35,6 +35,7 @@ describe('MembershipSelector', () => {
 
     // Ensure each plan is displayed in the list.
     Object.values(MEMBERSHIP_CONFIG)
+      .filter(({ disabled }) => !disabled)
       .map((p) => p.title)
       .forEach((t) => expect(getByText(t)).toBeInTheDocument());
   });

--- a/src/features/PurchaseMembership/components/MembershipSelector.tsx
+++ b/src/features/PurchaseMembership/components/MembershipSelector.tsx
@@ -43,7 +43,9 @@ export interface MembershipSelectorProps {
 }
 
 export default function MembershipSelector({ name, value, onSelect }: MembershipSelectorProps) {
-  const options: IMembershipConfig[] = Object.values(MEMBERSHIP_CONFIG);
+  const options: IMembershipConfig[] = Object.values(MEMBERSHIP_CONFIG).filter(
+    ({ disabled }) => !disabled
+  );
 
   return (
     <Selector<IMembershipConfig>

--- a/src/features/PurchaseMembership/config.ts
+++ b/src/features/PurchaseMembership/config.ts
@@ -4,8 +4,8 @@ import step2SVG from '@assets/images/icn-receive.svg';
 import step1SVG from '@assets/images/icn-send.svg';
 import lifetimeIcon from '@assets/images/membership/membership-lifetime.svg';
 import onemonthIcon from '@assets/images/membership/membership-onemonth.svg';
-import sixMonthsIcon from '@assets/images/membership/membership-sixmonths.svg';
-import threemonthsIcon from '@assets/images/membership/membership-threemonths.svg';
+//import sixMonthsIcon from '@assets/images/membership/membership-sixmonths.svg';
+//import threemonthsIcon from '@assets/images/membership/membership-threemonths.svg';
 import twelveMonthsIcon from '@assets/images/membership/membership-twelvemonths.svg';
 import { DAIUUID, ETHUUID } from '@config';
 import translate, { translateRaw } from '@translations';
@@ -47,8 +47,8 @@ export interface MembershipExpiry {
 
 export enum IMembershipId {
   onemonth = 'onemonth',
-  threemonths = 'threemonths',
-  sixmonths = 'sixmonths',
+  //threemonths = 'threemonths',
+  //sixmonths = 'sixmonths',
   twelvemonths = 'twelvemonths',
   lifetime = 'lifetime'
 }
@@ -69,31 +69,31 @@ export const MEMBERSHIP_CONFIG: IMembershipConfigObject = {
     discountNotice: ''
   },
 
-  threemonths: {
-    title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '3' }),
-    key: IMembershipId.threemonths,
-    contractAddress: '0xfe58C642A3F703e7Dc1060B3eE02ED4619046125',
-    description: '',
-    icon: threemonthsIcon,
-    price: '10.5',
-    discount: '10',
-    assetUUID: DAIUUID,
-    durationInDays: 90,
-    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '10%' })
-  },
+  // threemonths: {
+  //   title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '3' }),
+  //   key: IMembershipId.threemonths,
+  //   contractAddress: '0xfe58C642A3F703e7Dc1060B3eE02ED4619046125',
+  //   description: '',
+  //   icon: threemonthsIcon,
+  //   price: '10.5',
+  //   discount: '10',
+  //   assetUUID: DAIUUID,
+  //   durationInDays: 90,
+  //   discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '10%' })
+  // },
 
-  sixmonths: {
-    title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '6' }),
-    key: IMembershipId.sixmonths,
-    contractAddress: '0x7a84f1074B5929cBB7bd08Fb450CF9Fb22bf5329',
-    description: '',
-    icon: sixMonthsIcon,
-    price: '18',
-    discount: '20',
-    assetUUID: DAIUUID,
-    durationInDays: 180,
-    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '20%' })
-  },
+  // sixmonths: {
+  //   title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '6' }),
+  //   key: IMembershipId.sixmonths,
+  //   contractAddress: '0x7a84f1074B5929cBB7bd08Fb450CF9Fb22bf5329',
+  //   description: '',
+  //   icon: sixMonthsIcon,
+  //   price: '18',
+  //   discount: '20',
+  //   assetUUID: DAIUUID,
+  //   durationInDays: 180,
+  //   discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '20%' })
+  // },
 
   twelvemonths: {
     title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '12' }),
@@ -114,7 +114,7 @@ export const MEMBERSHIP_CONFIG: IMembershipConfigObject = {
     contractAddress: '0x098D8b363933D742476DDd594c4A5a5F1a62326a',
     description: '',
     icon: lifetimeIcon,
-    price: '5',
+    price: '2',
     assetUUID: ETHUUID,
     durationInDays: 36500,
     discountNotice: translateRaw('MEMBERSHIP_LIFETIME_DESC')

--- a/src/features/PurchaseMembership/config.ts
+++ b/src/features/PurchaseMembership/config.ts
@@ -4,8 +4,8 @@ import step2SVG from '@assets/images/icn-receive.svg';
 import step1SVG from '@assets/images/icn-send.svg';
 import lifetimeIcon from '@assets/images/membership/membership-lifetime.svg';
 import onemonthIcon from '@assets/images/membership/membership-onemonth.svg';
-//import sixMonthsIcon from '@assets/images/membership/membership-sixmonths.svg';
-//import threemonthsIcon from '@assets/images/membership/membership-threemonths.svg';
+import sixMonthsIcon from '@assets/images/membership/membership-sixmonths.svg';
+import threemonthsIcon from '@assets/images/membership/membership-threemonths.svg';
 import twelveMonthsIcon from '@assets/images/membership/membership-twelvemonths.svg';
 import { DAIUUID, ETHUUID } from '@config';
 import translate, { translateRaw } from '@translations';
@@ -22,6 +22,7 @@ export interface IMembershipConfig {
   assetUUID: string;
   durationInDays: number;
   discountNotice: string;
+  disabled?: boolean;
 }
 
 export type IMembershipConfigObject = {
@@ -47,8 +48,8 @@ export interface MembershipExpiry {
 
 export enum IMembershipId {
   onemonth = 'onemonth',
-  //threemonths = 'threemonths',
-  //sixmonths = 'sixmonths',
+  threemonths = 'threemonths',
+  sixmonths = 'sixmonths',
   twelvemonths = 'twelvemonths',
   lifetime = 'lifetime'
 }
@@ -69,31 +70,33 @@ export const MEMBERSHIP_CONFIG: IMembershipConfigObject = {
     discountNotice: ''
   },
 
-  // threemonths: {
-  //   title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '3' }),
-  //   key: IMembershipId.threemonths,
-  //   contractAddress: '0xfe58C642A3F703e7Dc1060B3eE02ED4619046125',
-  //   description: '',
-  //   icon: threemonthsIcon,
-  //   price: '10.5',
-  //   discount: '10',
-  //   assetUUID: DAIUUID,
-  //   durationInDays: 90,
-  //   discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '10%' })
-  // },
+  threemonths: {
+    title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '3' }),
+    key: IMembershipId.threemonths,
+    contractAddress: '0xfe58C642A3F703e7Dc1060B3eE02ED4619046125',
+    description: '',
+    icon: threemonthsIcon,
+    price: '10.5',
+    discount: '10',
+    disabled: true,
+    assetUUID: DAIUUID,
+    durationInDays: 90,
+    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '~12.5%' })
+  },
 
-  // sixmonths: {
-  //   title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '6' }),
-  //   key: IMembershipId.sixmonths,
-  //   contractAddress: '0x7a84f1074B5929cBB7bd08Fb450CF9Fb22bf5329',
-  //   description: '',
-  //   icon: sixMonthsIcon,
-  //   price: '18',
-  //   discount: '20',
-  //   assetUUID: DAIUUID,
-  //   durationInDays: 180,
-  //   discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '20%' })
-  // },
+  sixmonths: {
+    title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '6' }),
+    key: IMembershipId.sixmonths,
+    contractAddress: '0x7a84f1074B5929cBB7bd08Fb450CF9Fb22bf5329',
+    description: '',
+    icon: sixMonthsIcon,
+    price: '18',
+    discount: '20',
+    disabled: true,
+    assetUUID: DAIUUID,
+    durationInDays: 180,
+    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '~25%' })
+  },
 
   twelvemonths: {
     title: translateRaw('MEMBERSHIP_MONTHS', { $duration: '12' }),
@@ -105,7 +108,7 @@ export const MEMBERSHIP_CONFIG: IMembershipConfigObject = {
     discount: '40',
     assetUUID: DAIUUID,
     durationInDays: 366,
-    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '40%' })
+    discountNotice: translateRaw('MEMBERSHIP_DISCOUNT', { $percentage: '~37.5%' })
   },
 
   lifetime: {


### PR DESCRIPTION
[ch7346]
### Description
Makes some changes for membership configs. Before this is merged, we need for ch7341 to be done.

###### Changes
- [x] Hide 3 & 6 month membership options.
- [x] Change price of Lifetime membership from 5 to 2 ETH.
- [x] Make the discount amounts for longer memberships more accurate.

###### Screenshots
![image](https://user-images.githubusercontent.com/29407814/101298840-aed1fa80-37e4-11eb-89b7-e0b694d87085.png)
