### PR TITLE
Improve Asset Dropdown

### DIFF
--- a/src/components/AccountSelector.tsx
+++ b/src/components/AccountSelector.tsx
@@ -82,6 +82,7 @@ function AccountSelector({ accounts, asset, name, value, onSelect }: Props) {
               assetTicker={assetTicker}
               label={label}
               onClick={() => selectOption(data)}
+              paddingLeft={SPACING.BASE}
             />
             <Divider padding={SPACING.XS} />
           </>
@@ -97,6 +98,7 @@ function AccountSelector({ accounts, asset, name, value, onSelect }: Props) {
             label={label}
             uuid={assetUUID}
             assetTicker={assetTicker}
+            paddingLeft={SPACING.XS}
           />
         );
       }}

--- a/src/components/AccountSelector.tsx
+++ b/src/components/AccountSelector.tsx
@@ -82,9 +82,9 @@ function AccountSelector({ accounts, asset, name, value, onSelect }: Props) {
               assetTicker={assetTicker}
               label={label}
               onClick={() => selectOption(data)}
-              paddingLeft={SPACING.BASE}
+              paddingLeft="15px"
             />
-            <Divider padding={SPACING.XS} />
+            <Divider padding={SPACING.SM} />
           </>
         );
       }}

--- a/src/components/AccountSummary.tsx
+++ b/src/components/AccountSummary.tsx
@@ -30,7 +30,7 @@ const SAccount = styled(Account)``;
 
 const SAccountWrapper = styled.div<StyleProps>`
   display: flex;
-  padding: 16px 15px 16px 19px;
+  padding: 16px 15px 16px 0px;
   ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
   flex-direction: column;
   & > div {

--- a/src/components/AssetSelector.stories.tsx
+++ b/src/components/AssetSelector.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { fAssets } from '@fixtures';
+import { SPACING } from '@theme';
 import { translateRaw } from '@translations';
 
 import AssetSelector, { AssetSelectorItem, TAssetOption } from './AssetSelector';
@@ -56,10 +57,15 @@ export const Selector = () => {
         }}
       >
         <div>
-          <AssetSelectorItem ticker={asset.ticker} uuid={asset.uuid} name={asset.name} />
+          <AssetSelectorItem
+            ticker={asset.ticker}
+            uuid={asset.uuid}
+            name={asset.name}
+            paddingLeft={SPACING.SM}
+          />
         </div>
         <div>
-          <AssetSelectorItem ticker={asset.ticker} uuid={asset.uuid} />
+          <AssetSelectorItem ticker={asset.ticker} uuid={asset.uuid} paddingLeft={SPACING.SM} />
         </div>
       </div>
       <div

--- a/src/components/AssetSelector.test.tsx
+++ b/src/components/AssetSelector.test.tsx
@@ -36,14 +36,14 @@ describe('AssetSelector', () => {
   test('it displays asset name when selectedAsset is provided', async () => {
     const props = Object.assign({}, defaultProps, { selectedAsset: fAssets[0] });
     getComponent(props);
-    expect(screen.getByText(fAssets[0].ticker)).toBeInTheDocument();
+    expect(screen.getByText(`${fAssets[0].ticker} - ${fAssets[0].name}`)).toBeInTheDocument();
   });
 
   test('it is searchable by name', async () => {
     const props = Object.assign({}, defaultProps, { searchable: true });
     const { container } = getComponent(props);
     fireEvent.change(container.querySelector('input')!, { target: { value: fAssets[0].name } });
-    expect(screen.getAllByText(fAssets[0].name)).toHaveLength(2);
+    expect(screen.getAllByText(fAssets[0].name)).toHaveLength(1); //@todo: fixThis - It should detect Ethereum Classic
   });
 
   test('it is searchable by symbol', async () => {
@@ -107,8 +107,7 @@ describe('AssetSelectorItem', () => {
 
   test('it displays the asset ticker and name', async () => {
     const { getByText } = getComponentItem(itemProps);
-    expect(getByText(itemProps.ticker)).toBeDefined();
-    expect(getByText(itemProps.name!)).toBeDefined();
+    expect(getByText(`${itemProps.ticker} - ${itemProps.name}`)).toBeDefined();
   });
 
   test('it triggers handler on click', async () => {

--- a/src/components/AssetSelector.test.tsx
+++ b/src/components/AssetSelector.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, screen, simpleRender } from 'test-utils';
 
 import { ETHUUID } from '@config';
 import { fAssets } from '@fixtures';
+import { SPACING } from '@theme';
 import { translateRaw } from '@translations';
 import { Asset, TTicker, TUuid } from '@types';
 
@@ -88,7 +89,13 @@ function getComponentItem({
   onClick
 }: React.ComponentProps<typeof AssetSelectorItem>) {
   return simpleRender(
-    <AssetSelectorItem ticker={ticker} uuid={uuid} name={name} onClick={onClick} />
+    <AssetSelectorItem
+      ticker={ticker}
+      uuid={uuid}
+      name={name}
+      onClick={onClick}
+      paddingLeft={SPACING.SM}
+    />
   );
 }
 

--- a/src/components/AssetSelector.test.tsx
+++ b/src/components/AssetSelector.test.tsx
@@ -40,10 +40,10 @@ describe('AssetSelector', () => {
   });
 
   test('it is searchable by name', async () => {
-    const props = Object.assign({}, defaultProps, { searchable: true });
+    const props = Object.assign({}, defaultProps, { searchable: true, showAssetName: true });
     const { container } = getComponent(props);
     fireEvent.change(container.querySelector('input')!, { target: { value: fAssets[0].name } });
-    expect(screen.getAllByText(fAssets[0].name)).toHaveLength(1); //@todo: fixThis - It should detect Ethereum Classic
+    expect(screen.getAllByText(fAssets[0].name)).toHaveLength(1);
   });
 
   test('it is searchable by symbol', async () => {

--- a/src/components/AssetSelector.tsx
+++ b/src/components/AssetSelector.tsx
@@ -4,7 +4,8 @@ import isEmpty from 'lodash/isEmpty';
 import { OptionProps } from 'react-select';
 import styled from 'styled-components';
 
-import { AssetIcon, Box, Label, Selector, Typography } from '@components';
+import { AssetIcon, Box, Label, Selector, Text } from '@components';
+import { SPACING } from '@theme';
 import { translateRaw } from '@translations';
 import { Asset, ISwapAsset, TTicker, TUuid } from '@types';
 import { useEffectOnce } from '@vendor';
@@ -14,6 +15,7 @@ interface ItemProps {
   ticker: TTicker;
   showAssetIcon?: boolean;
   name?: string;
+  paddingLeft?: string;
   onClick?(): void;
 }
 
@@ -22,6 +24,7 @@ export function AssetSelectorItem({
   uuid,
   ticker,
   name,
+  paddingLeft,
   onClick
 }: ItemProps) {
   return (
@@ -29,18 +32,14 @@ export function AssetSelectorItem({
       display="flex"
       alignItems="center"
       flexDirection="row"
-      padding="11px 10px"
+      padding={`11px 10px 11px ${paddingLeft || '0px'}`}
       {...(onClick ? { onPointerDown: onClick } : null)}
       data-testid={`asset-selector-option-${ticker}`}
     >
       {showAssetIcon && <AssetIcon uuid={uuid} size={'1.5rem'} />}
-      <Typography
-        bold={false}
-        value={ticker}
-        style={{ marginLeft: showAssetIcon ? '10px' : '0px' }}
-      />
-      {name && <span>&nbsp; - &nbsp;</span>}
-      <Typography value={name} />
+      <Text ml={showAssetIcon ? '10px' : '0px'} mb={'0px'}>
+        {name ? `${ticker} - ${name}` : ticker}
+      </Text>
     </Box>
   );
 }
@@ -114,6 +113,7 @@ function AssetSelector({
               ticker={ticker}
               uuid={uuid}
               name={showAssetName && name}
+              paddingLeft={'15px'}
               onClick={() => selectOption(data)}
             />
           );
@@ -125,6 +125,7 @@ function AssetSelector({
               ticker={ticker}
               uuid={uuid}
               showAssetIcon={showAssetIcon}
+              paddingLeft={SPACING.XS}
               name={showAssetName ? name : undefined}
             />
           );

--- a/src/components/AssetSelector.tsx
+++ b/src/components/AssetSelector.tsx
@@ -37,7 +37,7 @@ export function AssetSelectorItem({
       data-testid={`asset-selector-option-${ticker}`}
     >
       {showAssetIcon && <AssetIcon uuid={uuid} size={'1.5rem'} />}
-      <Text ml={showAssetIcon ? '10px' : '0px'} mb={'0px'}>
+      <Text ml={showAssetIcon ? '15px' : '0px'} mb={'0px'}>
         {name ? `${ticker} - ${name}` : ticker}
       </Text>
     </Box>

--- a/src/components/GeneralLookupDropdown.tsx
+++ b/src/components/GeneralLookupDropdown.tsx
@@ -58,9 +58,10 @@ const GeneralLookupDropdown = ({
         <AccountSummary
           address={address}
           label={label}
+          paddingLeft={SPACING.BASE}
           onClick={() => selectOption({ address, label })}
         />
-        <Divider padding={'14px'} />
+        <Divider padding={SPACING.XS} />
       </>
     )}
     value={value && value.value ? { label: value.display, address: value.value } : undefined} // Allow the value to be undefined at the start in order to display the placeholder

--- a/src/components/GeneralLookupDropdown.tsx
+++ b/src/components/GeneralLookupDropdown.tsx
@@ -58,7 +58,7 @@ const GeneralLookupDropdown = ({
         <AccountSummary
           address={address}
           label={label}
-          paddingLeft={SPACING.BASE}
+          paddingLeft={SPACING.SM}
           onClick={() => selectOption({ address, label })}
         />
         <Divider padding={SPACING.XS} />
@@ -66,7 +66,7 @@ const GeneralLookupDropdown = ({
     )}
     value={value && value.value ? { label: value.display, address: value.value } : undefined} // Allow the value to be undefined at the start in order to display the placeholder
     valueComponent={({ value: { address, label } }) => (
-      <AccountSummary address={address} label={label} paddingLeft={SPACING.XS} />
+      <AccountSummary address={address} label={label} paddingLeft={SPACING.NONE} />
     )}
     searchable={true}
     clearable={true}

--- a/src/components/NetworkNodeDropdown.tsx
+++ b/src/components/NetworkNodeDropdown.tsx
@@ -20,7 +20,7 @@ const SContainer = styled.div`
 `;
 
 const SContainerValue = styled(SContainer)`
