### PR TITLE
Normalize quotes when parsing signed message

### DIFF
--- a/src/features/SignAndVerifyMessage/VerifyMessage.tsx
+++ b/src/features/SignAndVerifyMessage/VerifyMessage.tsx
@@ -10,7 +10,7 @@ import { BREAK_POINTS, COLORS } from '@theme';
 import translate, { translateRaw } from '@translations';
 import { ISignedMessage } from '@types';
 import { verifySignedMessage } from '@utils';
-import { normalizeQuotes } from '@utils/normalize';
+import { normalizeJson, normalizeSingleQuotes } from '@utils/normalize';
 
 import { VerifyParams } from './types';
 
@@ -64,10 +64,12 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
 
   const handleClick = () => handleVerifySignedMessage();
 
-  const handleVerifySignedMessage = (json?: string) => {
+  const handleVerifySignedMessage = (json?: string, trySingleQuotes?: boolean): void => {
+    const rawMessage = json ?? message;
+
     try {
-      const normalizedMessage = normalizeQuotes(json ?? message);
-      const parsedSignature: ISignedMessage = JSON.parse(normalizedMessage);
+      const normalizedMessage = trySingleQuotes ? normalizeSingleQuotes(rawMessage) : rawMessage;
+      const parsedSignature: ISignedMessage = normalizeJson(normalizedMessage);
 
       const isValid = verifySignedMessage(parsedSignature);
       if (!isValid) {
@@ -77,6 +79,10 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
       setError(undefined);
       setSignedMessage(parsedSignature);
     } catch (err) {
+      if (!trySingleQuotes) {
+        return handleVerifySignedMessage(rawMessage, true);
+      }
+
       setError(translateRaw('ERROR_38'));
       setSignedMessage(null);
     }

--- a/src/features/SignAndVerifyMessage/VerifyMessage.tsx
+++ b/src/features/SignAndVerifyMessage/VerifyMessage.tsx
@@ -10,6 +10,7 @@ import { BREAK_POINTS, COLORS } from '@theme';
 import translate, { translateRaw } from '@translations';
 import { ISignedMessage } from '@types';
 import { verifySignedMessage } from '@utils';
+import { normalizeQuotes } from '@utils/normalize';
 
 import { VerifyParams } from './types';
 
@@ -65,9 +66,10 @@ const VerifyMessage: FunctionComponent<RouteComponentProps & Props> = ({ locatio
 
   const handleVerifySignedMessage = (json?: string) => {
     try {
-      const parsedSignature: ISignedMessage = JSON.parse(json ?? message);
-      const isValid = verifySignedMessage(parsedSignature);
+      const normalizedMessage = normalizeQuotes(json ?? message);
+      const parsedSignature: ISignedMessage = JSON.parse(normalizedMessage);
 
+      const isValid = verifySignedMessage(parsedSignature);
       if (!isValid) {
         throw Error();
       }

--- a/src/utils/normalize.spec.ts
+++ b/src/utils/normalize.spec.ts
@@ -1,5 +1,5 @@
 import { normalize } from '@utils';
-import { normalizeQuotes } from '@utils/normalize';
+import { normalizeJson, normalizeQuotes, normalizeSingleQuotes } from '@utils/normalize';
 
 describe('normalize', () => {
   it('converts a domain name to a normalized Unicode', () => {
@@ -11,5 +11,25 @@ describe('normalize', () => {
 describe('normalizeQuotes', () => {
   it('replaces curly quotes with regular quotes supported by JSON', () => {
     expect(normalizeQuotes('“foo”: “bar”')).toBe('"foo": "bar"');
+  });
+});
+
+describe('normalizeSingleQuotes', () => {
+  it('replaces curly single quotes with regular single quotes', () => {
+    expect(normalizeSingleQuotes('‘foo’: ‘bar’')).toBe("'foo': 'bar'");
+  });
+});
+
+describe('normalizeJson', () => {
+  it('normalizes quotes in a JSON string if it fails to parse', () => {
+    expect(normalizeJson(`{“foo”: “bar”}`)).toStrictEqual({
+      foo: 'bar'
+    });
+
+    expect(normalizeJson(`{"foo": "bar"}`)).toStrictEqual({
+      foo: 'bar'
+    });
+
+    expect(() => normalizeJson(`{foo: "bar"}`)).toThrow();
   });
 });

--- a/src/utils/normalize.spec.ts
+++ b/src/utils/normalize.spec.ts
@@ -1,8 +1,15 @@
 import { normalize } from '@utils';
+import { normalizeQuotes } from '@utils/normalize';
 
 describe('normalize', () => {
   it('converts a domain name to a normalized Unicode', () => {
     const data = normalize('xn--s-qfa0g.de');
     expect(data).toBe('süß.de');
+  });
+});
+
+describe('normalizeQuotes', () => {
+  it('replaces curly quotes with regular quotes supported by JSON', () => {
+    expect(normalizeQuotes('“foo”: “bar”')).toBe('"foo": "bar"');
   });
 });

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -3,3 +3,11 @@ import uts46 from 'idna-uts46';
 export function normalize(name: string): string {
   return uts46.toUnicode(name, { useStd3ASCII: true, transitional: false });
 }
+
+/**
+ * Normalizes quotes in a (JSON) string. Certain operating systems may replace quotes with other quotes, which don't
+ * work when parsing JSON.
+ */
+export const normalizeQuotes = (value: string): string => {
+  return value.replace(/[“”]/g, '"');
+};

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -11,3 +11,23 @@ export function normalize(name: string): string {
 export const normalizeQuotes = (value: string): string => {
   return value.replace(/[“”]/g, '"');
 };
+
+/**
+ * Normalizes single quotes in a (JSON) string. Certain operating systems may replace quotes with other quotes, which
+ * may not work when validating a signature.
+ */
+export const normalizeSingleQuotes = (value: string): string => {
+  return value.replace(/[‘’]/g, "'");
+};
+
+/**
+ * Attempts to parse a JSON string. If it fails (e.g. because the JSON is invalid), it normalizes the string and attempts
+ * to parse it again.
+ */
+export const normalizeJson = <T>(value: string): T => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return JSON.parse(normalizeQuotes(value));
+  }
+};


### PR DESCRIPTION
Fixes an issue with macOS sometimes changing quotes, which makes the signed message invalid.