### PR TITLE
Fix send assets data bug

### DIFF
--- a/src/features/SendAssets/components/SendAssetsForm.tsx
+++ b/src/features/SendAssets/components/SendAssetsForm.tsx
@@ -427,7 +427,8 @@ export const SendAssetsForm = ({ txConfig, onComplete, protectTxButton }: ISendF
     const asset = values.asset;
     const newAccount = getDefaultAccount(asset);
     const newInitialValues = getInitialFormikValues({
-      s: txConfig,
+      // @ts-expect-error @todo Fix reliance on txConfig being {}
+      s: asset.uuid === txConfig.asset?.uuid ? txConfig : {},
       defaultAccount: newAccount,
       defaultAsset: asset,
       defaultNetwork: getDefaultNetwork(newAccount),


### PR DESCRIPTION
Fixes an issue where data would be stick around if you previously tried to send an ERC20

Steps to test:

1. Go to send flow
2. Create an ERC20 tx
3. Go to confirm screen
4. Go back
5. Switch to ETH transfer and fill out form
6. Go to confirm screen
7. See that the data field is now `0x`