### PR TITLE
Update balance in hdwtable to be 5 decimal places

### DIFF
--- a/src/features/AddAccount/components/HDWTable.tsx
+++ b/src/features/AddAccount/components/HDWTable.tsx
@@ -365,8 +365,8 @@ const HDTable = ({
                       ticker={asset.ticker}
                       amount={
                         account.balance
-                          ? bigify(fromTokenBase(bigify(account.balance), asset.decimal)).toFixed(4)
-                          : '0.0000'
+                          ? bigify(fromTokenBase(bigify(account.balance), asset.decimal)).toFixed(5)
+                          : '0.00000'
                       }
                     />
                   </Typography>


### PR DESCRIPTION
### Description
Changes HDWallet scanner table to display balances with 5 decimal places instead of 4.