### PR TITLE
Fix: assign unique id to switch component

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import styled from 'styled-components';
 
 import { Box, Input, Text } from '@components';
@@ -62,26 +64,30 @@ interface Props {
   checked?: boolean;
   onChange?(): void;
 }
-export const Switch = ({ $greyable, onChange, labelLeft, labelRight, checked }: Props) => (
-  <Box variant="rowCenter">
-    <LabelText as="label" htmlFor="toggle">
-      {labelLeft}
-    </LabelText>
-    <SliderBackground htmlFor="toggle">
-      <Checkbox
-        $greyable={$greyable}
-        id="toggle"
-        type="checkbox"
-        onChange={onChange}
-        checked={checked}
-        data-testid="switch-checkbox"
-      />
-      <Slider checked={checked} $greyable={$greyable} />
-    </SliderBackground>
-    <LabelText as="label" htmlFor="toggle">
-      {labelRight}
-    </LabelText>
-  </Box>
-);
+export const Switch = ({ $greyable, onChange, labelLeft, labelRight, checked }: Props) => {
+  const [id] = useState(`toggle-${Math.random().toString(16).slice(-8)}`);
+
+  return (
+    <Box variant="rowCenter">
+      <LabelText as="label" htmlFor={id}>
+        {labelLeft}
+      </LabelText>
+      <SliderBackground htmlFor={id}>
+        <Checkbox
+          $greyable={$greyable}
+          id={id}
+          type="checkbox"
+          onChange={onChange}
+          checked={checked}
+          data-testid="switch-checkbox"
+        />
+        <Slider checked={checked} $greyable={$greyable} />
+      </SliderBackground>
+      <LabelText as="label" htmlFor={id}>
+        {labelRight}
+      </LabelText>
+    </Box>
+  );
+};
 
 export default Switch;


### PR DESCRIPTION
## Description

Slider for Product Analytics is currently not functioning because of a static `id` and `htmlFor` in Switch, this implements a fix for having multiple Switch components on the same page by generating a random id inside each Switch instance.

## Steps to Test
1. Go to Settings page
2. Toggle slider for Product Analytics

## Changes

### Before


https://user-images.githubusercontent.com/12037024/129277039-49322d17-9aee-4101-b816-f77823722b9c.mp4

### After


https://user-images.githubusercontent.com/12037024/129277110-261fd205-b867-491a-962e-d4886354408a.mp4

