### PR TITLE
[FIX] `RNS` Resolution

### DIFF
--- a/src/components/GeneralLookupField.tsx
+++ b/src/components/GeneralLookupField.tsx
@@ -10,7 +10,6 @@ import {
   ProviderHandler
 } from '@services/EthService';
 import { createENSResolutionError, isResolutionError } from '@services/EthService/ens';
-import { selectDefaultNetwork, useSelector } from '@store';
 import { ErrorObject, IReceiverAddress, Network } from '@types';
 
 import AddressLookupSelector, { LabeledAddress } from './AddressLookupSelector';
@@ -52,7 +51,6 @@ const GeneralLookupField = ({
   setFieldTouched,
   setFieldError
 }: IGeneralLookupFieldComponentProps) => {
-  const ethNetwork = useSelector(selectDefaultNetwork);
   const errorMessage =
     error && Object.prototype.hasOwnProperty.call(error, 'message')
       ? (error as ErrorObject).message
@@ -139,7 +137,7 @@ const GeneralLookupField = ({
     setIsResolvingDomain(true);
     setResolutionError(undefined);
     try {
-      const provider = new ProviderHandler(ethNetwork);
+      const provider = new ProviderHandler(network);
       const resolvedAddress = await provider.resolveName(domain, network);
       if (!resolvedAddress) {
         throw new ResolutionError(ResolutionErrorCode.UnregisteredDomain, { domain });

--- a/src/services/EthService/network/helpers.ts
+++ b/src/services/EthService/network/helpers.ts
@@ -7,6 +7,11 @@ import { ETHERSCAN_API_KEY } from '@config';
 import { DPathFormat, Network, NodeOptions, NodeType } from '@types';
 import { FallbackProvider } from '@vendor';
 
+const CHAIN_ID_TO_REGISTRY: { [key: number]: string } = {
+  30: '0xcb868aeabd31e2b66f74e9a55cf064abb31a4ad5',
+  31: '0x7d284aaac6e925aad802a53c0c69efe3764597b8'
+};
+
 const getProvider = (node: NodeOptions, chainId: number) => {
   const { type, url } = node;
   if (type === NodeType.ETHERSCAN) {
@@ -25,7 +30,13 @@ const getProvider = (node: NodeOptions, chainId: number) => {
       chainId
     );
   }
-  return new StaticJsonRpcProvider(connection, chainId);
+
+  const provider = new StaticJsonRpcProvider(connection, chainId);
+  if ([30, 31].includes(chainId)) {
+    provider.network.ensAddress = CHAIN_ID_TO_REGISTRY[chainId];
+  }
+
+  return provider;
 };
 
 export const createCustomNodeProvider = (network: Network): BaseProvider => {


### PR DESCRIPTION
## Description
This PR fixes RNS resolution issue on send screen. There are two reasons due to which RNS names are not resolving.
1) Network is hardcoded in lookup field component here: https://github.com/MyCryptoHQ/MyCrypto/blob/457ec2f0a1cce537275c3b67d7e871f1ae3ae162/src/components/GeneralLookupField.tsx#L142
2) In case of RSK network RPC provider does not know RNS registry address: https://github.com/MyCryptoHQ/MyCrypto/blob/457ec2f0a1cce537275c3b67d7e871f1ae3ae162/src/services/EthService/network/helpers.ts#L28 which in case of eth, points to correct address.

## Changes
1) Remove hardcoded network in lookup field component
2) Set RNS registry address inside provider in case of RSK network

## Demo

https://user-images.githubusercontent.com/104683677/223435969-c759ed23-a148-4425-96f3-5b73f7f718a7.mp4



## Steps to test
1) Select RSK network
2) Enter any `rns` name in the address field
3) Name should resolve to address
