### PR TITLE
Include generic asset icon

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -7,6 +7,7 @@ import { Asset } from '@types';
 import { sanitizeDecimalSeparator } from '@utils';
 
 import AssetIcon from './AssetIcon';
+import Box from './Box';
 import Typography from './Typography';
 
 interface Props {
@@ -42,10 +43,10 @@ function AmountInput({ asset, value, onChange, onBlur, placeholder, ...props }: 
       placeholder={placeholder}
       iconSide={'right'}
       icon={() => (
-        <div>
+        <Box variant="rowCenter">
           {asset.ticker && <SAssetIcon uuid={asset.uuid} size={'1.5rem'} />}
           <Typography>{asset.ticker}</Typography>
-        </div>
+        </Box>
       )}
     />
   );

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -1,14 +1,12 @@
 import React, { useContext } from 'react';
 
-import styled from 'styled-components';
-
-import genericIcon from '@assets/generic.svg';
 import { MYC_API } from '@config';
 import { StoreContext } from '@services';
 import { CoinGeckoManifest } from '@services/Store/StoreProvider';
 import { TUuid } from '@types';
 
 import Box from './Box';
+import { getSVGIcon } from './Icon';
 
 const baseURL = `${MYC_API}/images`;
 
@@ -17,16 +15,9 @@ function buildUrl(uuid: TUuid) {
 }
 
 function getIconUrl(uuid: TUuid, assetIconsManifest: CoinGeckoManifest) {
-  const assetIconsManifestEntry = assetIconsManifest && assetIconsManifest[uuid];
-
-  const curr = assetIconsManifestEntry || false;
-  return curr ? buildUrl(uuid) : genericIcon;
+  const assetIconExists = assetIconsManifest && !!assetIconsManifest[uuid];
+  return assetIconExists ? buildUrl(uuid) : getSVGIcon('generic-asset-icon');
 }
-
-const SImg = styled('img')`
-  height: ${(p: { size: string }) => p.size};
-  width: ${(p: { size: string }) => p.size};
-`;
 
 interface Props {
   uuid: TUuid;
@@ -38,15 +29,16 @@ const AssetIcon = ({ uuid, size = '32px', ...props }: Props & React.ComponentPro
   const { coinGeckoAssetManifest } = useContext(StoreContext);
   const iconUrl = getIconUrl(uuid, coinGeckoAssetManifest);
 
+  // Replace src in the eventuality the server fails to reply with the requested icon.
   const handleError = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
     const elem = event.currentTarget;
     elem.onerror = null;
-    elem.src = genericIcon;
+    elem.src = getSVGIcon('generic-asset-icon');
   };
 
   return (
-    <Box variant="rowCenter" {...props} height={size} width={size}>
-      <SImg src={iconUrl} size={size} onError={handleError} />
+    <Box display="inline-flex" height={size} width={size} {...props}>
+      <img src={iconUrl} onError={handleError} />
     </Box>
   );
 };

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -25,7 +25,7 @@ interface Props {
   className?: string;
 }
 
-const AssetIcon = ({ uuid, size = '32px', ...props }: Props & React.ComponentProps<typeof Box>) => {
+const AssetIcon = ({ uuid, size, ...props }: Props & React.ComponentProps<typeof Box>) => {
   const { coinGeckoAssetManifest } = useContext(StoreContext);
   const iconUrl = getIconUrl(uuid, coinGeckoAssetManifest);
 

--- a/src/components/Currency.stories.tsx
+++ b/src/components/Currency.stories.tsx
@@ -17,16 +17,16 @@ export const defaultState = () => {
   return (
     <div className="sb-container">
       <Currency amount={defaultProps.amount} ticker={defaultProps.ticker} />
-      <Divider height={'1em'} />
+      <Divider />
       <Currency amount={defaultProps.amount} ticker={'ETH' as TTicker} />
-      <Divider height={'1em'} />
+      <Divider />
       <Currency
         amount={defaultProps.amount}
         ticker={'ETH' as TTicker}
         icon={true}
         uuid={'dummy_id' as TUuid}
       />
-      <Divider height={'1em'} />
+      <Divider />
       <Currency
         amount={defaultProps.amount}
         ticker={'ETH' as TTicker}
@@ -34,7 +34,7 @@ export const defaultState = () => {
         uuid={'dummy_id' as TUuid}
         bold={true}
       />
-      <Divider height={'1em'} />
+      <Divider />
       <Currency
         amount={defaultProps.amount}
         ticker={'ETH' as TTicker}

--- a/src/components/Currency.tsx
+++ b/src/components/Currency.tsx
@@ -41,7 +41,7 @@ function Currency({
 
   return (
     <Box variant="rowAlign" display="inline-flex" style={{ fontSize: fontSize }} {...props}>
-      {icon && uuid && <AssetIcon uuid={uuid} mr="1ch" size="1em" />}
+      {icon && uuid && <AssetIcon uuid={uuid} mr="0.5ch" size="1.2em" />}
       <Body as="span" fontWeight={bold ? 'bold' : 'normal'} fontSize={fontSize} color={color}>
         {format(amount, decimals)}
         {!isFiatTicker(ticker) && ` ${symbol || ticker}`}

--- a/src/components/Currency.tsx
+++ b/src/components/Currency.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
 import { TCurrencySymbol, TTicker, TUuid } from '@types';
 import { isFiatTicker } from '@utils';
 
 import AssetIcon from './AssetIcon';
+import Box from './Box';
 import { Body } from './NewTypography';
-
-const SContainer = styled('div')`
-  display: inline-flex;
-`;
-
-const SAssetIconContainer = styled('span')`
-  padding-right: 5px;
-`;
 
 interface Props {
   amount: string;
@@ -49,17 +40,13 @@ function Currency({
   };
 
   return (
-    <SContainer {...props}>
-      {icon && uuid && (
-        <SAssetIconContainer>
-          <AssetIcon size={'19px'} uuid={uuid} />
-        </SAssetIconContainer>
-      )}
+    <Box variant="rowAlign" display="inline-flex" style={{ fontSize: fontSize }} {...props}>
+      {icon && uuid && <AssetIcon uuid={uuid} mr="1ch" size="1em" />}
       <Body as="span" fontWeight={bold ? 'bold' : 'normal'} fontSize={fontSize} color={color}>
         {format(amount, decimals)}
         {!isFiatTicker(ticker) && ` ${symbol || ticker}`}
       </Body>
-    </SContainer>
+    </Box>
   );
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -14,6 +14,7 @@ import {
   SpaceProps
 } from 'styled-system';
 
+import genericAssetIcon from '@assets/generic.svg';
 import add from '@assets/icons/actions/add.svg';
 import addBold from '@assets/icons/actions/add_bold.svg';
 import back from '@assets/icons/actions/back.svg';
@@ -173,6 +174,7 @@ const svgIcons = {
   swap,
   'twitter-icon': twitterIcon,
   'address-book': addressBookIcon,
+  'generic-asset-icon': genericAssetIcon,
 
   /* Brand icons */
   'logo-mycrypto': logoMyCrypto,
@@ -345,6 +347,7 @@ export const isSVGType = (type: TIcon): type is SvgIcons =>
   typeof svgIcons[type as SvgIcons] !== 'undefined';
 export const isPNGType = (type: TIcon): type is PngIcons =>
   typeof pngIcons[type as PngIcons] !== 'undefined';
+export const getSVGIcon = (type: SvgIcons) => svgIcons[type];
 
 const Icon = ({ type, color, ...props }: Props) => {
   if (type === 'website' || type === 'faucet-icon') {

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,2 +1,1 @@
-export { default } from './Icon';
-export { TIcon } from './Icon';
+export { default, TIcon, getSVGIcon } from './Icon';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -68,7 +68,7 @@ export { AddIcon, SubtractIcon } from './icons';
 export { default as PoweredByText } from './PoweredByText';
 export { default as EditableAccountLabel } from './EditableAccountLabel';
 export { default as TimeElapsed } from './TimeElapsed';
-export { default as Icon, TIcon } from './Icon';
+export { default as Icon, TIcon, getSVGIcon } from './Icon';
 export { default as IFrame } from './IFrame';
 export { Downloader } from './Downloader';
 export { TokenMigrationStepper } from './TokenMigration';


### PR DESCRIPTION
1. Stop `AssetIcon` ticker from wrapping.
Problem:
<img width="652" alt="Screenshot 2021-03-16 at 20 01 31" src="https://user-images.githubusercontent.com/2429708/111367031-90f21c80-8694-11eb-940c-0cc2de7c9fa1.png">

Fix:
<img width="656" alt="Screenshot 2021-03-16 at 20 02 11" src="https://user-images.githubusercontent.com/2429708/111367073-9f403880-8694-11eb-9108-303a77cad68b.png">


2. Fix alignment of `AssetIcon` in `Currency`
Problem:
<img width="653" alt="Screenshot 2021-03-16 at 20 01 22" src="https://user-images.githubusercontent.com/2429708/111367128-b2530880-8694-11eb-954d-b753b4bca326.png">


Fix: 
<img width="653" alt="Screenshot 2021-03-16 at 20 18 31" src="https://user-images.githubusercontent.com/2429708/111367221-cd257d00-8694-11eb-84f5-c313d971f8a9.png">
