### PR TITLE
Check if version is <2.0.0 for desktop app

### DIFF
--- a/common/utils/versioning/index.ts
+++ b/common/utils/versioning/index.ts
@@ -61,7 +61,7 @@ export async function getLatestElectronRelease() {
         continue;
       }
       const { versionNumber: nextVersion } = assetObj;
-      if (semver.lt(currentVersion, nextVersion)) {
+      if (semver.lt(currentVersion, nextVersion) && semver.lt(nextVersion, '2.0.0')) {
         return nextVersion;
       }
     }


### PR DESCRIPTION
This prevents versions `>=2.0.0` from showing up as new available version in the desktop app.