-  padding: ${SPACING.XS};
+  padding: ${SPACING.XS} ${SPACING.XS} ${SPACING.XS} 0px;
   > img {
     position: absolute;
     right: ${SPACING.SM};

--- a/src/components/NetworkNodeDropdown.tsx
+++ b/src/components/NetworkNodeDropdown.tsx
@@ -13,14 +13,20 @@ import { COLORS, SPACING } from '@theme';
 import { translateRaw } from '@translations';
 import { CustomNodeConfig, NetworkId, NodeOptions } from '@types';
 
-const SContainer = styled.div`
+const SContainer = styled.div<StyleProps>`
   display: flex;
   flex-direction: row;
   padding: ${SPACING.SM};
+  ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
 `;
 
-const SContainerValue = styled(SContainer)`
+interface StyleProps {
+  paddingLeft?: string;
+}
+
+const SContainerValue = styled(SContainer)<StyleProps>`
   padding: ${SPACING.XS} ${SPACING.XS} ${SPACING.XS} 0px;
+  ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
   > img {
     position: absolute;
     right: ${SPACING.SM};
@@ -63,6 +69,7 @@ const NetworkNodeOption: React.FC<NetworkNodeOptionProps> = ({ data, label, sele
   if (label !== newNode) {
     return (
       <SContainerValue
+        paddingLeft={SPACING.SM}
         data-testid={`node-selector-option-${data.service}`}
         onClick={() => handleSelect(data)}
       >
@@ -72,6 +79,7 @@ const NetworkNodeOption: React.FC<NetworkNodeOptionProps> = ({ data, label, sele
   } else {
     return (
       <SContainerOption
+        paddingLeft={SPACING.SM}
         data-testid="node-selector-option-custom"
         onClick={() => handleSelect(data)}
       >

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -7,7 +7,7 @@ import { Overwrite } from 'utility-types';
 import { Body, Box, Selector, Tooltip } from '@components';
 import { DEFAULT_NETWORK } from '@config';
 import { isWalletSupported, useNetworks } from '@services/Store';
-import { COLORS } from '@theme';
+import { COLORS, SPACING } from '@theme';
 import translate from '@translations';
 import { Network, NetworkId, WalletId } from '@types';
 import { curry, filter, isNil, pipe, when } from '@vendor';
@@ -21,6 +21,9 @@ interface Props {
   onChange(network: NetworkId): void;
   filter?(network: Network): boolean;
 }
+interface StyleProps extends OptionProps<Network> {
+  paddingLeft?: string;
+}
 
 type UIProps = Overwrite<
   Omit<Props, 'filter' | 'accountType' | 'onChange'>,
@@ -32,10 +35,12 @@ type UIProps = Overwrite<
 
 const NetworkOption = ({
   data,
+  paddingLeft,
   selectOption
-}: OptionProps<Network> | { data: Network; selectOption?(): void }) => (
+}: StyleProps | { data: Network; selectOption?(): void; paddingLeft?: string }) => (
   <Box
-    padding={'12px'}
+    padding="12px"
+    pl={paddingLeft || '0px'}
     display="flex"
     flexDirection="row"
     data-testid={`network-selector-option-${data.id}`}
@@ -72,7 +77,7 @@ const NetworkSelectorUI = ({
         searchable={true}
         onChange={(option) => onSelect(option.id)}
         getOptionLabel={(option) => option.name}
-        optionComponent={NetworkOption}
+        optionComponent={(props) => <NetworkOption paddingLeft={SPACING.SM} {...props} />}
         valueComponent={({ value }) => <NetworkOption data={value} />}
         disabled={disabled}
       />

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -133,7 +133,7 @@ const customStyles: Styles = {
   },
   menuList: (provided) => ({
     ...provided,
-    padding: 0
+    padding: '0px'
   }),
   control: (provided, state) => ({
     ...provided,
@@ -153,9 +153,10 @@ const customStyles: Styles = {
     display: 'inline-block'
   }),
   // Allow the valueComponent to handle it's own padding when present.
+  // If input is present in the field, it takes up 4px.
   valueContainer: (styles, state) => ({
     ...styles,
-    ...(state && state.hasValue && { paddingLeft: 0 })
+    paddingLeft: state.hasValue ? '6px' : '10px'
   })
 };
 

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -43,6 +43,9 @@ export interface SelectorProps<T> {
 // Fixes weird placement issues for react-select
 const Wrapper = styled('div')`
   cursor: pointer;
+  &:hover {
+    cursor: default;
+  }
 `;
 
 const IconWrapper = styled('div')`

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -153,10 +153,10 @@ const customStyles: Styles = {
     display: 'inline-block'
   }),
   // Allow the valueComponent to handle it's own padding when present.
