### PR TITLE
Check both undefined and null for change in balance breakdown

### DIFF
--- a/src/features/Dashboard/components/WalletBreakdown/WalletBreakdownView.tsx
+++ b/src/features/Dashboard/components/WalletBreakdown/WalletBreakdownView.tsx
@@ -412,7 +412,7 @@ export default function WalletBreakdownView({
                         decimals={2}
                       />
                     </BreakDownBalanceAssetAmount>
-                    {change !== undefined && change !== 0 && (
+                    {change && change !== 0 && (
                       <BreakDownBalanceChange change={change}>
                         {change > 0 && '+'}
                         {change.toFixed(2)}%


### PR DESCRIPTION
Previously if `change` was `null`, the checks would pass but result in `Cannot read properties of null (reading 'toFixed')`. Not sure why `change` could be `null` in the first place, but this is a simple fix for the issue.

Fixes #4220