### PR TITLE
Fix ok-to-test MyCryptoBuilds

### DIFF
--- a/.github/workflows/mycryptobuilds.yml
+++ b/.github/workflows/mycryptobuilds.yml
@@ -96,6 +96,14 @@ jobs:
 
       - name: yarn build:staging
         run: yarn build:staging
+        if: github.event_name == 'repository_dispatch'
+        env:
+          SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+          ANALYTICS_API_URL: ${{ secrets.ANALYTICS_API_URL }}
+          COMMIT_HASH: ${{ github.event.client_payload.pull_request.head.sha }}
+
+      - name: yarn build:staging
+        run: yarn build:staging
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}


### PR DESCRIPTION
Commits to add commit hash broke `/ok-to-test`