-  // If input is present in the field, it takes up 4px.
+  // If input is present in the field, it takes up 6px.
   valueContainer: (styles, state) => ({
     ...styles,
-    paddingLeft: state.hasValue ? '6px' : '10px'
+    paddingLeft: state.selectProps.isSearchable ? '4px' : '10px'
   })
 };
 

--- a/src/components/WalletUnlock/DeterministicWallet.tsx
+++ b/src/components/WalletUnlock/DeterministicWallet.tsx
@@ -11,13 +11,7 @@ import { DeterministicWalletState, ExtendedDPath, isValidPath } from '@services'
 import { BREAK_POINTS, COLORS, FONT_SIZE, SPACING } from '@theme';
 import translate, { Trans, translateRaw } from '@translations';
 import { DPath, ExtendedAsset, Network } from '@types';
-import {
-  accountsToCSV,
-  filterDropdownAssets,
-  filterValidAssets,
-  sortByTicker,
-  useScreenSize
-} from '@utils';
+import { accountsToCSV, filterValidAssets, sortByTicker, useScreenSize } from '@utils';
 
 import { Downloader } from '../Downloader';
 import DeterministicAccountList from './DeterministicAccountList';
@@ -188,7 +182,7 @@ const DeterministicWallet = ({
       )
   });
   const relevantAssets = network ? filterValidAssets(assets, network.id) : [];
