### PR TITLE
Rebrand Ether-1 to ETHO Protocol

### DIFF
--- a/src/database/data/networks.ts
+++ b/src/database/data/networks.ts
@@ -544,14 +544,14 @@ export const NETWORKS_CONFIG: NetworkConfig = {
   },
   ETHO: {
     id: 'ETHO',
-    name: 'Ether-1',
+    name: 'Etho Protocol',
     unit: 'ETHO' as TTicker,
     chainId: 1313114,
     isCustom: false,
     color: '#7a1336',
     blockExplorer: makeExplorer({
-      name: 'Ether-1 Explorer',
-      origin: 'https://explorer.ether1.org'
+      name: 'Etho Protocol Explorer',
+      origin: 'https://explorer.ethoprotocol.com'
     }),
     tokens: [],
     contracts: [],

--- a/src/database/data/nodes.ts
+++ b/src/database/data/nodes.ts
@@ -180,10 +180,10 @@ export const NODES_CONFIG: { [key in NetworkId]: StaticNodeConfig[] } = {
 
   ETHO: [
     {
-      name: NetworkUtils.makeNodeName('ETHO', 'ether1.org'),
+      name: NetworkUtils.makeNodeName('ETHO', 'ethoprotocol.com'),
       type: NodeType.RPC,
       service: 'ether1.org',
-      url: 'https://rpc.ether1.org'
+      url: 'https://rpc.ethoprotocol.com'
     }
   ],
 


### PR DESCRIPTION
Rebrand Ether-1 to ETHO Protocol
Changed rpc and explorer url's

<!-- Employees: Please use Clubhouse's "Open PR" button from the relevant story or include links to relevant Clubhouse stories in your branch name, commit messages, or pull request comments. Do not add links to your pull request description, they will be ignored. https://help.clubhouse.io/hc/en-us/articles/207540323-Using-The-Clubhouse-GitHub-Integration -->

<!-- Employees: Delete this section. -->
## Closes #ISSUE_NUMBER_GOES_HERE

🎉 🎉 🎉

## Description

......

## Changes

* High level
* changes that
* you made

### Reusable Code/Components

<!-- Preferably, include automated tests instead. -->
## Steps to Test

1. Steps
2. to
3. test

<!-- Contributors: Delete this section. -->
## [Zeplin Design](https://app.zeplin.io/project/5b0334f5e91e8c481645ad56)
<!-- Upload screenshots here. -->

## Quality Assurance

- [ ] The branch name is in lowercase-kebab-case with no prefix (unless it was created from Clubhouse)
- [ ] The base branch is develop or gau (no nested branches)
- [ ] This is related to a maximum of one Clubhouse story or GitHub issue
- [ ] Types are safe (avoid TypeScript/TSLint features like any and disable, instead use more specific types)
- [ ] If code is copied from existing directories, there is an explanation of why this is necesary in the description/changes, and all copying is done in separate commits to make them easy to filter out
- [ ] If your code adds new text to the UI, the added text is [translatable](https://github.com/MyCryptoHQ/MyCrypto/wiki/Contributing---Translatable-strings)
