### PR TITLE
Fix issue with base asset balances on jsonrpc provider-networks

### DIFF
--- a/src/services/Store/BalanceService.test.ts
+++ b/src/services/Store/BalanceService.test.ts
@@ -29,7 +29,7 @@ jest.mock('@mycrypto/eth-scan', () => ({
 }));
 ProviderHandler.prototype.getRawTokenBalance = jest.fn().mockResolvedValue('150');
 ProviderHandler.prototype.getTokenBalance = jest.fn().mockResolvedValue('150');
-ProviderHandler.prototype.getBalance = jest.fn().mockResolvedValue('150');
+ProviderHandler.prototype.getRawBalance = jest.fn().mockResolvedValue('150');
 ProviderHandler.fetchProvider = jest.fn().mockResolvedValue({} as FallbackProvider);
 
 const RopstenNoEthScanNetworkId = 'ROPSTEN_NO_ETHSCAN' as NetworkId;

--- a/src/services/Store/BalanceService.tsx
+++ b/src/services/Store/BalanceService.tsx
@@ -260,7 +260,7 @@ export const getBaseAssetBalancesForAddresses = async (
       .then(bigifyBalanceMap)
       .catch(() => ({} as BalanceMap));
   } else {
-    const result = await mapAsync(addresses, (address) => providerHandler.getBalance(address));
+    const result = await mapAsync(addresses, (address) => providerHandler.getRawBalance(address));
     return bigifyBalanceMap(toBalanceMap(addresses, result));
   }
 };


### PR DESCRIPTION
### Description
Swap over to use getRawBalance instead of getBalance for base assets on networks.