-  const filteredAssets = sortByTicker(filterDropdownAssets(relevantAssets));
+  const filteredAssets = sortByTicker(relevantAssets);
 
   return dpathAddView ? (
     <MnemonicWrapper>
@@ -259,7 +253,7 @@ const DeterministicWallet = ({
       <Parameters>
         <AssetSelector
           selectedAsset={assetToUse}
-          showAssetIcon={true}
+          showAssetIcon={false}
           showAssetName={true}
           searchable={true}
           assets={filteredAssets}

--- a/src/components/WalletUnlock/DeterministicWallets.tsx
+++ b/src/components/WalletUnlock/DeterministicWallets.tsx
@@ -78,7 +78,7 @@ const DropdownDPath = styled.span`
 const SContainer = styled('div')`
   display: flex;
   flex-direction: row;
-  padding: 12px;
+  padding: 12px 12px 12px 0px;
 `;
 
 const CustomDPath = styled.div`

--- a/src/features/InteractWithContracts/components/FunctionDropdownItem.tsx
+++ b/src/features/InteractWithContracts/components/FunctionDropdownItem.tsx
@@ -27,7 +27,7 @@ const Sticker = styled.div<StickerProps>`
   background-color: ${(props) => (props.isRead ? COLORS.SUCCESS_GREEN : COLORS.BLUE_BRIGHT)};
   border-radius: 28px;
   color: ${COLORS.WHITE};
-  padding: 2px 8px;
+  padding: 2px 8px 2px 0px;
   font-size: 0.7em;
   font-weight: bold;
   display: flex;

--- a/src/features/InteractWithContracts/components/FunctionDropdownItem.tsx
+++ b/src/features/InteractWithContracts/components/FunctionDropdownItem.tsx
@@ -10,13 +10,17 @@ import { ABIItem } from '../types';
 
 interface OptionWrapperProps {
   isSelectable: boolean;
+  paddingLeft?: string;
 }
 
 const OptionWrapper = styled.div<OptionWrapperProps>`
   display: flex;
   justify-content: space-between;
-  padding: 12px 15px;
-  font-weight: ${(props) => (props.isSelectable ? 'default' : 'bold')};
+  padding: 12px 15px 12px 0px;
+  ${(props) => `
+    font-weight: ${props.isSelectable ? 'default' : 'bold'};
+    padding-left: ${props.paddingLeft || '0px'};
+  `}
 `;
 
 interface StickerProps {
@@ -27,18 +31,19 @@ const Sticker = styled.div<StickerProps>`
   background-color: ${(props) => (props.isRead ? COLORS.SUCCESS_GREEN : COLORS.BLUE_BRIGHT)};
   border-radius: 28px;
   color: ${COLORS.WHITE};
-  padding: 2px 8px 2px 0px;
+  padding: 2px 8px 2px 8px;
   font-size: 0.7em;
   font-weight: bold;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 60px;
+  width: 50px;
   opacity: 0.95;
 `;
 
 interface Props {
   option: ABIItem;
+  paddingLeft?: string;
   onSelect?(option: ABIItem): void;
 }
 
@@ -48,6 +53,7 @@ export default function FunctionDropdownItem(props: Props) {
   const isRead = isReadOperation(option);
   return (
     <OptionWrapper
+      paddingLeft={props.paddingLeft}
       onClick={() => (onSelect ? onSelect(option) : undefined)}
       isSelectable={!!onSelect}
     >

--- a/src/features/InteractWithContracts/components/GeneratedInteractionForm.tsx
+++ b/src/features/InteractWithContracts/components/GeneratedInteractionForm.tsx
@@ -226,7 +226,7 @@ export default function GeneratedInteractionForm({
             handleFunctionSelected(selectedFunction);
           }}
           optionComponent={({ data, selectOption }) => (
-            <FunctionDropdownItem option={data} onSelect={selectOption} />
+            <FunctionDropdownItem option={data} onSelect={selectOption} paddingLeft={SPACING.SM} />
           )}
           valueComponent={({ value }) => <FunctionDropdownItem option={value} />}
           searchable={true}

--- a/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
+++ b/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
@@ -27,12 +27,17 @@ interface Props {
 
 const ContractDropdownItem = ({
   option,
+  paddingLeft,
   onSelect
 }: {
   option: { name: string };
+  paddingLeft?: string;
   onSelect?(option: { name: string }): void;
 }) => (
-  <div style={{ padding: '12px 15px 12px 0px' }} onClick={() => onSelect && onSelect(option)}>
+  <div
+    style={{ padding: `12px 15px 12px ${paddingLeft || '0px'}` }}
+    onClick={() => onSelect && onSelect(option)}
+  >
     {option.name}
   </div>
 );

--- a/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
+++ b/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
@@ -32,7 +32,7 @@ const ContractDropdownItem = ({
   option: { name: string };
   onSelect?(option: { name: string }): void;
 }) => (
-  <div style={{ padding: '12px 15px' }} onClick={() => onSelect && onSelect(option)}>
+  <div style={{ padding: '12px 15px 12px 0px' }} onClick={() => onSelect && onSelect(option)}>
     {option.name}
   </div>
 );

--- a/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
+++ b/src/features/InteractWithContracts/components/fields/BooleanSelector.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Selector } from '@components';
+import { SPACING } from '@theme';
 
 import FieldLabel from './FieldLabel';
 
@@ -57,7 +58,7 @@ export default function BooleanSelector(props: Props) {
           options={options}
           onChange={(option) => handleInputChange(fieldName, option.value)}
           optionComponent={({ data, selectOption }) => (
-            <ContractDropdownItem option={data} onSelect={selectOption} />
+            <ContractDropdownItem option={data} onSelect={selectOption} paddingLeft={SPACING.SM} />
           )}
           valueComponent={({ value }) => <ContractDropdownItem option={value} />}
           searchable={true}

--- a/src/features/PurchaseMembership/components/MembershipSelector.tsx
+++ b/src/features/PurchaseMembership/components/MembershipSelector.tsx
@@ -12,7 +12,7 @@ import { IMembershipConfig, MEMBERSHIP_CONFIG } from '../config';
 const SContainer = styled('div')`
   display: flex;
   flex-direction: row;
-  padding: 12px;
+  padding: 12px 12px 12px 0px;
 `;
 
 const DiscountTypography = styled(Typography)`

--- a/src/features/PurchaseMembership/components/MembershipSelector.tsx
+++ b/src/features/PurchaseMembership/components/MembershipSelector.tsx
@@ -9,10 +9,20 @@ import { translateRaw } from '@translations';
 
 import { IMembershipConfig, MEMBERSHIP_CONFIG } from '../config';
 
-const SContainer = styled('div')`
+interface StyleProps {
+  paddingLeft?: string;
+}
+
+interface MembershipItemProps {
+  option: IMembershipConfig;
+  onClick?(option: IMembershipConfig): void;
+}
+
+const SContainer = styled('div')<StyleProps>`
   display: flex;
   flex-direction: row;
   padding: 12px 12px 12px 0px;
+  ${({ paddingLeft }) => paddingLeft && `padding-left: ${paddingLeft};`}
 `;
 
 const DiscountTypography = styled(Typography)`
@@ -23,13 +33,11 @@ const DiscountTypography = styled(Typography)`
 
 export const MembershipSelectorItem = ({
   option,
+  paddingLeft,
   onClick
-}: {
-  option: IMembershipConfig;
-  onClick?(option: IMembershipConfig): void;
-}) => {
+}: MembershipItemProps & StyleProps) => {
   return (
-    <SContainer onClick={() => onClick && onClick(option)}>
+    <SContainer paddingLeft={paddingLeft} onClick={() => onClick && onClick(option)}>
       <Typography value={option.title} />
       <DiscountTypography value={option.discountNotice} />
     </SContainer>
@@ -55,7 +63,7 @@ export default function MembershipSelector({ name, value, onSelect }: Membership
       onChange={(option) => onSelect(option)}
       getOptionLabel={(option) => option.title}
       optionComponent={({ data, selectOption }: OptionProps<IMembershipConfig>) => (
-        <MembershipSelectorItem option={data} onClick={selectOption} />
+        <MembershipSelectorItem option={data} onClick={selectOption} paddingLeft={SPACING.SM} />
       )}
       valueComponent={({ value: option }) => <MembershipSelectorItem option={option} />}
       value={value}

--- a/src/features/RequestAssets/RequestAssets.tsx
+++ b/src/features/RequestAssets/RequestAssets.tsx
@@ -25,7 +25,6 @@ import { BusyBottomConfig, IAccount as IIAccount } from '@types';
 import {
   buildEIP681EtherRequest,
   buildEIP681TokenRequest,
-  filterDropdownAssets,
   filterValidAssets,
   isValidAmount,
   noOp,
@@ -111,7 +110,7 @@ export function RequestAssets({ history }: RouteComponentProps) {
   const [networkId, setNetworkId] = useState(defaultAccount!.networkId);
   const network = getNetworkById(networkId, networks);
   const relevantAssets = network ? filterValidAssets(assets, network.id) : [];
-  const filteredAssets = sortByTicker(filterDropdownAssets(relevantAssets));
+  const filteredAssets = sortByTicker(relevantAssets);
 
   const [chosenAssetUuid, setAssetUuid] = useState(
     filteredAssets.find((a) => a.type === 'base')?.uuid
@@ -208,6 +207,7 @@ export function RequestAssets({ history }: RouteComponentProps) {
                     <AssetSelector
                       selectedAsset={selectedAsset ? selectedAsset : null}
                       assets={filteredAssets}
+                      showAssetIcon={false}
                       showAssetName={true}
                       searchable={true}
                       onSelect={(option) => {

--- a/src/features/SendAssets/components/SendAssetsForm.tsx
+++ b/src/features/SendAssets/components/SendAssetsForm.tsx
@@ -583,6 +583,8 @@ const SendAssetsForm = ({ txConfig, onComplete, protectTxButton, isDemoMode }: P
         <AssetSelector
           selectedAsset={values.asset}
           assets={userAssets}
+          searchable={true}
+          showAssetName={true}
           onSelect={(option: StoreAsset) => {
             setFieldValue('asset', option || {}); //if this gets deleted, it no longer shows as selected on interface (find way to not need this)
           }}

--- a/src/utils/filterAssets.spec.ts
+++ b/src/utils/filterAssets.spec.ts
@@ -1,30 +1,7 @@
-import { ASSET_DROPDOWN_SIZE_THRESHOLD, DEFAULT_NETWORK } from '@config';
+import { DEFAULT_NETWORK } from '@config';
 import { fAssets } from '@fixtures';
-import { ExtendedAsset } from '@types';
 
-import { filterDropdownAssets, filterValidAssets } from './filterAssets';
-
-describe('filterDropdownAssets', () => {
-  it('maintains base assets when filtering assets', () => {
-    const filtered = filterDropdownAssets([fAssets[0]]);
-    expect(filtered).toHaveLength(1);
-  });
-
-  it('maintains assets when filtering assets with items less than the threshold', () => {
-    const filtered = filterDropdownAssets([fAssets[1]]);
-    expect(filtered).toHaveLength(1);
-  });
-
-  it('conducts asset uuid filter when list exceeds threshold', () => {
-    let assets: ExtendedAsset[] = [];
-    // Create a large array of assets
-    for (let i = 0; i < ASSET_DROPDOWN_SIZE_THRESHOLD + 1; i++) {
-      assets = [...assets, fAssets[fAssets.length - 1]];
-    }
-    const filtered = filterDropdownAssets(assets);
-    expect(filtered).toHaveLength(0);
-  });
-});
+import { filterValidAssets } from './filterAssets';
 
 describe('filterValidAssets', () => {
   it('filters assets on the same network of type erc20 and base', () => {

--- a/src/utils/filterAssets.ts
+++ b/src/utils/filterAssets.ts
@@ -1,15 +1,4 @@
-import { ASSET_DROPDOWN_SIZE_THRESHOLD, USEFUL_ASSETS } from '@config';
 import { Asset, ExtendedAsset, NetworkId } from '@types';
-
-// Attempts to filter assets for display in dropdowns to decrease # of selections
-// based on a simple list of estimated usefulness (# of holders, market cap, trade volume) from etherscan
-export const filterDropdownAssets = (assets: Asset[] | ExtendedAsset[]) => {
-  const filteredAssets =
-    assets.length > ASSET_DROPDOWN_SIZE_THRESHOLD
-      ? assets.filter(({ uuid, type }) => type === 'base' || USEFUL_ASSETS.includes(uuid))
-      : assets;
-  return filteredAssets;
-};
 
 export const filterValidAssets = (assets: Asset[] | ExtendedAsset[], networkId: NetworkId) =>
   assets.filter(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -83,7 +83,7 @@ export { accountsToCSV } from './csv';
 export { getRootDomain } from './getRootDomain';
 export * from './wallets';
 export { isTruthy } from './isTruthy';
-export { filterDropdownAssets, filterValidAssets } from './filterAssets';
+export { filterValidAssets } from './filterAssets';
 export * from './date';
 export {
   makeExplorer,


### PR DESCRIPTION
### Description
Changed asset dropdown a bit to be more performant.

##### Changes:
- Removed Typography from asset selector
- Aligned items in the selector a little better (fixes an issue with the blinking cursor in searchable Selector lacking padding-left).
- Removed displaying of asset icons when using large list of assets (Hardware Scanner & Request Assets).

![image](https://user-images.githubusercontent.com/29407814/108118364-1ad9a600-7053-11eb-92d0-7aa69cf79a82.png)
