### PR TITLE
Optimise dev e2e

### DIFF
--- a/__tests__/addaccount-page.po.js
+++ b/__tests__/addaccount-page.po.js
@@ -22,10 +22,14 @@ export default class AddAccountPage extends BasePage {
     this.waitForPage(PAGES.ADD_ACCOUNT_VIEWONLY);
 
     await t
-      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM)
+      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM, {
+        paste: true
+      })
       .click(Selector('div[data-testid="selector"]').find('span').withText(FIXTURE_ETHEREUM))
       .click(Selector('button').withText(getTransValueByKey('ACTION_6')))
-      .typeText(Selector(`div[data-testid="selector"]`).find('input'), FIXTURE_VIEW_ONLY_ADDRESS)
+      .typeText(Selector(`div[data-testid="selector"]`).find('input'), FIXTURE_VIEW_ONLY_ADDRESS, {
+        paste: true
+      })
       // Lose focus
       .click(getByText(getTransValueByKey('INPUT_PUBLIC_ADDRESS_LABEL')))
       .click(Selector('button').withText(getTransValueByKey('ACTION_6')));
@@ -43,7 +47,9 @@ export default class AddAccountPage extends BasePage {
 
   async selectEthereumNetwork() {
     await t
-      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM)
+      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM, {
+        paste: true
+      })
       .click(Selector('div[data-testid="selector"]').find('span').withText(FIXTURE_ETHEREUM))
       .click(Selector('button').withText(getTransValueByKey('ACTION_6')));
   }

--- a/__tests__/txstatus-page.po.js
+++ b/__tests__/txstatus-page.po.js
@@ -15,9 +15,11 @@ export default class TxStatusPage extends BasePage {
 
   async fillForm() {
     await t
-      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM)
+      .typeText(Selector('div[data-testid="selector"]').find('input'), FIXTURE_ETHEREUM, {
+        paste: true
+      })
       .click(Selector('div[data-testid="selector"]').find('span').withText(FIXTURE_ETHEREUM))
-      .typeText(Selector(`input[name="txhash"]`), FIXTURE_INCOMING_TX_HASH)
+      .typeText(Selector(`input[name="txhash"]`), FIXTURE_INCOMING_TX_HASH, { paste: true })
       .click(Selector('button').withText(getTransValueByKey('FETCH')));
   }
 }


### PR DESCRIPTION
Use `paste` option for form filling to decrease test time. 

Before
<img width="431" alt="Screenshot 2021-04-08 at 16 32 46" src="https://user-images.githubusercontent.com/2429708/114045222-2a71b000-9888-11eb-9f4f-36b35b43f1ce.png">

After
<img width="427" alt="Screenshot 2021-04-08 at 16 27 26" src="https://user-images.githubusercontent.com/2429708/114045219-29d91980-9888-11eb-8610-5ca8995a8c55.png">


