### PR TITLE
Remove pending txs when nonce is used

### DIFF
--- a/src/services/Store/store/account.slice.test.ts
+++ b/src/services/Store/store/account.slice.test.ts
@@ -837,9 +837,11 @@ describe('AccountSlice', () => {
         .silentRun();
     });
 
-    it('skips if pending tx not mined and nonce hasn\'t been used', () => {
+    it("skips if pending tx not mined and nonce hasn't been used", () => {
       ProviderHandler.prototype.getTransactionByHash = jest.fn().mockResolvedValue(undefined);
-      ProviderHandler.prototype.getTransactionCount = jest.fn().mockResolvedValue(fTxReceipt.nonce - 1);
+      ProviderHandler.prototype.getTransactionCount = jest
+        .fn()
+        .mockResolvedValue(fTxReceipt.nonce - 1);
       const account = { ...fAccounts[0], transactions: [pendingTx] };
       return expectSaga(pendingTxPolling)
         .withState({

--- a/src/services/Store/store/index.ts
+++ b/src/services/Store/store/index.ts
@@ -30,6 +30,7 @@ export {
   selectAccountTxs,
   selectTxsByStatus,
   addTxToAccount,
+  removeAccountTx,
   getStoreAccounts,
   getDefaultAccount,
   getMergedTxHistory,


### PR DESCRIPTION
[ch8805]
### Description
Removes pending transaction when nonce is used. This is useful for removing txs that were overwritten by external sources (a different app like Metamask).