### PR TITLE
Track network for addAccounts

### DIFF
--- a/src/services/Analytics/analytics.middleware.ts
+++ b/src/services/Analytics/analytics.middleware.ts
@@ -25,7 +25,7 @@ export const analyticsMiddleware: Middleware<TObject, any, Dispatch<Action>> = (
             qty: action.payload.length,
             // multiple add accounts are always of the same type and network
             walletId: action.payload[0].wallet,
-            networkId: action.payload[0].wallet
+            networkId: action.payload[0].networkId
           }
         })
       );

--- a/src/services/Analytics/analytics.middleware.ts
+++ b/src/services/Analytics/analytics.middleware.ts
@@ -15,7 +15,12 @@ export const analyticsMiddleware: Middleware<TObject, any, Dispatch<Action>> = (
       state.dispatch(
         trackEvent({
           name: 'Add Account',
-          params: { qty: action.payload.length, walletId: action.payload[0].wallet } // multiple add accounts are always of the same type.
+          params: {
+            qty: action.payload.length,
+            // multiple add accounts are always of the same type and network
+            walletId: action.payload[0].wallet,
+            networkId: action.payload[0].wallet
+          }
         })
       );
       break;

--- a/src/services/Analytics/analytics.middleware.ts
+++ b/src/services/Analytics/analytics.middleware.ts
@@ -1,6 +1,12 @@
 import { Action, Dispatch, Middleware } from '@reduxjs/toolkit';
 
-import { addAccounts, createAsset, importState, setProductAnalyticsAuthorisation } from '@store';
+import {
+  addAccounts,
+  createAsset,
+  importState,
+  setDemoMode,
+  setProductAnalyticsAuthorisation
+} from '@store';
 
 import { trackEvent } from './saga';
 
@@ -31,6 +37,15 @@ export const analyticsMiddleware: Middleware<TObject, any, Dispatch<Action>> = (
         trackEvent({
           name: 'Add Asset',
           params: action.payload
+        })
+      );
+      break;
+    }
+
+    case setDemoMode.type: {
+      state.dispatch(
+        trackEvent({
+          name: 'Set Demo Mode'
         })
       );
       break;

--- a/src/services/Analytics/constants.ts
+++ b/src/services/Analytics/constants.ts
@@ -8,4 +8,5 @@ export type TAnalyticEvents =
   | 'Total Account Count'
   | 'Deactivate analytics'
   | 'Export AppState'
-  | 'Import AppState';
+  | 'Import AppState'
+  | 'Set Demo Mode';


### PR DESCRIPTION
Additional product events. 
- include networkId for add account event
- add setDemoMode to tracked events